### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vndee/llm-sandbox/security/code-scanning/2](https://github.com/vndee/llm-sandbox/security/code-scanning/2)

To fix the issue, we need to explicitly define the `permissions` block for the workflow and its jobs. The permissions should be set to the least privileges required for each job. For example:
- Most jobs (e.g., `quality`, `tests-and-type-check`, `check-docs`) only need `contents: read`.
- The `deploy-docs` job already has `contents: write`, which is appropriate for its task.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, and overridden for specific jobs (like `deploy-docs`) that require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
