### PR TITLE
fix(mcp): clear plots before execution and return latest plot

### DIFF
--- a/llm_sandbox/mcp_server/server.py
+++ b/llm_sandbox/mcp_server/server.py
@@ -92,10 +92,11 @@ def execute_code(
                 code=code,
                 libraries=libraries or [],
                 timeout=timeout,
+                clear_plots=True,
             )
 
             if use_artifact_session and hasattr(result, "plots") and result.plots:
-                plot = result.plots[0]
+                plot = result.plots[-1]
                 results.append(
                     ImageContent(
                         data=plot.content_base64,


### PR DESCRIPTION
## Problem

When using the MCP server, the `execute_code` tool always returns the same stale image regardless of what code is executed. This is caused by two bugs:

1. `session.run()` was never called with `clear_plots=True`, so old plots accumulated in `/tmp/sandbox_plots/` across sessions and bled into new executions.
2. The server always returned `plots[0]` (the oldest plot) instead of `plots[-1]` (the most recently generated one).

## Fix

- Pass `clear_plots=True` to `session.run()` to reset the plot directory before each execution.
- Use `plots[-1]` instead of `plots[0]` to return the latest plot.

## Testing

Tested locally and confirmed the fix resolves the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Visualization handling improved to display the most recently generated plot instead of the initial one, providing more relevant visual output
  * Plot management enhanced with automatic clearing after capture to prevent previous visualizations from interfering with subsequent analysis operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->