### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -8,6 +8,8 @@ jobs:
 
   set-version:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -32,6 +34,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [set-version]
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Check out
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/vndee/llm-sandbox/security/code-scanning/1](https://github.com/vndee/llm-sandbox/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `set-version` and `publish` jobs. These permissions will be scoped to the minimal level required for the jobs to function correctly. Based on the workflow's steps:

1. The `set-version` job requires `contents: write` to update the `pyproject.toml` file and upload it as an artifact.
2. The `publish` job requires `contents: read` to download the artifact and build the package, and `packages: write` to publish the package.

We will add these permissions explicitly to the respective jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
