### PR TITLE
Add `skip_environment_setup` option for faster K8s deployments (#92)

### DIFF
--- a/examples/skip_environment_setup_demo.py
+++ b/examples/skip_environment_setup_demo.py
@@ -1,0 +1,131 @@
+"""Example demonstrating skip_environment_setup feature for Kubernetes deployments.
+
+This example shows how to use the skip_environment_setup configuration option
+to avoid package installation delays in Kubernetes environments where
+administrators want to use custom images with pre-configured environments.
+"""
+
+import logging
+
+from llm_sandbox import SandboxBackend, SandboxSession
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+logger = logging.getLogger(__name__)
+
+
+def demo_skip_environment_setup() -> None:
+    """Demonstrate using skip_environment_setup=True to avoid pip upgrade and environment setup."""
+    logger.info("Demo: Skip environment setup for faster container startup")
+
+    # This configuration skips language-specific environment setup
+    # Useful when using custom images with pre-configured environments
+    # or when administrators want to avoid pip upgrade delays in K8s deployments
+    with SandboxSession(
+        lang="python",
+        verbose=True,
+        backend=SandboxBackend.KUBERNETES,  # Change to KUBERNETES for K8s deployment
+        skip_environment_setup=True,
+        # For K8s deployments, administrators can also set custom images
+        # with pre-installed packages to avoid package installation delays
+    ) as session:
+        logger.info("Session created with skip_environment_setup=True")
+        logger.info("No pip upgrade or virtual environment creation will be performed")
+
+        # This assumes the container image already has the required environment set up
+        # For custom images, ensure they include necessary Python packages
+        output = session.run("print('Hello from pre-configured environment!')")
+        logger.info("Output: %s", output.stdout.strip())
+
+        # When skip_environment_setup=True, libraries cannot be installed dynamically
+        # They must be pre-installed in the container image
+        try:
+            output = session.run(
+                "import sys; print(f'Python version: {sys.version}')",
+            )
+            logger.info("Python info: %s", output.stdout.strip())
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Failed to run code: %s", e)
+            logger.info("This might happen if the base image doesn't have the expected Python setup")
+
+
+def demo_normal_environment_setup() -> None:
+    """Demonstrate normal environment setup (default behavior)."""
+    logger.info("\nDemo: Normal environment setup (default behavior)")
+
+    # Default behavior - performs full environment setup
+    with SandboxSession(
+        lang="python",
+        verbose=True,
+        backend=SandboxBackend.KUBERNETES,
+        skip_environment_setup=False,  # This is the default
+    ) as session:
+        logger.info("Session created with default environment setup")
+        logger.info("This will create venv, pip cache, and upgrade pip")
+
+        output = session.run("print('Hello with full environment setup!')")
+        logger.info("Output: %s", output.stdout.strip())
+
+
+def demo_kubernetes_use_case() -> None:
+    """Show how this would be used in a Kubernetes deployment scenario."""
+    logger.info("\nDemo: Kubernetes deployment scenario")
+
+    # In a Kubernetes environment, administrators might want to:
+    # 1. Use a custom image with pre-installed packages
+    # 2. Skip environment setup to reduce pod startup time
+    # 3. Avoid potential network issues with pip index access
+
+    # In a Kubernetes environment, administrators might configure:
+    session_config = {
+        "lang": "python",
+        "verbose": True,
+        "backend": SandboxBackend.KUBERNETES,  # Would be KUBERNETES in real scenario
+        "skip_environment_setup": True,
+        "image": "ghcr.io/vndee/sandbox-python-311-bullseye",  # Custom pre-configured image
+        "runtime_configs": {
+            # K8s specific configurations
+            "mem_limit": "512m",
+            "cpu_count": 1,
+        },
+    }
+
+    logger.info("Kubernetes-style configuration:")
+    logger.info("  - skip_environment_setup: %s", session_config["skip_environment_setup"])
+    logger.info("  - Custom image: %s", session_config["image"])
+    logger.info("  - Resource limits: %s", session_config["runtime_configs"])
+
+    with SandboxSession(
+        lang=session_config["lang"],
+        verbose=session_config["verbose"],
+        backend=session_config["backend"],  # type: ignore[arg-type]
+        skip_environment_setup=session_config["skip_environment_setup"],
+        image=session_config["image"],
+        runtime_configs=session_config["runtime_configs"],
+    ) as session:
+        output = session.run("""
+import os
+import sys
+print(f"Running in: {os.environ.get('HOSTNAME', 'unknown')}")
+print(f"Python path: {sys.executable}")
+print("Environment setup was skipped - using pre-configured image!")
+""")
+        logger.info("K8s demo output:\n%s", output.stdout)
+
+
+if __name__ == "__main__":
+    demo_skip_environment_setup()
+    demo_normal_environment_setup()
+    demo_kubernetes_use_case()
+
+    separator = "=" * 60
+    logger.info("\n%s", separator)
+    logger.info("Summary:")
+    logger.info("- Use skip_environment_setup=True for:")
+    logger.info("  • Custom images with pre-configured environments")
+    logger.info("  • Kubernetes deployments to reduce startup time")
+    logger.info("  • Avoiding pip index/network configuration issues")
+    logger.info("- Use skip_environment_setup=False (default) for:")
+    logger.info("  • Standard development and testing")
+    logger.info("  • When using base images without pre-installed packages")
+    logger.info("  • Maximum compatibility with dynamic package installation")

--- a/llm_sandbox/core/config.py
+++ b/llm_sandbox/core/config.py
@@ -76,6 +76,14 @@ class SessionConfig(BaseModel):
         "By default, containers run as the root user for maximum compatibility.",
     )
 
+    # Environment setup customization
+    skip_environment_setup: bool = Field(
+        default=False,
+        description="Skip language-specific environment setup during container initialization. "
+        "Useful when using custom images with pre-configured environments or when administrators "
+        "want to avoid package installation delays in Kubernetes deployments.",
+    )
+
     def get_execution_timeout(self) -> float | None:
         """Get the execution timeout."""
         return self.execution_timeout or self.default_timeout

--- a/llm_sandbox/docker.py
+++ b/llm_sandbox/docker.py
@@ -98,6 +98,7 @@ class SandboxDockerSession(BaseSession):
         execution_timeout: float | None = None,
         session_timeout: float | None = None,
         container_id: str | None = None,
+        skip_environment_setup: bool = False,
         **kwargs: Any,
     ) -> None:
         r"""Initialize Docker session.
@@ -118,6 +119,7 @@ class SandboxDockerSession(BaseSession):
             execution_timeout (float | None): The execution timeout to use.
             session_timeout (float | None): The session timeout to use.
             container_id (str | None): ID of existing container to connect to.
+            skip_environment_setup (bool): Skip language-specific environment setup.
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -136,6 +138,7 @@ class SandboxDockerSession(BaseSession):
             execution_timeout=execution_timeout,
             session_timeout=session_timeout,
             container_id=container_id,
+            skip_environment_setup=skip_environment_setup,
         )
 
         super().__init__(config=config, **kwargs)

--- a/llm_sandbox/kubernetes.py
+++ b/llm_sandbox/kubernetes.py
@@ -276,6 +276,7 @@ class SandboxKubernetesSession(BaseSession):
         execution_timeout: float | None = None,
         session_timeout: float | None = None,
         container_id: str | None = None,  # This will be pod_id for Kubernetes
+        skip_environment_setup: bool = False,
         **kwargs: Any,
     ) -> None:
         r"""Initialize Kubernetes session.
@@ -294,6 +295,7 @@ class SandboxKubernetesSession(BaseSession):
             execution_timeout (float | None): The execution timeout to use.
             session_timeout (float | None): The session timeout to use.
             container_id (str | None): ID of existing pod to connect to.
+            skip_environment_setup (bool): Skip language-specific environment setup.
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -310,6 +312,7 @@ class SandboxKubernetesSession(BaseSession):
             execution_timeout=execution_timeout,
             session_timeout=session_timeout,
             container_id=container_id,
+            skip_environment_setup=skip_environment_setup,
         )
 
         super().__init__(config=config, **kwargs)

--- a/llm_sandbox/micromamba.py
+++ b/llm_sandbox/micromamba.py
@@ -52,6 +52,7 @@ class MicromambaSession(SandboxDockerSession):
         execution_timeout: float | None = None,
         session_timeout: float | None = None,
         container_id: str | None = None,
+        skip_environment_setup: bool = False,
         **kwargs: Any,
     ) -> None:
         r"""Initialize a new Micromamba-enabled sandbox session.
@@ -90,6 +91,8 @@ class MicromambaSession(SandboxDockerSession):
                 Defaults to None.
             container_id (str | None, optional): ID of existing container to connect to.
                 Defaults to None.
+            skip_environment_setup (bool, optional): Skip language-specific environment setup.
+                Defaults to False.
             **kwargs: Additional keyword arguments.
 
         """
@@ -110,6 +113,7 @@ class MicromambaSession(SandboxDockerSession):
             execution_timeout=execution_timeout,
             session_timeout=session_timeout,
             container_id=container_id,
+            skip_environment_setup=skip_environment_setup,
             **kwargs,
         )
 

--- a/llm_sandbox/podman.py
+++ b/llm_sandbox/podman.py
@@ -67,6 +67,7 @@ class SandboxPodmanSession(SandboxDockerSession):
         execution_timeout: float | None = None,
         session_timeout: float | None = None,
         container_id: str | None = None,
+        skip_environment_setup: bool = False,
         **kwargs: dict[str, Any],
     ) -> None:
         r"""Initialize Podman session.
@@ -88,6 +89,7 @@ class SandboxPodmanSession(SandboxDockerSession):
             execution_timeout (float | None): The execution timeout to use.
             session_timeout (float | None): The session timeout to use.
             container_id (str | None): ID of existing container to connect to.
+            skip_environment_setup (bool): Skip language-specific environment setup.
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -106,6 +108,7 @@ class SandboxPodmanSession(SandboxDockerSession):
             execution_timeout=execution_timeout,
             session_timeout=session_timeout,
             container_id=container_id,
+            skip_environment_setup=skip_environment_setup,
         )
 
         # Initialize BaseSession (skip Docker's __init__)


### PR DESCRIPTION
## Summary

This PR addresses issue #92 by implementing a `skip_environment_setup` configuration option that allows administrators to bypass   language-specific environment setup during container initialization. This is particularly valuable for Kubernetes deployments where administrators want to:
  • Use custom images with pre-configured environments
  • Reduce pod startup time by avoiding pip upgrade delays
  • Eliminate the need to configure PIP_INDEX for cache infrastructure

  ## Changes Made
  - **Added `skip_environment_setup` field to `SessionConfig`** (defaults to `False` for backward compatibility)
  - **Updated `environment_setup()` method** to respect the skip flag with proper logging
  - **Enhanced library installation logic** to block dynamic installation when skip is enabled (with helpful error messages)
  - **Updated all backend constructors** (Docker, Kubernetes, Podman, Micromamba) to support the new parameter
  - **Added comprehensive demo** showing usage patterns for different deployment scenarios

  ## Usage Example
  ```python
  from llm_sandbox import SandboxSession, SandboxBackend

  # Skip environment setup for faster K8s pod startup
  with SandboxSession(
      lang="python",
      backend=SandboxBackend.KUBERNETES,
      skip_environment_setup=True,  # No pip upgrades or venv creation
      image="my-registry.com/custom-python:latest"  # Pre-configured image
  ) as session:
      result = session.run("print('Hello from pre-configured environment!')")
```