### PR TITLE
Fixed Windows Docker Code File Not found Issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "llm-sandbox"
-version = "0.1.1"
+version = "0.1.1-alpha"
 description = "Lightweight and portable LLM sandbox runtime (code interpreter) Python library"
 authors = ["Duy Huynh <vndee.huynh@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
When running the package on Windows 11 + Docker Desktop, an error: ```code_file not found``` was experienced.

Used ```tempfile``` python package to create the temporary file to store the code before copying it to the Docker Image