### PR TITLE
Enable configuring custom pod manifests when using Kubernetes

### DIFF
--- a/llm_sandbox/kubernetes.py
+++ b/llm_sandbox/kubernetes.py
@@ -27,6 +27,7 @@ class SandboxKubernetesSession(Session):
         verbose: bool = False,
         kube_namespace: Optional[str] = "default",
         env_vars: Optional[dict] = None,
+        pod_manifest: Optional[dict] = None,
     ):
         """
         Create a new sandbox session
@@ -37,6 +38,8 @@ class SandboxKubernetesSession(Session):
         :param keep_template: if True, the image and container will not be removed after the session ends
         :param verbose: if True, print messages
         :param kube_namespace: Kubernetes namespace to use, default is 'default'
+        :param env_vars: Environment variables to use
+        :param pod_manifest: Pod manifest to use (ignores other settings: `image`, `kube_namespace` and `env_vars`)
         """
         super().__init__(lang, verbose)
         if lang not in SupportedLanguageValues:
@@ -62,11 +65,34 @@ class SandboxKubernetesSession(Session):
         self.keep_template = keep_template
         self.container = None
         self.env_vars = env_vars
+        self.pod_manifest = pod_manifest or self._default_pod_manifest()
+        self._reconfigure_with_pod_manifest()
+
+    def _reconfigure_with_pod_manifest(self):
+        self.pod_name = self.pod_manifest.get("metadata", {}).get("name", self.pod_name)
+        self.kube_namespace = self.pod_manifest.get("metadata", {}).get(
+            "namespace", self.kube_namespace
+        )
 
     def open(self):
         self._create_kubernetes_pod()
 
     def _create_kubernetes_pod(self):
+        self.client.create_namespaced_pod(
+            namespace=self.kube_namespace, body=self.pod_manifest
+        )
+
+        while True:
+            pod = self.client.read_namespaced_pod(
+                name=self.pod_name, namespace=self.kube_namespace
+            )
+            if pod.status.phase == "Running":
+                break
+            time.sleep(1)
+
+        self.container = self.pod_name
+
+    def _default_pod_manifest(self) -> dict:
         pod_manifest = {
             "apiVersion": "v1",
             "kind": "Pod",
@@ -83,22 +109,10 @@ class SandboxKubernetesSession(Session):
         }
         # Add environment variables if provided
         if self.env_vars:
-            pod_manifest["spec"]["containers"][0]["env"] = [
+            pod_manifest["spec"]["containers"][0]["env"] = [  # type: ignore[index]
                 {"name": key, "value": value} for key, value in self.env_vars.items()
             ]
-        self.client.create_namespaced_pod(
-            namespace=self.kube_namespace, body=pod_manifest
-        )
-
-        while True:
-            pod = self.client.read_namespaced_pod(
-                name=self.pod_name, namespace=self.kube_namespace
-            )
-            if pod.status.phase == "Running":
-                break
-            time.sleep(1)
-
-        self.container = self.pod_name
+        return pod_manifest
 
     def close(self):
         self._delete_kubernetes_pod()

--- a/tests/test_session_kubernetes.py
+++ b/tests/test_session_kubernetes.py
@@ -6,9 +6,6 @@ from llm_sandbox.kubernetes import SandboxKubernetesSession
 class TestSandboxKubernetesSession(unittest.TestCase):
     @patch("kubernetes.config.load_kube_config")
     def setUp(self, mock_kube_config):
-        self.mock_kube_config = MagicMock()
-        mock_kube_config.return_value = self.mock_kube_config
-
         self.image = "python:3.9.19-bullseye"
         self.dockerfile = None
         self.lang = "python"
@@ -23,7 +20,8 @@ class TestSandboxKubernetesSession(unittest.TestCase):
             verbose=self.verbose,
         )
 
-    def test_with_pod_manifest(self):
+    @patch("kubernetes.config.load_kube_config")
+    def test_with_pod_manifest(self, mock_kube_config):
         pod_manifest = {
             "apiVersion": "v1",
             "kind": "Pod",

--- a/tests/test_session_kubernetes.py
+++ b/tests/test_session_kubernetes.py
@@ -1,0 +1,66 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from llm_sandbox.kubernetes import SandboxKubernetesSession
+
+
+class TestSandboxKubernetesSession(unittest.TestCase):
+    @patch("kubernetes.config.load_kube_config")
+    def setUp(self, mock_kube_config):
+        self.mock_kube_config = MagicMock()
+        mock_kube_config.return_value = self.mock_kube_config
+
+        self.image = "python:3.9.19-bullseye"
+        self.dockerfile = None
+        self.lang = "python"
+        self.keep_template = False
+        self.verbose = False
+
+        self.session = SandboxKubernetesSession(
+            image=self.image,
+            dockerfile=self.dockerfile,
+            lang=self.lang,
+            keep_template=self.keep_template,
+            verbose=self.verbose,
+        )
+
+    def test_with_pod_manifest(self):
+        pod_manifest = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": "test",
+                "namespace": "test",
+                "labels": {"app": "sandbox"},
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "name": "sandbox-container",
+                        "image": "test",
+                        "tty": True,
+                        "volumeMounts": {
+                            "name": "tmp",
+                            "mountPath": "/tmp",
+                        },
+                    }
+                ],
+                "volumes": [{"name": "tmp", "emptyDir": {"sizeLimit": "5Gi"}}],
+            },
+        }
+        self.session = SandboxKubernetesSession(
+            image=self.image,
+            dockerfile=self.dockerfile,
+            lang=self.lang,
+            keep_template=self.keep_template,
+            verbose=self.verbose,
+            pod_manifest=pod_manifest,
+        )
+
+        self.session.client = MagicMock()
+        self.session.client.read_namespaced_pod.return_value.status.phase = "Running"
+        self.session.open()
+
+        self.session.client.create_namespaced_pod.assert_called_with(
+            namespace="test",
+            body=pod_manifest,
+        )


### PR DESCRIPTION
Hi!

The current configuration options for `SandboxKubernetesSession` are quite limited. In this PR, I propose a `pod_manifest` argument to bring maximum flexibility when defining pods. This way, one can define e.g. envs based on secrets or volume mounts.