### PR TITLE
Add NAMESPACE environment variable for Kubernetes pod customization

### DIFF
--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -89,6 +89,22 @@ For specific backends, set the `BACKEND` environment variable:
 }
 ```
 
+**Kubernetes with Custom Namespace:**
+```json
+{
+  "mcpServers": {
+    "llm-sandbox": {
+      "command": "python3",
+      "args": ["-m", "llm_sandbox.mcp_server.server"],
+      "env": {
+        "BACKEND": "kubernetes",
+        "NAMESPACE": "llm-sandbox"
+      }
+    }
+  }
+}
+```
+
 ## Troubleshooting
 
 If you encounter connection issues with your backend, you may need to specify additional environment variables:
@@ -148,6 +164,7 @@ If you encounter connection issues with your backend, you may need to specify ad
 - `BACKEND`: Choose your container backend (`docker`, `podman`, or `kubernetes`)
 - `COMMIT_CONTAINER`: Control whether container changes are saved to the image (default: `true`)
 - `KEEP_TEMPLATE`: Control whether template containers are preserved (default: `true`)
+- `NAMESPACE`: Specify Kubernetes namespace for pod creation (default: `default`)
 
 ### Container Behavior Control
 
@@ -210,6 +227,7 @@ Both `COMMIT_CONTAINER` and `KEEP_TEMPLATE` accept:
 **Use Cases:**
 - `COMMIT_CONTAINER=false`: Prevent Docker images from growing over time, useful in CI/CD or automated environments
 - `KEEP_TEMPLATE=false`: Clean up template containers automatically, reduces Docker container clutter
+- `NAMESPACE="custom-namespace"`: Organize Kubernetes pods in specific namespaces for multi-tenant environments
 - Both disabled: Minimal resource usage, ideal for ephemeral environments
 
 ## Available Tools

--- a/llm_sandbox/mcp_server/server.py
+++ b/llm_sandbox/mcp_server/server.py
@@ -43,6 +43,11 @@ def _get_keep_template() -> bool:
     return keep_template_env in ("true", "1", "yes", "on")
 
 
+def _get_kube_namespace() -> str:
+    """Get the Kubernetes namespace from environment variable."""
+    return os.environ.get("NAMESPACE", "default")
+
+
 def _supports_visualization(language: str) -> bool:
     """Check if a language supports visualization capture."""
     lang_details = LANGUAGE_RESOURCES.get(language)
@@ -81,6 +86,7 @@ def execute_code(
             verbose=False,
             backend=_get_backend(),
             session_timeout=timeout,
+            kube_namespace=_get_kube_namespace(),
         ) as session:
             result = session.run(
                 code=code,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16,6 +16,7 @@ from llm_sandbox.mcp_server.server import (
     _get_backend,
     _get_commit_container,
     _get_keep_template,
+    _get_kube_namespace,
     _supports_visualization,
     execute_code,
     get_language_details,
@@ -180,6 +181,34 @@ class TestGetKeepTemplate:
         assert result is True
 
 
+class TestGetKubeNamespace:
+    """Test _get_kube_namespace function."""
+
+    @patch.dict(os.environ, {"NAMESPACE": "custom-namespace"})
+    def test_get_kube_namespace_custom(self) -> None:
+        """Test getting custom namespace from environment variable."""
+        result = _get_kube_namespace()
+        assert result == "custom-namespace"
+
+    @patch.dict(os.environ, {"NAMESPACE": "production"})
+    def test_get_kube_namespace_production(self) -> None:
+        """Test getting production namespace from environment variable."""
+        result = _get_kube_namespace()
+        assert result == "production"
+
+    @patch.dict(os.environ, {"NAMESPACE": "llm-sandbox"})
+    def test_get_kube_namespace_llm_sandbox(self) -> None:
+        """Test getting llm-sandbox namespace from environment variable."""
+        result = _get_kube_namespace()
+        assert result == "llm-sandbox"
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_get_kube_namespace_default(self) -> None:
+        """Test getting default namespace when no environment variable is set."""
+        result = _get_kube_namespace()
+        assert result == "default"
+
+
 class TestSupportsVisualization:
     """Test _supports_visualization function."""
 
@@ -220,10 +249,12 @@ class TestExecuteCode:
     @patch("llm_sandbox.mcp_server.server._get_backend")
     @patch("llm_sandbox.mcp_server.server._get_commit_container")
     @patch("llm_sandbox.mcp_server.server._get_keep_template")
+    @patch("llm_sandbox.mcp_server.server._get_kube_namespace")
     @patch("llm_sandbox.mcp_server.server.ArtifactSandboxSession")
     def test_execute_code_basic_success(
         self,
         mock_session_cls: MagicMock,
+        mock_get_kube_namespace: MagicMock,
         mock_get_keep_template: MagicMock,
         mock_get_commit_container: MagicMock,
         mock_get_backend: MagicMock,
@@ -234,6 +265,7 @@ class TestExecuteCode:
         mock_get_backend.return_value = mock_backend
         mock_get_commit_container.return_value = True
         mock_get_keep_template.return_value = True
+        mock_get_kube_namespace.return_value = "default"
 
         mock_session = MagicMock()
         mock_session_cls.return_value.__enter__ = MagicMock(return_value=mock_session)
@@ -258,16 +290,19 @@ class TestExecuteCode:
             verbose=False,
             backend=mock_backend,
             session_timeout=30,
+            kube_namespace="default",
         )
         mock_session.run.assert_called_once_with(code="print('Hello, World!')", libraries=[], timeout=30)
 
     @patch("llm_sandbox.mcp_server.server._get_backend")
     @patch("llm_sandbox.mcp_server.server._get_commit_container")
     @patch("llm_sandbox.mcp_server.server._get_keep_template")
+    @patch("llm_sandbox.mcp_server.server._get_kube_namespace")
     @patch("llm_sandbox.mcp_server.server.ArtifactSandboxSession")
     def test_execute_code_with_visualization(
         self,
         mock_session_cls: MagicMock,
+        mock_get_kube_namespace: MagicMock,
         mock_get_keep_template: MagicMock,
         mock_get_commit_container: MagicMock,
         mock_get_backend: MagicMock,
@@ -278,6 +313,7 @@ class TestExecuteCode:
         mock_get_backend.return_value = mock_backend
         mock_get_commit_container.return_value = True
         mock_get_keep_template.return_value = True
+        mock_get_kube_namespace.return_value = "default"
 
         mock_session = MagicMock()
         mock_session_cls.return_value.__enter__ = MagicMock(return_value=mock_session)
@@ -314,15 +350,18 @@ class TestExecuteCode:
             verbose=False,
             backend=mock_backend,
             session_timeout=30,
+            kube_namespace="default",
         )
 
     @patch("llm_sandbox.mcp_server.server._get_backend")
     @patch("llm_sandbox.mcp_server.server._get_commit_container")
     @patch("llm_sandbox.mcp_server.server._get_keep_template")
+    @patch("llm_sandbox.mcp_server.server._get_kube_namespace")
     @patch("llm_sandbox.mcp_server.server.ArtifactSandboxSession")
     def test_execute_code_with_libraries(
         self,
         mock_session_cls: MagicMock,
+        mock_get_kube_namespace: MagicMock,
         mock_get_keep_template: MagicMock,
         mock_get_commit_container: MagicMock,
         mock_get_backend: MagicMock,
@@ -333,6 +372,7 @@ class TestExecuteCode:
         mock_get_backend.return_value = mock_backend
         mock_get_commit_container.return_value = True
         mock_get_keep_template.return_value = True
+        mock_get_kube_namespace.return_value = "default"
 
         mock_session = MagicMock()
         mock_session_cls.return_value.__enter__ = MagicMock(return_value=mock_session)
@@ -362,15 +402,18 @@ class TestExecuteCode:
             verbose=False,
             backend=mock_backend,
             session_timeout=60,
+            kube_namespace="default",
         )
 
     @patch("llm_sandbox.mcp_server.server._get_backend")
     @patch("llm_sandbox.mcp_server.server._get_commit_container")
     @patch("llm_sandbox.mcp_server.server._get_keep_template")
+    @patch("llm_sandbox.mcp_server.server._get_kube_namespace")
     @patch("llm_sandbox.mcp_server.server.SandboxSession")
     def test_execute_code_javascript(
         self,
         mock_session_cls: MagicMock,
+        mock_get_kube_namespace: MagicMock,
         mock_get_keep_template: MagicMock,
         mock_get_commit_container: MagicMock,
         mock_get_backend: MagicMock,
@@ -381,6 +424,7 @@ class TestExecuteCode:
         mock_get_backend.return_value = mock_backend
         mock_get_commit_container.return_value = True
         mock_get_keep_template.return_value = True
+        mock_get_kube_namespace.return_value = "default"
 
         mock_session = MagicMock()
         mock_session_cls.return_value.__enter__ = MagicMock(return_value=mock_session)
@@ -404,15 +448,18 @@ class TestExecuteCode:
             verbose=False,
             backend=mock_backend,
             session_timeout=30,
+            kube_namespace="default",
         )
 
     @patch("llm_sandbox.mcp_server.server._get_backend")
     @patch("llm_sandbox.mcp_server.server._get_commit_container")
     @patch("llm_sandbox.mcp_server.server._get_keep_template")
+    @patch("llm_sandbox.mcp_server.server._get_kube_namespace")
     @patch("llm_sandbox.mcp_server.server.ArtifactSandboxSession")
     def test_execute_code_error_handling(
         self,
         mock_session_cls: MagicMock,
+        mock_get_kube_namespace: MagicMock,
         mock_get_keep_template: MagicMock,
         mock_get_commit_container: MagicMock,
         mock_get_backend: MagicMock,
@@ -423,6 +470,7 @@ class TestExecuteCode:
         mock_get_backend.return_value = mock_backend
         mock_get_commit_container.return_value = True
         mock_get_keep_template.return_value = True
+        mock_get_kube_namespace.return_value = "default"
 
         # Simulate an exception during session creation
         mock_session_cls.side_effect = RuntimeError("Docker not available")
@@ -440,10 +488,12 @@ class TestExecuteCode:
     @patch("llm_sandbox.mcp_server.server._get_backend")
     @patch("llm_sandbox.mcp_server.server._get_commit_container")
     @patch("llm_sandbox.mcp_server.server._get_keep_template")
+    @patch("llm_sandbox.mcp_server.server._get_kube_namespace")
     @patch("llm_sandbox.mcp_server.server.ArtifactSandboxSession")
     def test_execute_code_session_error(
         self,
         mock_session_cls: MagicMock,
+        mock_get_kube_namespace: MagicMock,
         mock_get_keep_template: MagicMock,
         mock_get_commit_container: MagicMock,
         mock_get_backend: MagicMock,
@@ -454,6 +504,7 @@ class TestExecuteCode:
         mock_get_backend.return_value = mock_backend
         mock_get_commit_container.return_value = True
         mock_get_keep_template.return_value = True
+        mock_get_kube_namespace.return_value = "default"
 
         mock_session = MagicMock()
         mock_session_cls.return_value.__enter__ = MagicMock(return_value=mock_session)


### PR DESCRIPTION
## Summary

Fixes #96 - Add `NAMESPACE` environment variable for Kubernetes pod customization.

## Problem

Users using the MCP server with Kubernetes backend were unable to control which namespace pods were created in. The namespace was hardcoded to "default", making it difficult to organize pods in multi-tenant environments or use specific namespaces for different applications like LibreChat.

## Solution

### Core Implementation
- **Added `_get_kube_namespace()` function**: Reads `NAMESPACE` environment variable with "default" fallback
- **Updated MCP server**: Passes `kube_namespace=_get_kube_namespace()` to session creation
- **Infrastructure Support**: Leverages existing `kube_namespace` parameter in `SandboxKubernetesSession`

### Environment Variable Support
- **Variable**: `NAMESPACE` 
- **Default**: `"default"`
- **Usage**: Accepts any valid Kubernetes namespace string
- **Backward Compatibility**: Fully maintained (default behavior unchanged)

## Test Plan

- [x] Added comprehensive tests for `_get_kube_namespace()` function
- [x] Updated all existing MCP server tests to include kube_namespace parameter
- [x] All tests pass (52/52)
- [x] Code quality checks pass (ruff, mypy, pre-commit)
- [x] Manual verification with custom namespace values

## Documentation Updates

- Added `NAMESPACE` to environment variables reference
- Added Kubernetes with custom namespace example
- Updated use cases section with namespace organization benefits
- Provided practical configuration for multi-tenant environments

## Usage Examples

### Basic Kubernetes with Custom Namespace
```json
{
  "mcpServers": {
    "llm-sandbox": {
      "command": "python3",
      "args": ["-m", "llm_sandbox.mcp_server.server"],
      "env": {
        "BACKEND": "kubernetes",
        "NAMESPACE": "llm-sandbox"
      }
    }
  }
}
```

### LibreChat Integration
```json
{
  "mcpServers": {
    "llm-sandbox": {
      "command": "python3",
      "args": ["-m", "llm_sandbox.mcp_server.server"],
      "env": {
        "BACKEND": "kubernetes",
        "NAMESPACE": "librechat",
        "COMMIT_CONTAINER": "false"
      }
    }
  }
}
```

## Use Cases

- **Multi-tenant environments**: Isolate different applications/users in separate namespaces
- **Resource organization**: Group sandbox pods by project or team
- **Permission management**: Use Kubernetes RBAC with namespace-level permissions
- **Clean separation**: Avoid polluting the default namespace with sandbox pods

## Impact

- **Breaking Change**: None - default behavior unchanged
- **Backward Compatibility**: Fully maintained
- **Performance**: No impact
- **Security**: Enhanced by enabling better namespace-based isolation

💘 Generated with Crush

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce NAMESPACE env var and pass kube_namespace to sessions, enabling Kubernetes namespace selection with docs and tests updated.
> 
> - **Server/MCP**:
>   - Add `_get_kube_namespace()` reading `NAMESPACE` (default `"default"`).
>   - Pass `kube_namespace=_get_kube_namespace()` into `SandboxSession`/`ArtifactSandboxSession`.
> - **Tests**:
>   - New tests for `_get_kube_namespace()`.
>   - Update `execute_code` tests to expect `kube_namespace` argument across scenarios.
> - **Docs**:
>   - Add Kubernetes config example with custom `NAMESPACE`.
>   - Document `NAMESPACE` in common env vars and use-cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bef161576c5a889900283a49938857799c8c31e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->