### PR TITLE
Fix: Pool manager namespace parameter bug (issue #134)

### DIFF
--- a/llm_sandbox/pool/kubernetes_pool.py
+++ b/llm_sandbox/pool/kubernetes_pool.py
@@ -83,7 +83,7 @@ class KubernetesPoolManager(ContainerPoolManager):
             client=self.client,
             image=self.image,
             lang=str(self.lang),
-            namespace=self.namespace,
+            kube_namespace=self.namespace,
             pod_manifest=self.pod_manifest_template,
             **self.session_kwargs,
         )

--- a/tests/test_pool_kubernetes.py
+++ b/tests/test_pool_kubernetes.py
@@ -110,7 +110,7 @@ class TestKubernetesPoolManagerSessionCreation:
         assert call_kwargs["client"] == mock_client
         assert call_kwargs["image"] == "test:latest"
         assert call_kwargs["lang"] == "python"
-        assert call_kwargs["namespace"] == "test-ns"
+        assert call_kwargs["kube_namespace"] == "test-ns"
 
     @patch("kubernetes.config.load_kube_config")
     @patch("llm_sandbox.pool.kubernetes_pool.CoreV1Api")
@@ -138,7 +138,7 @@ class TestKubernetesPoolManagerSessionCreation:
         assert call_kwargs["client"] == mock_client
         assert call_kwargs["image"] == "test:latest"
         assert call_kwargs["lang"] == "python"
-        assert call_kwargs["namespace"] == "test-ns"
+        assert call_kwargs["kube_namespace"] == "test-ns"
 
 
 class TestKubernetesPoolManagerContainerDestruction:


### PR DESCRIPTION
## Summary
Fixes #134 - Pool manager now correctly passes the namespace parameter to Kubernetes sessions, preventing 403 Forbidden errors and pod leaks.

## Problem
The `KubernetesPoolManager` was passing `namespace=` to `SandboxKubernetesSession`, but the session constructor expects `kube_namespace=`. This parameter mismatch caused:
- ✅ Pods created in the correct custom namespace
- ❌ Cleanup attempts in the wrong "default" namespace  
- ❌ 403 Forbidden errors when users lack permissions on default namespace
- ❌ Pod leaks - pods remain running because cleanup fails

## Root Cause
This bug was previously fixed in commits e3ab166 and 27303f1, but was accidentally reverted when PR #136 merged. PR #136's commit 0093d59 was created before the namespace fix was merged to main, so it overwrote the fix with the old buggy code.

## Solution
- Changed `namespace=self.namespace` to `kube_namespace=self.namespace` in `KubernetesPoolManager._create_session_for_container()`
- Updated test assertions to validate `kube_namespace` parameter instead of `namespace`

## Testing
- Updated unit tests in `tests/test_pool_kubernetes.py` to assert the correct parameter name
- Tests now properly validate that the pool manager passes `kube_namespace` to sessions

## Impact
This fix ensures pods are properly cleaned up in the correct namespace, preventing resource leaks and permission errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal parameter naming for better code clarity and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->