### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -32,6 +32,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [set-version]
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Check out
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/vndee/llm-sandbox/security/code-scanning/4](https://github.com/vndee/llm-sandbox/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the `publish` job. Based on the steps in the `publish` job, it requires `contents: read` to check out the repository and `packages: write` to publish the package. These permissions should be explicitly defined to limit the scope of the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
