### PR TITLE
Include `exit_code` in `ConsoleOutput`

### DIFF
--- a/llm_sandbox/base.py
+++ b/llm_sandbox/base.py
@@ -3,7 +3,7 @@ from typing import Optional, List
 
 
 class ConsoleOutput:
-    def __init__(self, exit_code: int, text: str):
+    def __init__(self, exit_code: Optional[int], text: str):
         self._exit_code = exit_code
         self._text = text
 

--- a/llm_sandbox/base.py
+++ b/llm_sandbox/base.py
@@ -3,22 +3,23 @@ from typing import Optional, List
 
 
 class ConsoleOutput:
-    def __init__(self, text: str):
+    def __init__(self, exit_code: int, text: str):
+        self._exit_code = exit_code
         self._text = text
+
+    @property
+    def exit_code(self):
+        return self._exit_code
 
     @property
     def text(self):
         return self._text
 
     def __str__(self):
-        return f"ConsoleOutput(text={self.text})"
+        return f"ConsoleOutput(text={self.text}, exit_code={self._exit_code})"
 
 
 class KubernetesConsoleOutput(ConsoleOutput):
-    def __init__(self, exit_code: int, text: str):
-        super().__init__(text)
-        self.exit_code = exit_code
-
     def __str__(self):
         return f"KubernetesConsoleOutput(text={self.text}, exit_code={self.exit_code})"
 

--- a/llm_sandbox/docker.py
+++ b/llm_sandbox/docker.py
@@ -196,7 +196,7 @@ class SandboxDockerSession(Session):
 
             self.copy_to_runtime(code_file, code_dest_file)
 
-            output = ConsoleOutput("")
+            output = ConsoleOutput(0, "")
             commands = get_code_execution_command(self.lang, code_dest_file)
             for command in commands:
                 if self.lang == SupportedLanguage.GO:
@@ -280,4 +280,4 @@ class SandboxDockerSession(Session):
             if self.verbose:
                 print(chunk_str, end="")
 
-        return ConsoleOutput(output)
+        return ConsoleOutput(exit_code, output)

--- a/llm_sandbox/docker.py
+++ b/llm_sandbox/docker.py
@@ -47,6 +47,7 @@ class SandboxDockerSession(Session):
         :param commit_container: if True, the Docker container will be commited after the session ends
         :param verbose: if True, print messages
         :param mounts: List of mounts to be mounted to the container
+        :param stream: if True, the output will be streamed (enabling this option prevents obtaining an exit code of run command)
         :param container_configs: Additional configurations for the container, i.e. resources limits (cpu_count, mem_limit), etc.
         """
         super().__init__(lang, verbose)

--- a/llm_sandbox/docker.py
+++ b/llm_sandbox/docker.py
@@ -34,6 +34,7 @@ class SandboxDockerSession(Session):
         commit_container: bool = True,
         verbose: bool = False,
         mounts: Optional[list[Mount]] = None,
+        stream: bool = True,
         container_configs: Optional[dict] = None,
     ):
         """
@@ -80,6 +81,7 @@ class SandboxDockerSession(Session):
         self.is_create_template: bool = False
         self.verbose = verbose
         self.mounts = mounts
+        self.stream = stream
         self.container_configs = container_configs
 
     def open(self):
@@ -263,16 +265,19 @@ class SandboxDockerSession(Session):
 
         if workdir:
             exit_code, exec_log = self.container.exec_run(
-                command, stream=True, tty=True, workdir=workdir
+                command, stream=self.stream, tty=True, workdir=workdir
             )
         else:
             exit_code, exec_log = self.container.exec_run(
-                command, stream=True, tty=True
+                command, stream=self.stream, tty=True
             )
 
         output = ""
         if self.verbose:
             print("Output:", end=" ")
+
+        if not self.stream:
+            exec_log = [exec_log]
 
         for chunk in exec_log:
             chunk_str = chunk.decode("utf-8")

--- a/llm_sandbox/kubernetes.py
+++ b/llm_sandbox/kubernetes.py
@@ -164,7 +164,7 @@ class SandboxKubernetesSession(Session):
             if output.exit_code != 0:
                 break
 
-        return ConsoleOutput(output.text)
+        return ConsoleOutput(output.exit_code, output.text)
 
     def copy_to_runtime(self, src: str, dest: str):
         if not self.container:

--- a/llm_sandbox/micromamba.py
+++ b/llm_sandbox/micromamba.py
@@ -21,7 +21,6 @@ class MicromambaSession(SandboxDockerSession):
         keep_template: bool = False,
         verbose: bool = False,
         mounts: Optional[list[Mount]] = None,
-        stream: bool = True,
         environment: str = "base",
     ):
         super().__init__(
@@ -32,7 +31,6 @@ class MicromambaSession(SandboxDockerSession):
             keep_template=keep_template,
             verbose=verbose,
             mounts=mounts,
-            stream=stream,
         )
         self.environment = environment
 
@@ -53,19 +51,16 @@ class MicromambaSession(SandboxDockerSession):
 
         if workdir:
             exit_code, exec_log = self.container.exec_run(
-                command, stream=self.stream, tty=True, workdir=workdir
+                command, stream=True, tty=True, workdir=workdir
             )
         else:
             exit_code, exec_log = self.container.exec_run(
-                command, stream=self.stream, tty=True
+                command, stream=True, tty=True
             )
 
         output = ""
         if self.verbose:
             print("Output:", end=" ")
-
-        if not self.stream:
-            exec_log = [exec_log]
 
         for chunk in exec_log:
             chunk_str = chunk.decode("utf-8")

--- a/llm_sandbox/micromamba.py
+++ b/llm_sandbox/micromamba.py
@@ -68,4 +68,4 @@ class MicromambaSession(SandboxDockerSession):
             if self.verbose:
                 print(chunk_str, end="")
 
-        return ConsoleOutput(output)
+        return ConsoleOutput(exit_code, output)

--- a/llm_sandbox/micromamba.py
+++ b/llm_sandbox/micromamba.py
@@ -21,6 +21,7 @@ class MicromambaSession(SandboxDockerSession):
         keep_template: bool = False,
         verbose: bool = False,
         mounts: Optional[list[Mount]] = None,
+        stream: bool = True,
         environment: str = "base",
     ):
         super().__init__(
@@ -31,6 +32,7 @@ class MicromambaSession(SandboxDockerSession):
             keep_template=keep_template,
             verbose=verbose,
             mounts=mounts,
+            stream=stream,
         )
         self.environment = environment
 
@@ -51,16 +53,19 @@ class MicromambaSession(SandboxDockerSession):
 
         if workdir:
             exit_code, exec_log = self.container.exec_run(
-                command, stream=True, tty=True, workdir=workdir
+                command, stream=self.stream, tty=True, workdir=workdir
             )
         else:
             exit_code, exec_log = self.container.exec_run(
-                command, stream=True, tty=True
+                command, stream=self.stream, tty=True
             )
 
         output = ""
         if self.verbose:
             print("Output:", end=" ")
+
+        if not self.stream:
+            exec_log = [exec_log]
 
         for chunk in exec_log:
             chunk_str = chunk.decode("utf-8")

--- a/llm_sandbox/podman.py
+++ b/llm_sandbox/podman.py
@@ -218,7 +218,7 @@ class SandboxPodmanSession(Session):
 
             self.copy_to_runtime(code_file, code_dest_file)
 
-            output = ConsoleOutput("")
+            output = ConsoleOutput(0, "")
             commands = get_code_execution_command(self.lang, code_dest_file)
             for command in commands:
                 if self.lang == SupportedLanguage.GO:
@@ -304,4 +304,4 @@ class SandboxPodmanSession(Session):
         if self.verbose:
             print(output)
 
-        return ConsoleOutput(output)
+        return ConsoleOutput(exit_code, output)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -124,6 +124,18 @@ class TestSandboxSession(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.session.execute_command("")
 
+    def test_execute_failing_command(self):
+        mock_container = MagicMock()
+        self.session.container = mock_container
+
+        command = "exit 1"
+        mock_container.exec_run.return_value = (1, iter([]))
+
+        output = self.session.execute_command(command)
+        mock_container.exec_run.assert_called_with(command, stream=True, tty=True)
+        self.assertEqual(output.exit_code, 1)
+        self.assertEqual(output.text, "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_session_podman.py
+++ b/tests/test_session_podman.py
@@ -149,6 +149,19 @@ class TestSandboxSession(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.session.execute_command("")
 
+    def test_execute_failing_command(self):
+        mock_container = MagicMock()
+        self.session.container = mock_container
+
+        command = "exit 1"
+        mock_container.exec_run.return_value = (1, iter([]))
+
+        output = self.session.execute_command(command)
+
+        mock_container.exec_run.assert_called_with(command, stream=True, tty=True)
+        self.assertEqual(output.exit_code, 1)
+        self.assertEqual(output.text, "")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As mentioned here: https://github.com/vndee/llm-sandbox/issues/14

I had to add a toggle for `stream`. When it is enabled, the exit code is always `None`.