### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   quality:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -27,6 +29,8 @@ jobs:
 
   tests-and-type-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
@@ -58,6 +62,8 @@ jobs:
 
   check-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/vndee/llm-sandbox/security/code-scanning/3](https://github.com/vndee/llm-sandbox/security/code-scanning/3)

To fix the issue, we need to add explicit `permissions` blocks to each job in the workflow. These blocks should define the least privileges required for the job to function correctly. For example:
- Jobs that only read repository contents (e.g., `quality`, `tests-and-type-check`, `check-docs`) should use `contents: read`.
- Jobs that require write access (e.g., `deploy-docs`) already have appropriate permissions defined.

The changes will involve adding `permissions` blocks to the `quality`, `tests-and-type-check`, and `check-docs` jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
