### PR TITLE
Add configurable encoding error handling for command output

### DIFF
--- a/llm_sandbox/const.py
+++ b/llm_sandbox/const.py
@@ -7,7 +7,7 @@ container image names.
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 
 
 class StrEnum(str, Enum):
@@ -95,3 +95,9 @@ class DefaultImage:
     GO = "ghcr.io/vndee/sandbox-go-123-bullseye"
     RUBY = "ghcr.io/vndee/sandbox-ruby-302-bullseye"
     R = "ghcr.io/vndee/sandbox-r-451-bullseye"
+
+
+# Type alias for encoding error handling modes (matches Python's bytes.decode errors parameter)
+EncodingErrorsType = Literal[
+    "strict", "replace", "ignore", "surrogateescape", "backslashreplace", "xmlcharrefreplace"
+]

--- a/llm_sandbox/core/config.py
+++ b/llm_sandbox/core/config.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field, model_validator
 
-from llm_sandbox.const import SupportedLanguage
+from llm_sandbox.const import EncodingErrorsType, SupportedLanguage
 from llm_sandbox.security import SecurityPolicy
 
 
@@ -82,6 +82,15 @@ class SessionConfig(BaseModel):
         description="Skip language-specific environment setup during container initialization. "
         "Useful when using custom images with pre-configured environments or when administrators "
         "want to avoid package installation delays in Kubernetes deployments.",
+    )
+
+    # Output encoding
+    encoding_errors: EncodingErrorsType = Field(
+        default="strict",
+        description="Error handling for decoding command output bytes to strings. "
+        "Uses Python's bytes.decode() error modes: 'strict' (default, raises UnicodeDecodeError), "
+        "'replace' (uses replacement character), 'surrogateescape' (PEP 383, round-trips), "
+        "'ignore' (skips invalid bytes), 'backslashreplace', 'xmlcharrefreplace'.",
     )
 
     def get_execution_timeout(self) -> float | None:

--- a/llm_sandbox/kubernetes.py
+++ b/llm_sandbox/kubernetes.py
@@ -12,7 +12,7 @@ from kubernetes.client import CoreV1Api
 from kubernetes.client.exceptions import ApiException
 from kubernetes.stream import stream
 
-from llm_sandbox.const import DefaultImage, SupportedLanguage
+from llm_sandbox.const import DefaultImage, EncodingErrorsType, SupportedLanguage
 from llm_sandbox.core.config import SessionConfig
 from llm_sandbox.core.session_base import BaseSession
 from llm_sandbox.data import ConsoleOutput
@@ -331,6 +331,7 @@ class SandboxKubernetesSession(BaseSession):
         session_timeout: float | None = None,
         container_id: str | None = None,  # This will be pod_id for Kubernetes
         skip_environment_setup: bool = False,
+        encoding_errors: EncodingErrorsType = "strict",
         **kwargs: Any,
     ) -> None:
         r"""Initialize Kubernetes session.
@@ -350,6 +351,7 @@ class SandboxKubernetesSession(BaseSession):
             session_timeout (float | None): The session timeout to use.
             container_id (str | None): ID of existing pod to connect to.
             skip_environment_setup (bool): Skip language-specific environment setup.
+            encoding_errors (EncodingErrorsType): Error handling for decoding command output.
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -367,6 +369,7 @@ class SandboxKubernetesSession(BaseSession):
             session_timeout=session_timeout,
             container_id=container_id,
             skip_environment_setup=skip_environment_setup,
+            encoding_errors=encoding_errors,
         )
 
         super().__init__(config=config, **kwargs)

--- a/llm_sandbox/podman.py
+++ b/llm_sandbox/podman.py
@@ -6,7 +6,7 @@ from podman import PodmanClient
 from podman.errors.exceptions import ImageNotFound as PodmanImageNotFound
 from podman.errors.exceptions import NotFound as PodmanNotFound
 
-from llm_sandbox.const import SupportedLanguage
+from llm_sandbox.const import EncodingErrorsType, SupportedLanguage
 from llm_sandbox.core.config import SessionConfig
 from llm_sandbox.docker import DockerContainerAPI, SandboxDockerSession
 from llm_sandbox.exceptions import ContainerError, ImagePullError
@@ -71,6 +71,7 @@ class SandboxPodmanSession(SandboxDockerSession):
         session_timeout: float | None = None,
         container_id: str | None = None,
         skip_environment_setup: bool = False,
+        encoding_errors: EncodingErrorsType = "strict",
         **kwargs: dict[str, Any],
     ) -> None:
         r"""Initialize Podman session.
@@ -93,6 +94,7 @@ class SandboxPodmanSession(SandboxDockerSession):
             session_timeout (float | None): The session timeout to use.
             container_id (str | None): ID of existing container to connect to.
             skip_environment_setup (bool): Skip language-specific environment setup.
+            encoding_errors (EncodingErrorsType): Error handling for decoding command output.
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -112,6 +114,7 @@ class SandboxPodmanSession(SandboxDockerSession):
             session_timeout=session_timeout,
             container_id=container_id,
             skip_environment_setup=skip_environment_setup,
+            encoding_errors=encoding_errors,
         )
 
         # Initialize BaseSession (skip Docker's __init__)

--- a/llm_sandbox/pool/session.py
+++ b/llm_sandbox/pool/session.py
@@ -4,7 +4,7 @@ import logging
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
 
-from llm_sandbox.const import SandboxBackend
+from llm_sandbox.const import EncodingErrorsType, SandboxBackend
 from llm_sandbox.data import ConsoleOutput, ExecutionResult
 from llm_sandbox.pool.base import ContainerPoolManager, PooledContainer
 from llm_sandbox.security import SecurityPolicy
@@ -53,6 +53,7 @@ class PooledSandboxSession:
         default_timeout: float | None = None,
         execution_timeout: float | None = None,
         session_timeout: float | None = None,
+        encoding_errors: EncodingErrorsType = "strict",
         **kwargs: Any,
     ) -> None:
         """Initialize pooled sandbox session.
@@ -66,6 +67,7 @@ class PooledSandboxSession:
             default_timeout: Default timeout for operations
             execution_timeout: Timeout for code execution
             session_timeout: Maximum session lifetime
+            encoding_errors: Error handling for decoding command output
             **kwargs: Additional backend-specific arguments
 
         Examples:
@@ -108,6 +110,7 @@ class PooledSandboxSession:
         self._default_timeout = default_timeout
         self._execution_timeout = execution_timeout
         self._session_timeout = session_timeout
+        self._encoding_errors = encoding_errors
 
         # Extract common parameters that the backend session expects, falling back to pool defaults
         self._lang = kwargs.pop("lang", self._pool_manager.lang)
@@ -231,6 +234,7 @@ class PooledSandboxSession:
                     session_timeout=self._session_timeout,
                     container_id=container_id,  # Connect to existing pooled container
                     skip_environment_setup=True,  # Pool already set up the environment
+                    encoding_errors=self._encoding_errors,
                     **session_kwargs,
                 )
 
@@ -259,6 +263,7 @@ class PooledSandboxSession:
                     session_timeout=self._session_timeout,
                     pod_id=container_id,  # Connect to existing pooled pod
                     skip_environment_setup=True,
+                    encoding_errors=self._encoding_errors,
                     **session_kwargs,
                 )
 
@@ -283,6 +288,7 @@ class PooledSandboxSession:
                     session_timeout=self._session_timeout,
                     container_id=container_id,  # Connect to existing pooled container
                     skip_environment_setup=True,
+                    encoding_errors=self._encoding_errors,
                     **session_kwargs,
                 )
 

--- a/tests/test_encoding_errors.py
+++ b/tests/test_encoding_errors.py
@@ -1,0 +1,126 @@
+"""Tests for encoding error handling in Docker sessions."""
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llm_sandbox.docker import SandboxDockerSession
+from llm_sandbox.session import SandboxSession
+
+
+@pytest.fixture
+def mock_docker_client() -> MagicMock:
+    """Create a mock Docker client."""
+    return MagicMock()
+
+
+class TestDefaultEncodingBehavior:
+    """Test default encoding behavior without explicit encoding_errors parameter."""
+
+    @patch("llm_sandbox.docker.docker.from_env")
+    def test_sandbox_session_default_raises_on_invalid_utf8(self, mock_from_env: MagicMock) -> None:
+        """SandboxSession without encoding_errors raises UnicodeDecodeError on invalid UTF-8.
+
+        This documents the original/default behavior: non-UTF-8 output causes an error.
+        """
+        mock_client = MagicMock()
+        mock_from_env.return_value = mock_client
+
+        session = SandboxSession(lang="python")
+        assert session.config.encoding_errors == "strict"
+
+        # Simulate container output with invalid UTF-8
+        invalid_utf8 = (b"output\xff\xfebytes", None)
+        with pytest.raises(UnicodeDecodeError):
+            session._process_non_stream_output(invalid_utf8)
+
+
+class TestEncodingErrors:
+    """Tests for encoding_errors parameter in Docker output processing."""
+
+    def test_strict_raises_on_invalid_utf8(self, mock_docker_client: MagicMock) -> None:
+        """Default strict mode raises UnicodeDecodeError on invalid UTF-8."""
+        session = SandboxDockerSession(client=mock_docker_client, encoding_errors="strict")
+        invalid_utf8 = (b"\xff\xfe", None)
+        with pytest.raises(UnicodeDecodeError):
+            session._process_non_stream_output(invalid_utf8)
+
+    def test_replace_substitutes_invalid_bytes(self, mock_docker_client: MagicMock) -> None:
+        """Replace mode uses replacement character for invalid bytes."""
+        session = SandboxDockerSession(client=mock_docker_client, encoding_errors="replace")
+        stdout, _ = session._process_non_stream_output((b"hello\xff\xfeworld", None))
+        assert "hello" in stdout
+        assert "world" in stdout
+        assert "\ufffd" in stdout  # Replacement character
+
+    def test_surrogateescape_roundtrips(self, mock_docker_client: MagicMock) -> None:
+        """Surrogateescape mode allows round-tripping binary data."""
+        session = SandboxDockerSession(client=mock_docker_client, encoding_errors="surrogateescape")
+        original = b"hello\xff\xfeworld"
+        stdout, _ = session._process_non_stream_output((original, None))
+        assert stdout.encode("utf-8", errors="surrogateescape") == original
+
+    def test_ignore_skips_invalid_bytes(self, mock_docker_client: MagicMock) -> None:
+        """Ignore mode skips invalid bytes."""
+        session = SandboxDockerSession(client=mock_docker_client, encoding_errors="ignore")
+        stdout, _ = session._process_non_stream_output((b"hello\xff\xfeworld", None))
+        assert stdout == "helloworld"
+
+    def test_backslashreplace_escapes_invalid_bytes(self, mock_docker_client: MagicMock) -> None:
+        """Backslashreplace mode escapes invalid bytes with backslash sequences."""
+        session = SandboxDockerSession(client=mock_docker_client, encoding_errors="backslashreplace")
+        stdout, _ = session._process_non_stream_output((b"hello\xffworld", None))
+        assert "hello" in stdout
+        assert "world" in stdout
+        assert "\\xff" in stdout
+
+    def test_default_encoding_is_strict(self, mock_docker_client: MagicMock) -> None:
+        """Default encoding_errors is 'strict'."""
+        session = SandboxDockerSession(client=mock_docker_client)
+        assert session.config.encoding_errors == "strict"
+
+    def test_stderr_also_uses_encoding_errors(self, mock_docker_client: MagicMock) -> None:
+        """Stderr is also decoded using encoding_errors setting."""
+        session = SandboxDockerSession(client=mock_docker_client, encoding_errors="replace")
+        _, stderr = session._process_non_stream_output((None, b"error\xff\xfemsg"))
+        assert "error" in stderr
+        assert "msg" in stderr
+        assert "\ufffd" in stderr
+
+    def test_stream_output_respects_encoding_errors(self, mock_docker_client: MagicMock) -> None:
+        """Stream processing also respects encoding_errors setting."""
+        session = SandboxDockerSession(client=mock_docker_client, encoding_errors="replace", stream=True)
+
+        def mock_stream() -> Generator[tuple[bytes | None, bytes | None], Any, None]:
+            yield (b"hello\xff", None)
+            yield (b"\xfeworld", None)
+
+        stdout, _ = session._process_stream_output(mock_stream())
+        assert "hello" in stdout
+        assert "world" in stdout
+        assert "\ufffd" in stdout
+
+    def test_stream_strict_swallows_unicode_error(self, mock_docker_client: MagicMock) -> None:
+        """Stream processing swallows UnicodeDecodeError for resilience."""
+        session = SandboxDockerSession(client=mock_docker_client, encoding_errors="strict", stream=True)
+
+        def mock_stream() -> Generator[tuple[bytes | None, bytes | None], Any, None]:
+            yield (b"hello\xff\xfeworld", None)
+
+        # Stream mode swallows exceptions (except SandboxTimeoutError) for resilience
+        stdout, stderr = session._process_stream_output(mock_stream())
+        # Returns partial output up to the error point
+        assert stdout == ""
+        assert stderr == ""
+
+    def test_valid_utf8_works_with_all_modes(self, mock_docker_client: MagicMock) -> None:
+        """Valid UTF-8 works correctly with all encoding modes."""
+        valid_utf8 = "Hello, \u4e16\u754c!".encode()  # "Hello, World!" with Chinese characters
+        modes = ["strict", "replace", "ignore", "surrogateescape", "backslashreplace"]
+
+        for mode in modes:
+            session = SandboxDockerSession(client=mock_docker_client, encoding_errors=mode)  # type: ignore[arg-type]
+            stdout, _ = session._process_non_stream_output((valid_utf8, None))
+            assert stdout == "Hello, \u4e16\u754c!", f"Failed for mode: {mode}"


### PR DESCRIPTION
Add `encoding_errors` parameter to SessionConfig and all session classes (Docker, Kubernetes, Podman, PooledSandboxSession) to control how non-UTF-8 bytes are handled when decoding command output.

Supports all standard Python decode error modes: `strict` (default), `replace`, `ignore`, `surrogateescape`, `backslashreplace`, `xmlcharrefreplace`.

This allows callers to handle binary/non-UTF-8 output gracefully instead of getting `UnicodeDecodeError` with the default `strict` mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable encoding error handling for sandbox output processing. Users can now specify how decoding errors are handled when processing stdout and stderr (strict, replace, ignore, surrogateescape, backslashreplace, xmlcharrefreplace). Default remains "strict" for backward compatibility.

* **Tests**
  * Added comprehensive test coverage for encoding error handling across multiple modes and processing paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->