### PR TITLE
Fix: More posix path issues when preparing image

### DIFF
--- a/llm_sandbox/core/session_base.py
+++ b/llm_sandbox/core/session_base.py
@@ -393,9 +393,10 @@ class BaseSession(
                 code_dest_file = (
                     Path(self.config.workdir) / f"{uuid.uuid4().hex}.{self.language_handler.file_extension}"
                 )
-                self.copy_to_runtime(temp_file_path, str(code_dest_file))
+                code_dest_path_posix = code_dest_file.as_posix()
+                self.copy_to_runtime(temp_file_path, code_dest_path_posix)
 
-                commands = self.language_handler.get_execution_commands(str(code_dest_file))
+                commands = self.language_handler.get_execution_commands(code_dest_path_posix)
                 return self.execute_commands(
                     cast("list[str | tuple[str, str | None]]", commands),
                     workdir=self.config.workdir,


### PR DESCRIPTION
We were ending up with `/sandbox/'\sandbox`  `~\sandbox` and `~\tmp'

I don't know how I didn't catch this before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of file paths for better compatibility across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->