### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-codecov-config.yml
+++ b/.github/workflows/validate-codecov-config.yml
@@ -1,5 +1,8 @@
 name: validate-codecov-config
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths: [codecov.yaml]


### PR DESCRIPTION
Potential fix for [https://github.com/vndee/llm-sandbox/security/code-scanning/5](https://github.com/vndee/llm-sandbox/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only validates a Codecov configuration file and does not require write access, we will set `contents: read` as the minimal permission. This ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
