### PR TITLE
fix ConsoleOutput result when running with k8s

### DIFF
--- a/llm_sandbox/kubernetes.py
+++ b/llm_sandbox/kubernetes.py
@@ -183,7 +183,7 @@ class SandboxKubernetesSession(Session):
             if output.exit_code != 0:
                 break
 
-        return ConsoleOutput(output.exit_code, output.text)
+        return ConsoleOutput(text=output.text, exit_code=output.exit_code)
 
     def copy_to_runtime(self, src: str, dest: str):
         if not self.container:


### PR DESCRIPTION
due to the wrong order, `ConsoleOutput` return was getting initiated with wrong properties. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code clarity by updating how output is returned, with no impact on user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->