### PR TITLE
fix(session): use system Python for external containers

### DIFF
--- a/llm_sandbox/core/session_base.py
+++ b/llm_sandbox/core/session_base.py
@@ -482,15 +482,13 @@ class BaseSession(
                 self.copy_to_runtime(temp_file_path, code_dest_path_posix)
 
                 # Create runtime context for execution
-                # Use venv paths for Python when:
-                # 1. Not skipping environment setup (normal case)
-                # 2. OR when skip_environment_setup=True but using existing container
-                #    (pooled containers have venv)
-                #    Note: For pooled containers, skip_environment_setup=True means
-                #    "don't set up again", but the venv already exists from pool
-                #    initialization, so we should use it.
+                # Use venv paths for Python ONLY when:
+                # 1. Not skipping environment setup (normal case - we created the venv)
+                # 2. AND not using an existing container (external containers may not have venv)
+                # Note: For pooled containers, they use a different code path via PooledSandboxSession
+                # which explicitly sets up the venv and knows it exists.
                 use_venv_paths = self.language_handler.name == "python" and (
-                    not self.config.skip_environment_setup or self.using_existing_container
+                    not self.config.skip_environment_setup and not self.using_existing_container
                 )
                 runtime_context = RuntimeContext(
                     workdir=self.config.workdir,


### PR DESCRIPTION
When connecting to containers via container_id, use system Python instead of assuming the container has llm-sandbox's venv structure.

External containers created by users likely don't have the /sandbox/.sandbox-venv/bin/python path that llm-sandbox creates. The previous logic incorrectly assumed all existing containers had this venv structure.

Fixes #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes Python environment selection so virtualenv paths are only used when environment setup runs and no existing container is used; system Python is used for external-container scenarios.
  * Clarifies differing behavior for pooled container execution paths.

* **Tests**
  * Adds parameterized tests covering both skipped-setup and external-container scenarios to verify the interpreter choice.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->