### PR TITLE
Make container commit optional

### DIFF
--- a/llm_sandbox/docker.py
+++ b/llm_sandbox/docker.py
@@ -31,6 +31,7 @@ class SandboxDockerSession(Session):
         dockerfile: Optional[str] = None,
         lang: str = SupportedLanguage.PYTHON,
         keep_template: bool = False,
+        commit_container: bool = True,
         verbose: bool = False,
         mounts: Optional[list[Mount]] = None,
     ):
@@ -41,6 +42,7 @@ class SandboxDockerSession(Session):
         :param dockerfile: Path to the Dockerfile, if image is not provided
         :param lang: Language of the code
         :param keep_template: if True, the image and container will not be removed after the session ends
+        :param commit_container: if True, the Docker container will be commited after the session ends
         :param verbose: if True, print messages
         """
         super().__init__(lang, verbose)
@@ -71,6 +73,7 @@ class SandboxDockerSession(Session):
         self.container: Optional[Container] = None
         self.path = None
         self.keep_template = keep_template
+        self.commit_container = commit_container
         self.is_create_template: bool = False
         self.verbose = verbose
         self.mounts = mounts
@@ -114,7 +117,7 @@ class SandboxDockerSession(Session):
 
     def close(self):
         if self.container:
-            if isinstance(self.image, Image):
+            if self.commit_container and isinstance(self.image, Image):
                 self.container.commit(self.image.tags[-1])
 
             self.container.remove(force=True)

--- a/llm_sandbox/session.py
+++ b/llm_sandbox/session.py
@@ -14,6 +14,7 @@ class SandboxSession:
         dockerfile: Optional[str] = None,
         lang: str = SupportedLanguage.PYTHON,
         keep_template: bool = False,
+        commit_container: bool = True,
         verbose: bool = False,
         use_kubernetes: bool = False,
         kube_namespace: Optional[str] = "default",
@@ -25,6 +26,7 @@ class SandboxSession:
         :param dockerfile: Path to the Dockerfile, if image is not provided
         :param lang: Language of the code
         :param keep_template: if True, the image and container will not be removed after the session ends
+        :param commit_container: if True, the Docker container will be commited after the session ends
         :param verbose: if True, print messages (default is True)
         :param use_kubernetes: if True, use Kubernetes instead of Docker (default is False)
         :param kube_namespace: Kubernetes namespace to use (only if 'use_kubernetes' is True), default is 'default'
@@ -46,5 +48,6 @@ class SandboxSession:
             dockerfile=dockerfile,
             lang=lang,
             keep_template=keep_template,
+            commit_container=commit_container,
             verbose=verbose,
         )


### PR DESCRIPTION
This PR makes container committing optional, i.e. user defined.
I believe this may be not what the user always wants, e.g. when they want to start from scratch with each call. It may also address https://github.com/vndee/llm-sandbox/issues/1 ("The history of the image is getting longer and longer up to the point where the error message with “max depth exceeded” appears."