### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest
@@ -58,6 +61,8 @@ jobs:
 
   check-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -74,6 +79,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
+      pages: write
     steps:
       - name: Check out
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/vndee/llm-sandbox/security/code-scanning/6](https://github.com/vndee/llm-sandbox/security/code-scanning/6)

To fix the issue, we need to add explicit `permissions` blocks to the workflow or individual jobs. Each job should be assigned the least privileges required to complete its tasks. For example:
- Jobs that only read repository contents should have `contents: read`.
- Jobs that upload coverage reports or deploy documentation may require additional permissions, such as `contents: write`.

The fix involves:
1. Adding a `permissions` block at the root level of the workflow to set default permissions for all jobs.
2. Overriding the permissions for specific jobs if they require additional privileges.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
