### PR TITLE
feat: update Docker image references to use GitHub Container Registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,71 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'docker/**'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'docker/**'
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: ${{ github.repository_owner }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        include:
+          - dockerfile: docker/python311.Dockerfile
+            image: sandbox-python-311-bullseye
+          - dockerfile: docker/java11.Dockerfile
+            image: sandbox-java-11-bullseye
+          - dockerfile: docker/node22.Dockerfile
+            image: sandbox-node-22-bullseye
+          - dockerfile: docker/cpp11.Dockerfile
+            image: sandbox-cpp-11-bullseye
+          - dockerfile: docker/go123.Dockerfile
+            image: sandbox-go-123-bullseye
+          - dockerfile: docker/ruby302.Dockerfile
+            image: sandbox-ruby-302-bullseye
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=long
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,11 +23,12 @@ Supported languages and their identifiers:
 
 | Language | Identifier | Default Image |
 |----------|------------|---------------|
-| Python | `python` | `vndee/sandbox-python-311-bullseye` |
-| JavaScript | `javascript` | `node:22-bullseye` |
-| Java | `java` | `openjdk:11.0.12-jdk-bullseye` |
-| C++ | `cpp` | `gcc:11.2.0-bullseye` |
-| Go | `go` | `golang:1.23.4-bullseye` |
+| Python | `python` | `ghcr.io/vndee/sandbox-python-311-bullseye` |
+| JavaScript | `javascript` | `ghcr.io/vndee/sandbox-node-22-bullseye` |
+| Java | `java` | `ghcr.io/vndee/sandbox-java-11-bullseye` |
+| C++ | `cpp` | `ghcr.io/vndee/sandbox-cpp-11-bullseye` |
+| Go | `go` | `ghcr.io/vndee/sandbox-go-123-bullseye` |
+| Ruby | `ruby` | `ghcr.io/vndee/sandbox-ruby-302-bullseye` |
 
 ### Container Images
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -559,7 +559,7 @@ from llm_sandbox import SandboxSession
 
 with SandboxSession(
     lang="python",
-    image="vndee/sandbox-python-311-bullseye"
+    image="ghcr.io/vndee/sandbox-python-311-bullseye"
 ) as session:
     result = session.run("print('Hello from my custom image!')")
     print(result.stdout)

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -6,11 +6,11 @@ LLM Sandbox supports multiple programming languages, each with specific features
 
 | Language | Version | Package Manager | Plot Support | Default Image |
 |----------|---------|----------------|--------------|---------------|
-| **Python** | 3.11 | pip | ✅ Full | `vndee/sandbox-python-311-bullseye` |
-| **JavaScript** | Node 22 | npm | ❌ | `node:22-bullseye` |
-| **Java** | 11 | Maven | ❌ | `openjdk:11.0.12-jdk-bullseye` |
-| **C++** | GCC 11.2 | apt | ❌ | `gcc:11.2.0-bullseye` |
-| **Go** | 1.23.4 | go get | ❌ | `golang:1.23.4-bullseye` |
+| **Python** | 3.11 | pip | ✅ Full | `ghcr.io/vndee/sandbox-python-311-bullseye` |
+| **JavaScript** | Node 22 | npm | ❌ | `ghcr.io/vndee/sandbox-node-22-bullseye` |
+| **Java** | 11 | Maven | ❌ | `ghcr.io/vndee/sandbox-java-11-bullseye` |
+| **C++** | GCC 11.2 | apt | ❌ | `ghcr.io/vndee/sandbox-cpp-11-bullseye` |
+| **Go** | 1.23.4 | go get | ❌ | `ghcr.io/vndee/sandbox-go-123-bullseye` |
 
 ## Python
 

--- a/examples/container_user_privilege.py
+++ b/examples/container_user_privilege.py
@@ -175,7 +175,7 @@ def test_kubernetes_custom_security() -> None:
                 "containers": [
                     {
                         "name": "sandbox-container",
-                        "image": "vndee/sandbox-python-311-bullseye",
+                        "image": "ghcr.io/vndee/sandbox-python-311-bullseye",
                         "tty": True,
                         "securityContext": {
                             "runAsUser": 1000,

--- a/examples/python_artifact.py
+++ b/examples/python_artifact.py
@@ -249,7 +249,7 @@ Path("plots").mkdir(exist_ok=True)
 with ArtifactSandboxSession(
     lang="python",
     verbose=True,
-    image="vndee/sandbox-python-311-bullseye",
+    image="ghcr.io/vndee/sandbox-python-311-bullseye",
     backend=SandboxBackend.KUBERNETES,
 ) as session:
     result = session.run(code)
@@ -267,7 +267,7 @@ with ArtifactSandboxSession(
 with ArtifactSandboxSession(
     lang="python",
     verbose=True,
-    image="vndee/sandbox-python-311-bullseye",
+    image="ghcr.io/vndee/sandbox-python-311-bullseye",
     backend=SandboxBackend.DOCKER,
 ) as session:
     result = session.run(code)
@@ -286,7 +286,7 @@ with ArtifactSandboxSession(
     client=podman_client,
     lang="python",
     verbose=True,
-    image="vndee/sandbox-python-311-bullseye",
+    image="ghcr.io/vndee/sandbox-python-311-bullseye",
     backend=SandboxBackend.PODMAN,
 ) as session:
     result = session.run(code)

--- a/llm_sandbox/const.py
+++ b/llm_sandbox/const.py
@@ -87,9 +87,9 @@ class DefaultImage:
     provided by the user for a given programming language.
     """
 
-    PYTHON = "vndee/sandbox-python-311-bullseye"
-    JAVA = "openjdk:11.0.12-jdk-bullseye"
-    JAVASCRIPT = "node:22-bullseye"
-    CPP = "gcc:11.2.0-bullseye"
-    GO = "golang:1.23.4-bullseye"
-    RUBY = "ruby:3.0.2-bullseye"
+    PYTHON = "ghcr.io/vndee/sandbox-python-311-bullseye"
+    JAVA = "ghcr.io/vndee/sandbox-java-11-bullseye"
+    JAVASCRIPT = "ghcr.io/vndee/sandbox-node-22-bullseye"
+    CPP = "ghcr.io/vndee/sandbox-cpp-11-bullseye"
+    GO = "ghcr.io/vndee/sandbox-go-123-bullseye"
+    RUBY = "ghcr.io/vndee/sandbox-ruby-302-bullseye"

--- a/llm_sandbox/docker.py
+++ b/llm_sandbox/docker.py
@@ -54,7 +54,7 @@ class SandboxDockerSession(Session):
             client (docker.DockerClient | None, optional): An existing Docker client instance.
                 If None, a new client will be created based on the local Docker environment.
                 Defaults to None.
-            image (str | None, optional): The name of the Docker image to use (e.g., "vndee/sandbox-python-311-bullseye").
+            image (str | None, optional): The name of the Docker image to use (e.g., "ghcr.io/vndee/sandbox-python-311-bullseye").
                 If None and `dockerfile` is also None, a default image for the specified `lang` is used.
                 Defaults to None.
             dockerfile (str | None, optional): The path to a Dockerfile to build an image from.

--- a/llm_sandbox/kubernetes.py
+++ b/llm_sandbox/kubernetes.py
@@ -45,8 +45,8 @@ class SandboxKubernetesSession(Session):
                 If None, a new client will be created based on the local Kubernetes configuration
                 (e.g., from `~/.kube/config`). Defaults to None.
             image (str | None, optional): The name of the Docker image to use for the Pod's container
-                (e.g., "vndee/sandbox-python-311-bullseye"). If None and `pod_manifest` is not provided with an image,
-                a default image for the specified `lang` is used. Defaults to None.
+                (e.g., "ghcr.io/vndee/sandbox-python-311-bullseye"). If None and `pod_manifest` is not provided with an
+                image, a default image for the specified `lang` is used. Defaults to None.
             lang (str, optional): The programming language of the code to be run (e.g., "python", "java").
                 Determines default image and language-specific handlers. Defaults to SupportedLanguage.PYTHON.
             verbose (bool, optional): If True, print detailed log messages. Defaults to False.

--- a/llm_sandbox/podman.py
+++ b/llm_sandbox/podman.py
@@ -57,7 +57,7 @@ class SandboxPodmanSession(Session):
             client (PodmanClient | None, optional): An existing Podman client instance.
                 If None, a new client will be created based on the local Podman environment
                 (e.g., Podman socket). Defaults to None.
-            image (str | None, optional): The name of the Podman image to use (e.g., "vndee/sandbox-python-311-bullseye").
+            image (str | None, optional): The name of the Podman image to use (e.g., "ghcr.io/vndee/sandbox-python-311-bullseye").
                 If None and `dockerfile` is also None, a default image for the specified `lang` is used.
                 Defaults to None.
             dockerfile (str | None, optional): The path to a Dockerfile or Containerfile to build an image from.

--- a/llm_sandbox/session.py
+++ b/llm_sandbox/session.py
@@ -228,7 +228,7 @@ class ArtifactSandboxSession:
             with ArtifactSandboxSession(
                 lang="python",
                 verbose=True,
-                image="vndee/sandbox-python-311-bullseye",
+                image="ghcr.io/vndee/sandbox-python-311-bullseye",
                 backend=SandboxBackend.DOCKER
             ) as session:
                 # Example code that generates matplotlib, seaborn, and plotly plots
@@ -266,7 +266,7 @@ class ArtifactSandboxSession:
                 client=podman_client,  # Podman specific
                 lang="python",
                 verbose=True,
-                image="vndee/sandbox-python-311-bullseye",
+                image="ghcr.io/vndee/sandbox-python-311-bullseye",
                 backend=SandboxBackend.PODMAN
             ) as session:
                 result = session.run(code)
@@ -277,7 +277,7 @@ class ArtifactSandboxSession:
             with ArtifactSandboxSession(
                 lang="python",
                 verbose=True,
-                image="vndee/sandbox-python-311-bullseye",
+                image="ghcr.io/vndee/sandbox-python-311-bullseye",
                 backend=SandboxBackend.KUBERNETES
             ) as session:
                 result = session.run(code)
@@ -351,7 +351,7 @@ class ArtifactSandboxSession:
             with ArtifactSandboxSession(
                 lang="python",
                 verbose=True,
-                image="vndee/sandbox-python-311-bullseye"
+                image="ghcr.io/vndee/sandbox-python-311-bullseye"
             ) as session:
                 code = '''
                 import matplotlib.pyplot as plt

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -152,7 +152,7 @@ class TestSandboxDockerSessionOpen:
         mock_client.images.get.side_effect = ImageNotFound("Image not found")
 
         mock_image = MagicMock()
-        mock_image.tags = ["vndee/sandbox-python-311-bullseye"]
+        mock_image.tags = [DefaultImage.PYTHON]
         mock_client.images.pull.return_value = mock_image
 
         mock_container = MagicMock()

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from llm_sandbox.const import SupportedLanguage
+from llm_sandbox.const import DefaultImage, SupportedLanguage
 from llm_sandbox.data import ConsoleOutput
 from llm_sandbox.docker import SandboxDockerSession
 from llm_sandbox.exceptions import CommandEmptyError, ExtraArgumentsError, ImagePullError, NotOpenSessionError
@@ -31,7 +31,7 @@ class TestSandboxDockerSessionInit:
 
         assert session.lang == SupportedLanguage.PYTHON
         assert session.verbose is False
-        assert session.image == "vndee/sandbox-python-311-bullseye"  # Default Python image
+        assert session.image == DefaultImage.PYTHON
         assert session.keep_template is False
         assert session.commit_container is False
         assert session.stream is True
@@ -120,7 +120,7 @@ class TestSandboxDockerSessionOpen:
         mock_docker_from_env.return_value = mock_client
 
         mock_image = MagicMock()
-        mock_image.tags = ["vndee/sandbox-python-311-bullseye"]
+        mock_image.tags = [DefaultImage.PYTHON]
         mock_client.images.get.return_value = mock_image
 
         mock_container = MagicMock()
@@ -131,7 +131,7 @@ class TestSandboxDockerSessionOpen:
         with patch.object(session, "environment_setup") as mock_env_setup:
             session.open()
 
-        mock_client.images.get.assert_called_once_with("vndee/sandbox-python-311-bullseye")
+        mock_client.images.get.assert_called_once_with(DefaultImage.PYTHON)
         mock_client.containers.run.assert_called_once()
         mock_env_setup.assert_called_once()
         assert session.container == mock_container
@@ -163,7 +163,7 @@ class TestSandboxDockerSessionOpen:
         with patch.object(session, "environment_setup"):
             session.open()
 
-        mock_client.images.pull.assert_called_once_with("vndee/sandbox-python-311-bullseye")
+        mock_client.images.pull.assert_called_once_with(DefaultImage.PYTHON)
         assert session.is_create_template is True
 
     @patch("llm_sandbox.docker.docker.from_env")

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from llm_sandbox.const import SupportedLanguage
+from llm_sandbox.const import DefaultImage, SupportedLanguage
 from llm_sandbox.data import ConsoleOutput
 from llm_sandbox.exceptions import NotOpenSessionError
 from llm_sandbox.kubernetes import SandboxKubernetesSession
@@ -35,7 +35,7 @@ class TestSandboxKubernetesSessionInit:
 
         assert session.lang == SupportedLanguage.PYTHON
         assert session.verbose is False
-        assert session.image == "vndee/sandbox-python-311-bullseye"
+        assert session.image == DefaultImage.PYTHON
         assert session.workdir == "/sandbox"
         assert session.kube_namespace == "default"
         assert session.client == mock_client
@@ -125,7 +125,7 @@ class TestSandboxKubernetesSessionInit:
         assert manifest["apiVersion"] == "v1"
         assert manifest["kind"] == "Pod"
         assert manifest["metadata"]["namespace"] == "default"
-        assert manifest["spec"]["containers"][0]["image"] == "vndee/sandbox-python-311-bullseye"
+        assert manifest["spec"]["containers"][0]["image"] == DefaultImage.PYTHON
         assert manifest["spec"]["containers"][0]["env"] == [{"name": "TEST_VAR", "value": "test_value"}]
 
 

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -126,7 +126,7 @@ class TestSandboxPodmanSessionOpen:
         mock_podman_from_env.return_value = mock_client
 
         mock_image = MagicMock()
-        mock_image.tags = ["vndee/sandbox-python-311-bullseye"]
+        mock_image.tags = [DefaultImage.PYTHON]
         mock_client.images.get.return_value = mock_image
 
         mock_container = MagicMock()
@@ -193,7 +193,7 @@ class TestSandboxPodmanSessionOpen:
         mock_client.images.get.side_effect = ImageNotFound("Image not found")
 
         mock_image = MagicMock()
-        mock_image.tags = ["vndee/sandbox-python-311-bullseye"]
+        mock_image.tags = [DefaultImage.PYTHON]
         mock_client.images.pull.return_value = [mock_image]  # Returns list
 
         mock_container = MagicMock()

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from llm_sandbox.const import SupportedLanguage
+from llm_sandbox.const import DefaultImage, SupportedLanguage
 from llm_sandbox.data import ConsoleOutput
 from llm_sandbox.exceptions import (
     CommandEmptyError,
@@ -37,7 +37,7 @@ class TestSandboxPodmanSessionInit:
 
         assert session.lang == SupportedLanguage.PYTHON
         assert session.verbose is False
-        assert session.image == "vndee/sandbox-python-311-bullseye"
+        assert session.image == DefaultImage.PYTHON
         assert session.keep_template is False
         assert session.commit_container is False
         assert session.stream is True
@@ -137,7 +137,7 @@ class TestSandboxPodmanSessionOpen:
         with patch.object(session, "environment_setup") as mock_env_setup:
             session.open()
 
-        mock_client.images.get.assert_called_once_with("vndee/sandbox-python-311-bullseye")
+        mock_client.images.get.assert_called_once_with(DefaultImage.PYTHON)
         mock_client.containers.create.assert_called_once()
         mock_container.start.assert_called_once()
         mock_env_setup.assert_called_once()
@@ -162,7 +162,7 @@ class TestSandboxPodmanSessionOpen:
         mock_client.images.get.side_effect = ImageNotFound("Image not found")
 
         mock_image = Mock(spec=PodmanImage)  # Use Mock with spec
-        mock_image.tags = ["vndee/sandbox-python-311-bullseye"]
+        mock_image.tags = [DefaultImage.PYTHON]
         mock_client.images.pull.return_value = mock_image
 
         mock_container = MagicMock()
@@ -173,7 +173,7 @@ class TestSandboxPodmanSessionOpen:
         with patch.object(session, "environment_setup"):
             session.open()
 
-        mock_client.images.pull.assert_called_once_with("vndee/sandbox-python-311-bullseye")
+        mock_client.images.pull.assert_called_once_with(DefaultImage.PYTHON)
         assert session.is_create_template is True
         assert session.docker_image == mock_image
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automated building and publishing of Docker images to the GitHub Container Registry for multiple supported languages.

- **Documentation**
  - Updated all documentation to reference container images hosted on the GitHub Container Registry (`ghcr.io/vndee`) instead of Docker Hub.
  - Added Ruby as a supported language with its default image.

- **Refactor**
  - Standardized default container image references throughout the codebase to use fully qualified GitHub Container Registry paths.

- **Tests**
  - Updated tests to use centralized constants for default image references, ensuring consistency with new image naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->