### PR TITLE
feat: support MCP runtime configs from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,6 +840,41 @@ For Kubernetes, you might need to set the `KUBECONFIG` environment variable to t
 }
 ```
 
+#### Runtime Config Environment Variables
+
+For Docker and Podman backends, the MCP server can translate `SANDBOX_*` environment variables into
+session `runtime_configs`.
+
+```json
+{
+  "mcpServers": {
+    "llm-sandbox": {
+      "command": "python3",
+      "args": ["-m", "llm_sandbox.mcp_server.server"],
+      "env": {
+        "BACKEND": "podman",
+        "DOCKER_HOST": "unix:///run/podman/podman.sock",
+        "SANDBOX_NETWORK_MODE": "none",
+        "SANDBOX_READ_ONLY": "true",
+        "SANDBOX_CAP_DROP": "ALL",
+        "SANDBOX_SECURITY_OPT": "no-new-privileges:true",
+        "SANDBOX_MEMORY": "4g",
+        "SANDBOX_CPU_COUNT": "1"
+      }
+    }
+  }
+}
+```
+
+Supported variables: `SANDBOX_NETWORK_MODE`, `SANDBOX_READ_ONLY`, `SANDBOX_MEMORY`, `SANDBOX_MEM_LIMIT`,
+`SANDBOX_CPUS`, `SANDBOX_CPU_COUNT`, `SANDBOX_CAP_DROP`, `SANDBOX_SECURITY_OPT`, and `SANDBOX_PRIVILEGED`.
+
+`SANDBOX_MEMORY` is normalized to the backend-safe `mem_limit` runtime config. `SANDBOX_CPUS` is normalized
+to backend-safe CPU limits, while `SANDBOX_CPU_COUNT` maps directly to `cpu_count`.
+
+These MCP runtime config variables are not supported for the Kubernetes backend. Use `pod_manifest`
+for Kubernetes resource and security settings instead.
+
 ### Available Tools
 
 The MCP server provides the following tools:

--- a/README.md
+++ b/README.md
@@ -869,9 +869,15 @@ session `runtime_configs`.
 Supported variables: `SANDBOX_NETWORK_MODE`, `SANDBOX_READ_ONLY`, `SANDBOX_MEMORY`, `SANDBOX_MEM_LIMIT`,
 `SANDBOX_CPUS`, `SANDBOX_CPU_COUNT`, `SANDBOX_CAP_DROP`, `SANDBOX_SECURITY_OPT`, and `SANDBOX_PRIVILEGED`.
 
-`SANDBOX_MEMORY` is normalized to the backend-safe `mem_limit` runtime config. `SANDBOX_CPUS` is normalized
-to backend-safe CPU limits, while `SANDBOX_CPU_COUNT` maps directly to `cpu_count`.
+`SANDBOX_MEMORY` is normalized to the backend-safe `mem_limit` runtime config. `SANDBOX_CPUS` and
+`SANDBOX_CPU_COUNT` are normalized to Linux-compatible CPU quota settings.
 
+> Security note: prefer `SANDBOX_NETWORK_MODE=none`, `SANDBOX_READ_ONLY=true`,
+> `SANDBOX_CAP_DROP=ALL`, and restrictive `SANDBOX_SECURITY_OPT` values for hardened
+> sandboxes. Avoid `SANDBOX_PRIVILEGED=true` unless you explicitly need it, keep CPU
+> and memory limits minimal, and audit any combination that re-enables privileges.
+> `SANDBOX_*` settings do not apply to the Kubernetes backend; use `pod_manifest`
+> there instead.
 These MCP runtime config variables are not supported for the Kubernetes backend. Use `pod_manifest`
 for Kubernetes resource and security settings instead.
 

--- a/README.md
+++ b/README.md
@@ -842,8 +842,8 @@ For Kubernetes, you might need to set the `KUBECONFIG` environment variable to t
 
 #### Runtime Config Environment Variables
 
-For Docker and Podman backends, the MCP server can translate `SANDBOX_*` environment variables into
-session `runtime_configs`.
+For Docker, Podman, and Micromamba backends, the MCP server can translate `SANDBOX_*` environment
+variables into session `runtime_configs`.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -876,10 +876,9 @@ Supported variables: `SANDBOX_NETWORK_MODE`, `SANDBOX_READ_ONLY`, `SANDBOX_MEMOR
 > `SANDBOX_CAP_DROP=ALL`, and restrictive `SANDBOX_SECURITY_OPT` values for hardened
 > sandboxes. Avoid `SANDBOX_PRIVILEGED=true` unless you explicitly need it, keep CPU
 > and memory limits minimal, and audit any combination that re-enables privileges.
-> `SANDBOX_*` settings do not apply to the Kubernetes backend; use `pod_manifest`
-> there instead.
-These MCP runtime config variables are not supported for the Kubernetes backend. Use `pod_manifest`
-for Kubernetes resource and security settings instead.
+> `SANDBOX_*` settings do not apply to the Kubernetes backend in this MCP server.
+> If you need Kubernetes-specific resource or security controls, provide a custom
+> `pod_manifest` via a custom MCP wrapper or use the llm-sandbox Python API directly.
 
 ### Available Tools
 

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -219,6 +219,47 @@ The MCP server provides fine-grained control over container behavior through env
 }
 ```
 
+### Runtime Configuration via Environment Variables
+
+For Docker and Podman backends, the MCP server can translate `SANDBOX_*` environment variables into
+`runtime_configs` for every sandbox session it creates.
+
+```json
+{
+  "mcpServers": {
+    "llm-sandbox": {
+      "command": "python3",
+      "args": ["-m", "llm_sandbox.mcp_server.server"],
+      "env": {
+        "BACKEND": "podman",
+        "DOCKER_HOST": "unix:///run/podman/podman.sock",
+        "SANDBOX_NETWORK_MODE": "none",
+        "SANDBOX_READ_ONLY": "true",
+        "SANDBOX_CAP_DROP": "ALL",
+        "SANDBOX_SECURITY_OPT": "no-new-privileges:true",
+        "SANDBOX_MEMORY": "4g",
+        "SANDBOX_CPU_COUNT": "1"
+      }
+    }
+  }
+}
+```
+
+Supported environment variables:
+
+- `SANDBOX_NETWORK_MODE` -> `runtime_configs["network_mode"]`
+- `SANDBOX_READ_ONLY` -> `runtime_configs["read_only"]`
+- `SANDBOX_MEMORY` -> `runtime_configs["mem_limit"]`
+- `SANDBOX_MEM_LIMIT` -> `runtime_configs["mem_limit"]`
+- `SANDBOX_CPUS` -> normalized CPU runtime configs (`cpu_count` for whole numbers, `cpu_period` and `cpu_quota` for fractional values)
+- `SANDBOX_CPU_COUNT` -> `runtime_configs["cpu_count"]`
+- `SANDBOX_CAP_DROP` -> `runtime_configs["cap_drop"]` (comma-separated)
+- `SANDBOX_SECURITY_OPT` -> `runtime_configs["security_opt"]` (comma-separated)
+- `SANDBOX_PRIVILEGED` -> `runtime_configs["privileged"]`
+
+`SANDBOX_*` runtime config variables are not supported for the Kubernetes backend. Use `pod_manifest`
+for Kubernetes-specific resource and security controls.
+
 **Environment Variable Values:**
 Both `COMMIT_CONTAINER` and `KEEP_TEMPLATE` accept:
 - `"true"`, `"1"`, `"yes"`, `"on"` → `True`

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -221,8 +221,8 @@ The MCP server provides fine-grained control over container behavior through env
 
 ### Runtime Configuration via Environment Variables
 
-For Docker and Podman backends, the MCP server can translate `SANDBOX_*` environment variables into
-`runtime_configs` for every sandbox session it creates.
+For Docker, Podman, and Micromamba backends, the MCP server can translate `SANDBOX_*` environment
+variables into `runtime_configs` for every sandbox session it creates.
 
 ```json
 {

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -251,7 +251,7 @@ Supported environment variables:
 - `SANDBOX_READ_ONLY` -> `runtime_configs["read_only"]`
 - `SANDBOX_MEMORY` -> `runtime_configs["mem_limit"]`
 - `SANDBOX_MEM_LIMIT` -> `runtime_configs["mem_limit"]`
-- `SANDBOX_CPUS` -> normalized CPU runtime configs (`cpu_count` for whole numbers, `cpu_period` and `cpu_quota` for fractional values)
+- `SANDBOX_CPUS` -> normalized CPU runtime configs (`cpu_period` and `cpu_quota`)
 - `SANDBOX_CPU_COUNT` -> normalized CPU runtime configs (`cpu_period` and `cpu_quota`)
 - `SANDBOX_CAP_DROP` -> `runtime_configs["cap_drop"]` (comma-separated)
 - `SANDBOX_SECURITY_OPT` -> `runtime_configs["security_opt"]` (comma-separated)
@@ -261,11 +261,9 @@ Supported environment variables:
 > `SANDBOX_CAP_DROP=ALL`, and restrictive `SANDBOX_SECURITY_OPT` values for hardened
 > sandboxes. Avoid `SANDBOX_PRIVILEGED=true` unless you explicitly need it, keep CPU
 > and memory limits minimal, and audit any combination that re-enables privileges.
-> `SANDBOX_*` settings do not apply to the Kubernetes backend; use `pod_manifest`
-> there instead.
-
-`SANDBOX_*` runtime config variables are not supported for the Kubernetes backend. Use `pod_manifest`
-for Kubernetes-specific resource and security controls.
+> `SANDBOX_*` settings do not apply to the Kubernetes backend in this MCP server.
+> If you need Kubernetes-specific resource or security controls, provide a custom
+> `pod_manifest` via a custom MCP wrapper or use the llm-sandbox Python API directly.
 
 **Environment Variable Values:**
 Both `COMMIT_CONTAINER` and `KEEP_TEMPLATE` accept:

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -252,10 +252,17 @@ Supported environment variables:
 - `SANDBOX_MEMORY` -> `runtime_configs["mem_limit"]`
 - `SANDBOX_MEM_LIMIT` -> `runtime_configs["mem_limit"]`
 - `SANDBOX_CPUS` -> normalized CPU runtime configs (`cpu_count` for whole numbers, `cpu_period` and `cpu_quota` for fractional values)
-- `SANDBOX_CPU_COUNT` -> `runtime_configs["cpu_count"]`
+- `SANDBOX_CPU_COUNT` -> normalized CPU runtime configs (`cpu_period` and `cpu_quota`)
 - `SANDBOX_CAP_DROP` -> `runtime_configs["cap_drop"]` (comma-separated)
 - `SANDBOX_SECURITY_OPT` -> `runtime_configs["security_opt"]` (comma-separated)
 - `SANDBOX_PRIVILEGED` -> `runtime_configs["privileged"]`
+
+> Security note: prefer `SANDBOX_NETWORK_MODE=none`, `SANDBOX_READ_ONLY=true`,
+> `SANDBOX_CAP_DROP=ALL`, and restrictive `SANDBOX_SECURITY_OPT` values for hardened
+> sandboxes. Avoid `SANDBOX_PRIVILEGED=true` unless you explicitly need it, keep CPU
+> and memory limits minimal, and audit any combination that re-enables privileges.
+> `SANDBOX_*` settings do not apply to the Kubernetes backend; use `pod_manifest`
+> there instead.
 
 `SANDBOX_*` runtime config variables are not supported for the Kubernetes backend. Use `pod_manifest`
 for Kubernetes-specific resource and security controls.

--- a/llm_sandbox/core/mixins.py
+++ b/llm_sandbox/core/mixins.py
@@ -6,7 +6,7 @@ import threading
 from abc import abstractmethod
 from contextlib import suppress
 from pathlib import Path, PurePosixPath
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -17,6 +17,7 @@ from llm_sandbox.exceptions import CommandEmptyError, NotOpenSessionError, Sandb
 CLEANUP_THREAD_TIMEOUT = 0.1
 
 
+@runtime_checkable
 class ContainerAPI(Protocol):
     """Protocol for container operations."""
 

--- a/llm_sandbox/mcp_server/server.py
+++ b/llm_sandbox/mcp_server/server.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 from decimal import Decimal, InvalidOperation
+from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ImageContent, TextContent
@@ -78,8 +79,19 @@ def _get_optional_list_env(var_name: str) -> list[str] | None:
     return items or None
 
 
-def _parse_cpu_count_env(value: str, var_name: str) -> int:
-    """Parse a CPU count environment variable into an integer CPU count."""
+def _build_cpu_runtime_configs(cpu_units: Decimal, var_name: str) -> dict[str, int]:
+    """Translate CPU units into Linux-compatible runtime config keys."""
+    cpu_period = 100_000
+    cpu_quota = int(cpu_units * cpu_period)
+    if cpu_quota <= 0:
+        msg = f"{var_name} is too small to translate into cpu_quota"
+        raise ValueError(msg)
+
+    return {"cpu_period": cpu_period, "cpu_quota": cpu_quota}
+
+
+def _parse_cpu_count_env(value: str, var_name: str) -> dict[str, int]:
+    """Parse SANDBOX_CPU_COUNT into Linux-compatible CPU runtime configs."""
     try:
         parsed = Decimal(value.strip())
     except InvalidOperation as exc:
@@ -93,11 +105,11 @@ def _parse_cpu_count_env(value: str, var_name: str) -> int:
         msg = f"{var_name} must be a whole number when mapped to cpu_count"
         raise ValueError(msg)
 
-    return int(parsed)
+    return _build_cpu_runtime_configs(parsed, var_name)
 
 
 def _parse_cpus_env(value: str) -> dict[str, int]:
-    """Parse SANDBOX_CPUS into backend-safe runtime configs."""
+    """Parse SANDBOX_CPUS into Linux-compatible CPU runtime configs."""
     try:
         parsed = Decimal(value.strip())
     except InvalidOperation as exc:
@@ -108,16 +120,7 @@ def _parse_cpus_env(value: str) -> dict[str, int]:
         msg = "SANDBOX_CPUS must be greater than 0"
         raise ValueError(msg)
 
-    if parsed == parsed.to_integral_value():
-        return {"cpu_count": int(parsed)}
-
-    cpu_period = 100_000
-    cpu_quota = int(parsed * cpu_period)
-    if cpu_quota <= 0:
-        msg = "SANDBOX_CPUS is too small to translate into cpu_quota"
-        raise ValueError(msg)
-
-    return {"cpu_period": cpu_period, "cpu_quota": cpu_quota}
+    return _build_cpu_runtime_configs(parsed, "SANDBOX_CPUS")
 
 
 def _get_runtime_configs() -> dict[str, bool | str | int | list[str]]:
@@ -139,7 +142,7 @@ def _get_runtime_configs() -> dict[str, bool | str | int | list[str]]:
     cpu_count = os.environ.get("SANDBOX_CPU_COUNT")
     cpus = os.environ.get("SANDBOX_CPUS")
     if cpu_count is not None:
-        runtime_configs["cpu_count"] = _parse_cpu_count_env(cpu_count, "SANDBOX_CPU_COUNT")
+        runtime_configs.update(_parse_cpu_count_env(cpu_count, "SANDBOX_CPU_COUNT"))
     elif cpus is not None:
         runtime_configs.update(_parse_cpus_env(cpus))
 
@@ -164,13 +167,22 @@ def _get_runtime_configs() -> dict[str, bool | str | int | list[str]]:
     return runtime_configs
 
 
-def _validate_backend_runtime_configs(backend: SandboxBackend, runtime_configs: dict) -> None:
+def _validate_backend_runtime_configs(
+    backend: SandboxBackend,
+    runtime_configs: dict[str, bool | str | int | list[str]] | None = None,
+) -> None:
     """Raise ValueError if runtime configs are used with an unsupported backend."""
-    if backend == SandboxBackend.KUBERNETES and runtime_configs:
-        msg = (
-            "SANDBOX_* runtime config environment variables are not supported for the Kubernetes backend. "
-            "Use a custom pod_manifest instead."
-        )
+    if backend != SandboxBackend.KUBERNETES:
+        return
+
+    msg = (
+        "SANDBOX_* runtime config environment variables are not supported for the Kubernetes backend. "
+        "Use a custom pod_manifest instead."
+    )
+
+    if any(env_name.startswith("SANDBOX_") for env_name in os.environ):
+        raise ValueError(msg)
+    if runtime_configs:
         raise ValueError(msg)
 
 
@@ -203,13 +215,14 @@ def execute_code(
 
     try:
         backend = _get_backend()
+        _validate_backend_runtime_configs(backend)
         runtime_configs = _get_runtime_configs()
         _validate_backend_runtime_configs(backend, runtime_configs)
 
         use_artifact_session = _supports_visualization(language)
         session_cls = ArtifactSandboxSession if use_artifact_session else SandboxSession
 
-        session_kwargs = {
+        session_kwargs: dict[str, Any] = {
             "lang": language,
             "keep_template": _get_keep_template(),
             "commit_container": _get_commit_container(),
@@ -221,9 +234,7 @@ def execute_code(
         if runtime_configs:
             session_kwargs["runtime_configs"] = runtime_configs
 
-        with session_cls(
-            **session_kwargs,  # type: ignore[arg-type]
-        ) as session:
+        with session_cls(**session_kwargs) as session:
             if use_artifact_session:
                 result = session.run(  # type: ignore[call-arg]
                     code=code, libraries=libraries or [], timeout=timeout, clear_plots=True

--- a/llm_sandbox/mcp_server/server.py
+++ b/llm_sandbox/mcp_server/server.py
@@ -6,6 +6,7 @@ A Model Context Protocol server that provides secure code execution capabilities
 import json
 import logging
 import os
+from decimal import Decimal, InvalidOperation
 
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ImageContent, TextContent
@@ -22,6 +23,9 @@ logging.basicConfig(
 logger = logging.getLogger("llm-sandbox-mcp")
 
 mcp = FastMCP("llm-sandbox")
+
+_TRUE_ENV_VALUES = {"true", "1", "yes", "on"}
+_FALSE_ENV_VALUES = {"false", "0", "no", "off"}
 
 
 def _get_backend() -> SandboxBackend:
@@ -46,6 +50,118 @@ def _get_keep_template() -> bool:
 def _get_kube_namespace() -> str:
     """Get the Kubernetes namespace from environment variable."""
     return os.environ.get("NAMESPACE", "default")
+
+
+def _get_optional_bool_env(var_name: str) -> bool | None:
+    """Parse an optional boolean environment variable."""
+    value = os.environ.get(var_name)
+    if value is None:
+        return None
+
+    normalized = value.strip().lower()
+    if normalized in _TRUE_ENV_VALUES:
+        return True
+    if normalized in _FALSE_ENV_VALUES:
+        return False
+
+    msg = f"{var_name} must be one of: true, false, 1, 0, yes, no, on, off"
+    raise ValueError(msg)
+
+
+def _get_optional_list_env(var_name: str) -> list[str] | None:
+    """Parse an optional comma-separated list environment variable."""
+    value = os.environ.get(var_name)
+    if value is None:
+        return None
+
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    return items or None
+
+
+def _parse_cpu_count_env(value: str, var_name: str) -> int:
+    """Parse a CPU count environment variable into an integer CPU count."""
+    try:
+        parsed = Decimal(value.strip())
+    except InvalidOperation as exc:
+        msg = f"{var_name} must be a positive number"
+        raise ValueError(msg) from exc
+
+    if parsed <= 0:
+        msg = f"{var_name} must be greater than 0"
+        raise ValueError(msg)
+    if parsed != parsed.to_integral_value():
+        msg = f"{var_name} must be a whole number when mapped to cpu_count"
+        raise ValueError(msg)
+
+    return int(parsed)
+
+
+def _parse_cpus_env(value: str) -> dict[str, int]:
+    """Parse SANDBOX_CPUS into backend-safe runtime configs."""
+    try:
+        parsed = Decimal(value.strip())
+    except InvalidOperation as exc:
+        msg = "SANDBOX_CPUS must be a positive number"
+        raise ValueError(msg) from exc
+
+    if parsed <= 0:
+        msg = "SANDBOX_CPUS must be greater than 0"
+        raise ValueError(msg)
+
+    if parsed == parsed.to_integral_value():
+        return {"cpu_count": int(parsed)}
+
+    cpu_period = 100_000
+    cpu_quota = int(parsed * cpu_period)
+    if cpu_quota <= 0:
+        msg = "SANDBOX_CPUS is too small to translate into cpu_quota"
+        raise ValueError(msg)
+
+    return {"cpu_period": cpu_period, "cpu_quota": cpu_quota}
+
+
+def _get_runtime_configs() -> dict[str, bool | str | int | list[str]]:
+    """Build runtime_configs from MCP server environment variables."""
+    runtime_configs: dict[str, bool | str | int | list[str]] = {}
+
+    passthrough_env_to_config: dict[str, str] = {
+        "SANDBOX_NETWORK_MODE": "network_mode",
+    }
+    for env_name, config_key in passthrough_env_to_config.items():
+        value = os.environ.get(env_name)
+        if value is not None:
+            runtime_configs[config_key] = value
+
+    mem_limit = os.environ.get("SANDBOX_MEM_LIMIT") or os.environ.get("SANDBOX_MEMORY")
+    if mem_limit is not None:
+        runtime_configs["mem_limit"] = mem_limit
+
+    cpu_count = os.environ.get("SANDBOX_CPU_COUNT")
+    cpus = os.environ.get("SANDBOX_CPUS")
+    if cpu_count is not None:
+        runtime_configs["cpu_count"] = _parse_cpu_count_env(cpu_count, "SANDBOX_CPU_COUNT")
+    elif cpus is not None:
+        runtime_configs.update(_parse_cpus_env(cpus))
+
+    bool_env_to_config: dict[str, str] = {
+        "SANDBOX_READ_ONLY": "read_only",
+        "SANDBOX_PRIVILEGED": "privileged",
+    }
+    for env_name, config_key in bool_env_to_config.items():
+        value = _get_optional_bool_env(env_name)
+        if value is not None:
+            runtime_configs[config_key] = value
+
+    list_env_to_config: dict[str, str] = {
+        "SANDBOX_CAP_DROP": "cap_drop",
+        "SANDBOX_SECURITY_OPT": "security_opt",
+    }
+    for env_name, config_key in list_env_to_config.items():
+        value = _get_optional_list_env(env_name)
+        if value is not None:
+            runtime_configs[config_key] = value
+
+    return runtime_configs
 
 
 def _supports_visualization(language: str) -> bool:
@@ -76,17 +192,32 @@ def execute_code(
     results: list[ImageContent | TextContent] = []
 
     try:
+        backend = _get_backend()
+        runtime_configs = _get_runtime_configs()
+        if backend == SandboxBackend.KUBERNETES and runtime_configs:
+            msg = (
+                "SANDBOX_* runtime config environment variables are not supported for the Kubernetes backend. "
+                "Use a custom pod_manifest instead."
+            )
+            raise ValueError(msg)
+
         use_artifact_session = _supports_visualization(language)
         session_cls = ArtifactSandboxSession if use_artifact_session else SandboxSession
 
+        session_kwargs = {
+            "lang": language,
+            "keep_template": _get_keep_template(),
+            "commit_container": _get_commit_container(),
+            "verbose": False,
+            "backend": backend,
+            "session_timeout": timeout,
+            "kube_namespace": _get_kube_namespace(),
+        }
+        if runtime_configs:
+            session_kwargs["runtime_configs"] = runtime_configs
+
         with session_cls(
-            lang=language,
-            keep_template=_get_keep_template(),
-            commit_container=_get_commit_container(),
-            verbose=False,
-            backend=_get_backend(),
-            session_timeout=timeout,
-            kube_namespace=_get_kube_namespace(),
+            **session_kwargs,
         ) as session:
             if use_artifact_session:
                 result = session.run(  # type: ignore[call-arg]

--- a/llm_sandbox/mcp_server/server.py
+++ b/llm_sandbox/mcp_server/server.py
@@ -12,7 +12,7 @@ from typing import Any
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ImageContent, TextContent
 
-from llm_sandbox import ArtifactSandboxSession, SandboxBackend, SandboxSession, SupportedLanguage
+from llm_sandbox import ArtifactSandboxSession, SandboxBackend, SandboxSession, SupportedLanguage, ValidationError
 from llm_sandbox.data import ExecutionResult
 from llm_sandbox.mcp_server.const import LANGUAGE_RESOURCES
 from llm_sandbox.session import _check_dependency
@@ -37,6 +37,11 @@ _RUNTIME_CONFIG_ENV_VARS = {
     "SANDBOX_CAP_DROP",
     "SANDBOX_SECURITY_OPT",
     "SANDBOX_PRIVILEGED",
+}
+_RUNTIME_CONFIG_SUPPORTED_BACKENDS = {
+    SandboxBackend.DOCKER,
+    SandboxBackend.PODMAN,
+    SandboxBackend.MICROMAMBA,
 }
 
 
@@ -77,7 +82,7 @@ def _get_optional_bool_env(var_name: str) -> bool | None:
         return False
 
     msg = f"{var_name} must be one of: true, false, 1, 0, yes, no, on, off"
-    raise ValueError(msg)
+    raise ValidationError(msg)
 
 
 def _get_optional_list_env(var_name: str) -> list[str] | None:
@@ -106,7 +111,7 @@ def _build_cpu_runtime_configs(cpu_units: Decimal, var_name: str) -> dict[str, i
     cpu_quota = int(cpu_units * cpu_period)
     if cpu_quota <= 0:
         msg = f"{var_name} is too small to translate into cpu_quota"
-        raise ValueError(msg)
+        raise ValidationError(msg)
 
     return {"cpu_period": cpu_period, "cpu_quota": cpu_quota}
 
@@ -117,14 +122,14 @@ def _parse_cpu_count_env(value: str, var_name: str) -> dict[str, int]:
         parsed = Decimal(value.strip())
     except InvalidOperation as exc:
         msg = f"{var_name} must be a positive number"
-        raise ValueError(msg) from exc
+        raise ValidationError(msg) from exc
 
     if parsed <= 0:
         msg = f"{var_name} must be greater than 0"
-        raise ValueError(msg)
+        raise ValidationError(msg)
     if parsed != parsed.to_integral_value():
         msg = f"{var_name} must be a whole number when mapped to cpu_period/cpu_quota"
-        raise ValueError(msg)
+        raise ValidationError(msg)
 
     return _build_cpu_runtime_configs(parsed, var_name)
 
@@ -135,11 +140,11 @@ def _parse_cpus_env(value: str) -> dict[str, int]:
         parsed = Decimal(value.strip())
     except InvalidOperation as exc:
         msg = "SANDBOX_CPUS must be a positive number"
-        raise ValueError(msg) from exc
+        raise ValidationError(msg) from exc
 
     if parsed <= 0:
         msg = "SANDBOX_CPUS must be greater than 0"
-        raise ValueError(msg)
+        raise ValidationError(msg)
 
     return _build_cpu_runtime_configs(parsed, "SANDBOX_CPUS")
 
@@ -192,20 +197,20 @@ def _validate_backend_runtime_configs(
     backend: SandboxBackend,
     runtime_configs: dict[str, bool | str | int | list[str]] | None = None,
 ) -> None:
-    """Raise ValueError if runtime configs are used with an unsupported backend."""
-    if backend != SandboxBackend.KUBERNETES:
+    """Raise ValidationError if runtime configs are used with an unsupported backend."""
+    if backend in _RUNTIME_CONFIG_SUPPORTED_BACKENDS:
         return
 
     msg = (
-        "SANDBOX_* runtime config environment variables are not supported for the Kubernetes backend "
+        f"SANDBOX_* runtime config environment variables are not supported for backend '{backend.value}' "
         "in this MCP server. Kubernetes resource and security controls require a custom pod_manifest "
         "via a custom MCP wrapper or direct llm-sandbox usage."
     )
 
     if any(env_name in os.environ for env_name in _RUNTIME_CONFIG_ENV_VARS):
-        raise ValueError(msg)
+        raise ValidationError(msg)
     if runtime_configs:
-        raise ValueError(msg)
+        raise ValidationError(msg)
 
 
 def _supports_visualization(language: str) -> bool:

--- a/llm_sandbox/mcp_server/server.py
+++ b/llm_sandbox/mcp_server/server.py
@@ -148,20 +148,30 @@ def _get_runtime_configs() -> dict[str, bool | str | int | list[str]]:
         "SANDBOX_PRIVILEGED": "privileged",
     }
     for env_name, config_key in bool_env_to_config.items():
-        value = _get_optional_bool_env(env_name)
-        if value is not None:
-            runtime_configs[config_key] = value
+        bool_value = _get_optional_bool_env(env_name)
+        if bool_value is not None:
+            runtime_configs[config_key] = bool_value
 
     list_env_to_config: dict[str, str] = {
         "SANDBOX_CAP_DROP": "cap_drop",
         "SANDBOX_SECURITY_OPT": "security_opt",
     }
     for env_name, config_key in list_env_to_config.items():
-        value = _get_optional_list_env(env_name)
-        if value is not None:
-            runtime_configs[config_key] = value
+        list_value = _get_optional_list_env(env_name)
+        if list_value is not None:
+            runtime_configs[config_key] = list_value
 
     return runtime_configs
+
+
+def _validate_backend_runtime_configs(backend: SandboxBackend, runtime_configs: dict) -> None:
+    """Raise ValueError if runtime configs are used with an unsupported backend."""
+    if backend == SandboxBackend.KUBERNETES and runtime_configs:
+        msg = (
+            "SANDBOX_* runtime config environment variables are not supported for the Kubernetes backend. "
+            "Use a custom pod_manifest instead."
+        )
+        raise ValueError(msg)
 
 
 def _supports_visualization(language: str) -> bool:
@@ -194,12 +204,7 @@ def execute_code(
     try:
         backend = _get_backend()
         runtime_configs = _get_runtime_configs()
-        if backend == SandboxBackend.KUBERNETES and runtime_configs:
-            msg = (
-                "SANDBOX_* runtime config environment variables are not supported for the Kubernetes backend. "
-                "Use a custom pod_manifest instead."
-            )
-            raise ValueError(msg)
+        _validate_backend_runtime_configs(backend, runtime_configs)
 
         use_artifact_session = _supports_visualization(language)
         session_cls = ArtifactSandboxSession if use_artifact_session else SandboxSession
@@ -217,7 +222,7 @@ def execute_code(
             session_kwargs["runtime_configs"] = runtime_configs
 
         with session_cls(
-            **session_kwargs,
+            **session_kwargs,  # type: ignore[arg-type]
         ) as session:
             if use_artifact_session:
                 result = session.run(  # type: ignore[call-arg]

--- a/llm_sandbox/mcp_server/server.py
+++ b/llm_sandbox/mcp_server/server.py
@@ -27,6 +27,17 @@ mcp = FastMCP("llm-sandbox")
 
 _TRUE_ENV_VALUES = {"true", "1", "yes", "on"}
 _FALSE_ENV_VALUES = {"false", "0", "no", "off"}
+_RUNTIME_CONFIG_ENV_VARS = {
+    "SANDBOX_NETWORK_MODE",
+    "SANDBOX_READ_ONLY",
+    "SANDBOX_MEMORY",
+    "SANDBOX_MEM_LIMIT",
+    "SANDBOX_CPUS",
+    "SANDBOX_CPU_COUNT",
+    "SANDBOX_CAP_DROP",
+    "SANDBOX_SECURITY_OPT",
+    "SANDBOX_PRIVILEGED",
+}
 
 
 def _get_backend() -> SandboxBackend:
@@ -39,13 +50,13 @@ def _get_backend() -> SandboxBackend:
 def _get_commit_container() -> bool:
     """Get the commit_container setting from environment variable."""
     commit_container_env = os.environ.get("COMMIT_CONTAINER", "true").lower()
-    return commit_container_env in ("true", "1", "yes", "on")
+    return commit_container_env in _TRUE_ENV_VALUES
 
 
 def _get_keep_template() -> bool:
     """Get the keep_template setting from environment variable."""
     keep_template_env = os.environ.get("KEEP_TEMPLATE", "true").lower()
-    return keep_template_env in ("true", "1", "yes", "on")
+    return keep_template_env in _TRUE_ENV_VALUES
 
 
 def _get_kube_namespace() -> str:
@@ -79,6 +90,16 @@ def _get_optional_list_env(var_name: str) -> list[str] | None:
     return items or None
 
 
+def _get_optional_str_env(var_name: str) -> str | None:
+    """Parse an optional string environment variable."""
+    value = os.environ.get(var_name)
+    if value is None:
+        return None
+
+    normalized = value.strip()
+    return normalized or None
+
+
 def _build_cpu_runtime_configs(cpu_units: Decimal, var_name: str) -> dict[str, int]:
     """Translate CPU units into Linux-compatible runtime config keys."""
     cpu_period = 100_000
@@ -102,7 +123,7 @@ def _parse_cpu_count_env(value: str, var_name: str) -> dict[str, int]:
         msg = f"{var_name} must be greater than 0"
         raise ValueError(msg)
     if parsed != parsed.to_integral_value():
-        msg = f"{var_name} must be a whole number when mapped to cpu_count"
+        msg = f"{var_name} must be a whole number when mapped to cpu_period/cpu_quota"
         raise ValueError(msg)
 
     return _build_cpu_runtime_configs(parsed, var_name)
@@ -131,11 +152,11 @@ def _get_runtime_configs() -> dict[str, bool | str | int | list[str]]:
         "SANDBOX_NETWORK_MODE": "network_mode",
     }
     for env_name, config_key in passthrough_env_to_config.items():
-        value = os.environ.get(env_name)
+        value = _get_optional_str_env(env_name)
         if value is not None:
             runtime_configs[config_key] = value
 
-    mem_limit = os.environ.get("SANDBOX_MEM_LIMIT") or os.environ.get("SANDBOX_MEMORY")
+    mem_limit = _get_optional_str_env("SANDBOX_MEM_LIMIT") or _get_optional_str_env("SANDBOX_MEMORY")
     if mem_limit is not None:
         runtime_configs["mem_limit"] = mem_limit
 
@@ -176,11 +197,12 @@ def _validate_backend_runtime_configs(
         return
 
     msg = (
-        "SANDBOX_* runtime config environment variables are not supported for the Kubernetes backend. "
-        "Use a custom pod_manifest instead."
+        "SANDBOX_* runtime config environment variables are not supported for the Kubernetes backend "
+        "in this MCP server. Kubernetes resource and security controls require a custom pod_manifest "
+        "via a custom MCP wrapper or direct llm-sandbox usage."
     )
 
-    if any(env_name.startswith("SANDBOX_") for env_name in os.environ):
+    if any(env_name in os.environ for env_name in _RUNTIME_CONFIG_ENV_VARS):
         raise ValueError(msg)
     if runtime_configs:
         raise ValueError(msg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,3 +133,4 @@ source = ["llm_sandbox"]
 
 [tool.deptry]
 ignore = ["DEP004"]
+extend_exclude = [".worktrees"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,4 +133,3 @@ source = ["llm_sandbox"]
 
 [tool.deptry]
 ignore = ["DEP004"]
-extend_exclude = [".worktrees"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -17,7 +17,10 @@ from llm_sandbox.mcp_server.server import (
     _get_commit_container,
     _get_keep_template,
     _get_kube_namespace,
+    _get_optional_list_env,
     _get_runtime_configs,
+    _parse_cpu_count_env,
+    _parse_cpus_env,
     _supports_visualization,
     execute_code,
     get_language_details,
@@ -251,6 +254,11 @@ class TestGetRuntimeConfigs:
             "cpu_quota": 50000,
         }
 
+    @patch.dict(os.environ, {"SANDBOX_MEM_LIMIT": "512m", "SANDBOX_MEMORY": "4g"}, clear=True)
+    def test_get_runtime_configs_prefers_mem_limit(self) -> None:
+        """Test SANDBOX_MEM_LIMIT takes precedence over SANDBOX_MEMORY."""
+        assert _get_runtime_configs() == {"mem_limit": "512m"}
+
     @patch.dict(os.environ, {"SANDBOX_CPU_COUNT": "2.5"}, clear=True)
     def test_get_runtime_configs_invalid_cpu_count(self) -> None:
         """Test invalid cpu_count values raise a clear error."""
@@ -262,6 +270,45 @@ class TestGetRuntimeConfigs:
         """Test invalid boolean environment values raise a clear error."""
         with pytest.raises(ValueError, match="SANDBOX_READ_ONLY must be one of"):
             _get_runtime_configs()
+
+
+class TestRuntimeConfigHelpers:
+    """Test helper functions used by runtime config env parsing."""
+
+    def test_parse_cpu_count_env_invalid_number(self) -> None:
+        """Test cpu_count parser rejects non-numeric values."""
+        with pytest.raises(ValueError, match="SANDBOX_CPU_COUNT must be a positive number"):
+            _parse_cpu_count_env("abc", "SANDBOX_CPU_COUNT")
+
+    def test_parse_cpu_count_env_must_be_positive(self) -> None:
+        """Test cpu_count parser rejects zero and negative values."""
+        with pytest.raises(ValueError, match="SANDBOX_CPU_COUNT must be greater than 0"):
+            _parse_cpu_count_env("0", "SANDBOX_CPU_COUNT")
+
+    def test_parse_cpu_count_env_requires_whole_number(self) -> None:
+        """Test cpu_count parser rejects fractional values."""
+        with pytest.raises(ValueError, match="SANDBOX_CPU_COUNT must be a whole number"):
+            _parse_cpu_count_env("1.5", "SANDBOX_CPU_COUNT")
+
+    def test_parse_cpus_env_invalid_number(self) -> None:
+        """Test CPU parser rejects non-numeric values."""
+        with pytest.raises(ValueError, match="SANDBOX_CPUS must be a positive number"):
+            _parse_cpus_env("abc")
+
+    def test_parse_cpus_env_must_be_positive(self) -> None:
+        """Test CPU parser rejects zero and negative values."""
+        with pytest.raises(ValueError, match="SANDBOX_CPUS must be greater than 0"):
+            _parse_cpus_env("0")
+
+    def test_parse_cpus_env_rejects_too_small_fraction(self) -> None:
+        """Test CPU parser rejects values that round down to zero quota."""
+        with pytest.raises(ValueError, match="SANDBOX_CPUS is too small to translate into cpu_quota"):
+            _parse_cpus_env("0.000001")
+
+    @patch.dict(os.environ, {"SANDBOX_CAP_DROP": " , "}, clear=True)
+    def test_get_optional_list_env_empty_value_returns_none(self) -> None:
+        """Test list parser ignores empty comma-separated values."""
+        assert _get_optional_list_env("SANDBOX_CAP_DROP") is None
 
 
 class TestSupportsVisualization:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -22,6 +22,7 @@ from llm_sandbox.mcp_server.server import (
     _parse_cpu_count_env,
     _parse_cpus_env,
     _supports_visualization,
+    _validate_backend_runtime_configs,
     execute_code,
     get_language_details,
     get_supported_languages,
@@ -317,6 +318,12 @@ class TestRuntimeConfigHelpers:
     def test_get_optional_list_env_empty_value_returns_none(self) -> None:
         """Test list parser ignores empty comma-separated values."""
         assert _get_optional_list_env("SANDBOX_CAP_DROP") is None
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_validate_backend_runtime_configs_rejects_kubernetes_runtime_configs(self) -> None:
+        """Test Kubernetes backend rejects parsed runtime configs even without raw env vars present."""
+        with pytest.raises(ValueError, match="not supported for the Kubernetes backend"):
+            _validate_backend_runtime_configs(SandboxBackend.KUBERNETES, {"mem_limit": "512m"})
 
 
 class TestSupportsVisualization:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -256,10 +256,20 @@ class TestGetRuntimeConfigs:
             "cpu_quota": 50000,
         }
 
+    @patch.dict(os.environ, {"SANDBOX_NETWORK_MODE": "  ", "SANDBOX_MEMORY": "   "}, clear=True)
+    def test_get_runtime_configs_ignores_empty_string_values(self) -> None:
+        """Test empty string runtime config values are treated as unset."""
+        assert _get_runtime_configs() == {}
+
     @patch.dict(os.environ, {"SANDBOX_MEM_LIMIT": "512m", "SANDBOX_MEMORY": "4g"}, clear=True)
     def test_get_runtime_configs_prefers_mem_limit(self) -> None:
         """Test SANDBOX_MEM_LIMIT takes precedence over SANDBOX_MEMORY."""
         assert _get_runtime_configs() == {"mem_limit": "512m"}
+
+    @patch.dict(os.environ, {"SANDBOX_MEM_LIMIT": "  ", "SANDBOX_MEMORY": "4g"}, clear=True)
+    def test_get_runtime_configs_falls_back_to_memory_when_mem_limit_is_blank(self) -> None:
+        """Test blank SANDBOX_MEM_LIMIT falls back to SANDBOX_MEMORY."""
+        assert _get_runtime_configs() == {"mem_limit": "4g"}
 
     @patch.dict(os.environ, {"SANDBOX_CPU_COUNT": "2.5"}, clear=True)
     def test_get_runtime_configs_invalid_cpu_count(self) -> None:
@@ -296,7 +306,10 @@ class TestRuntimeConfigHelpers:
 
     def test_parse_cpu_count_env_requires_whole_number(self) -> None:
         """Test cpu_count parser rejects fractional values."""
-        with pytest.raises(ValueError, match="SANDBOX_CPU_COUNT must be a whole number"):
+        with pytest.raises(
+            ValueError,
+            match="SANDBOX_CPU_COUNT must be a whole number when mapped to cpu_period/cpu_quota",
+        ):
             _parse_cpu_count_env("1.5", "SANDBOX_CPU_COUNT")
 
     def test_parse_cpus_env_invalid_number(self) -> None:
@@ -324,6 +337,11 @@ class TestRuntimeConfigHelpers:
         """Test Kubernetes backend rejects parsed runtime configs even without raw env vars present."""
         with pytest.raises(ValueError, match="not supported for the Kubernetes backend"):
             _validate_backend_runtime_configs(SandboxBackend.KUBERNETES, {"mem_limit": "512m"})
+
+    @patch.dict(os.environ, {"SANDBOX_FOO": "bar"}, clear=True)
+    def test_validate_backend_runtime_configs_ignores_unrelated_sandbox_envs(self) -> None:
+        """Test Kubernetes backend ignores SANDBOX_* env vars unrelated to runtime_configs."""
+        _validate_backend_runtime_configs(SandboxBackend.KUBERNETES)
 
 
 class TestSupportsVisualization:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -240,7 +240,8 @@ class TestGetRuntimeConfigs:
             "network_mode": "none",
             "read_only": True,
             "mem_limit": "4g",
-            "cpu_count": 1,
+            "cpu_period": 100000,
+            "cpu_quota": 100000,
             "cap_drop": ["ALL", "SYS_ADMIN"],
             "security_opt": ["no-new-privileges:true", "label=disable"],
             "privileged": False,
@@ -279,6 +280,13 @@ class TestRuntimeConfigHelpers:
         """Test cpu_count parser rejects non-numeric values."""
         with pytest.raises(ValueError, match="SANDBOX_CPU_COUNT must be a positive number"):
             _parse_cpu_count_env("abc", "SANDBOX_CPU_COUNT")
+
+    def test_parse_cpu_count_env_valid_value(self) -> None:
+        """Test cpu_count parser returns Linux-compatible CPU quota settings."""
+        assert _parse_cpu_count_env("2", "SANDBOX_CPU_COUNT") == {
+            "cpu_period": 100000,
+            "cpu_quota": 200000,
+        }
 
     def test_parse_cpu_count_env_must_be_positive(self) -> None:
         """Test cpu_count parser rejects zero and negative values."""
@@ -448,7 +456,8 @@ class TestExecuteCode:
                 "network_mode": "none",
                 "read_only": True,
                 "mem_limit": "4g",
-                "cpu_count": 1,
+                "cpu_period": 100000,
+                "cpu_quota": 100000,
                 "cap_drop": ["ALL"],
             },
         )
@@ -685,6 +694,34 @@ class TestExecuteCode:
     @patch("llm_sandbox.mcp_server.server._get_backend")
     def test_execute_code_rejects_runtime_configs_for_kubernetes(self, mock_get_backend: MagicMock) -> None:
         """Test runtime config env vars are rejected for Kubernetes backend."""
+        mock_get_backend.return_value = SandboxBackend.KUBERNETES
+
+        result = execute_code("print('Hello')", "python")
+
+        assert len(result) == 1
+        assert isinstance(result[0], TextContent)
+        result_data = json.loads(result[0].text)
+        assert result_data["exit_code"] == 1
+        assert "not supported for the Kubernetes backend" in result_data["stderr"]
+
+    @patch.dict(os.environ, {"SANDBOX_CAP_DROP": " , "}, clear=True)
+    @patch("llm_sandbox.mcp_server.server._get_backend")
+    def test_execute_code_rejects_empty_sandbox_env_for_kubernetes(self, mock_get_backend: MagicMock) -> None:
+        """Test Kubernetes rejects SANDBOX_* envs even when parsing yields no runtime config values."""
+        mock_get_backend.return_value = SandboxBackend.KUBERNETES
+
+        result = execute_code("print('Hello')", "python")
+
+        assert len(result) == 1
+        assert isinstance(result[0], TextContent)
+        result_data = json.loads(result[0].text)
+        assert result_data["exit_code"] == 1
+        assert "not supported for the Kubernetes backend" in result_data["stderr"]
+
+    @patch.dict(os.environ, {"SANDBOX_READ_ONLY": "maybe"}, clear=True)
+    @patch("llm_sandbox.mcp_server.server._get_backend")
+    def test_execute_code_rejects_invalid_sandbox_env_for_kubernetes(self, mock_get_backend: MagicMock) -> None:
+        """Test Kubernetes rejects SANDBOX_* envs before boolean parsing."""
         mock_get_backend.return_value = SandboxBackend.KUBERNETES
 
         result = execute_code("print('Hello')", "python")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from mcp.types import ImageContent, TextContent
 
-from llm_sandbox import SupportedLanguage
+from llm_sandbox import SupportedLanguage, ValidationError
 from llm_sandbox.const import SandboxBackend
 from llm_sandbox.data import ExecutionResult, FileType, PlotOutput
 from llm_sandbox.exceptions import MissingDependencyError
@@ -274,13 +274,13 @@ class TestGetRuntimeConfigs:
     @patch.dict(os.environ, {"SANDBOX_CPU_COUNT": "2.5"}, clear=True)
     def test_get_runtime_configs_invalid_cpu_count(self) -> None:
         """Test invalid cpu_count values raise a clear error."""
-        with pytest.raises(ValueError, match="SANDBOX_CPU_COUNT must be a whole number"):
+        with pytest.raises(ValidationError, match="SANDBOX_CPU_COUNT must be a whole number"):
             _get_runtime_configs()
 
     @patch.dict(os.environ, {"SANDBOX_READ_ONLY": "maybe"}, clear=True)
     def test_get_runtime_configs_invalid_boolean(self) -> None:
         """Test invalid boolean environment values raise a clear error."""
-        with pytest.raises(ValueError, match="SANDBOX_READ_ONLY must be one of"):
+        with pytest.raises(ValidationError, match="SANDBOX_READ_ONLY must be one of"):
             _get_runtime_configs()
 
 
@@ -289,7 +289,7 @@ class TestRuntimeConfigHelpers:
 
     def test_parse_cpu_count_env_invalid_number(self) -> None:
         """Test cpu_count parser rejects non-numeric values."""
-        with pytest.raises(ValueError, match="SANDBOX_CPU_COUNT must be a positive number"):
+        with pytest.raises(ValidationError, match="SANDBOX_CPU_COUNT must be a positive number"):
             _parse_cpu_count_env("abc", "SANDBOX_CPU_COUNT")
 
     def test_parse_cpu_count_env_valid_value(self) -> None:
@@ -301,30 +301,30 @@ class TestRuntimeConfigHelpers:
 
     def test_parse_cpu_count_env_must_be_positive(self) -> None:
         """Test cpu_count parser rejects zero and negative values."""
-        with pytest.raises(ValueError, match="SANDBOX_CPU_COUNT must be greater than 0"):
+        with pytest.raises(ValidationError, match="SANDBOX_CPU_COUNT must be greater than 0"):
             _parse_cpu_count_env("0", "SANDBOX_CPU_COUNT")
 
     def test_parse_cpu_count_env_requires_whole_number(self) -> None:
         """Test cpu_count parser rejects fractional values."""
         with pytest.raises(
-            ValueError,
+            ValidationError,
             match="SANDBOX_CPU_COUNT must be a whole number when mapped to cpu_period/cpu_quota",
         ):
             _parse_cpu_count_env("1.5", "SANDBOX_CPU_COUNT")
 
     def test_parse_cpus_env_invalid_number(self) -> None:
         """Test CPU parser rejects non-numeric values."""
-        with pytest.raises(ValueError, match="SANDBOX_CPUS must be a positive number"):
+        with pytest.raises(ValidationError, match="SANDBOX_CPUS must be a positive number"):
             _parse_cpus_env("abc")
 
     def test_parse_cpus_env_must_be_positive(self) -> None:
         """Test CPU parser rejects zero and negative values."""
-        with pytest.raises(ValueError, match="SANDBOX_CPUS must be greater than 0"):
+        with pytest.raises(ValidationError, match="SANDBOX_CPUS must be greater than 0"):
             _parse_cpus_env("0")
 
     def test_parse_cpus_env_rejects_too_small_fraction(self) -> None:
         """Test CPU parser rejects values that round down to zero quota."""
-        with pytest.raises(ValueError, match="SANDBOX_CPUS is too small to translate into cpu_quota"):
+        with pytest.raises(ValidationError, match="SANDBOX_CPUS is too small to translate into cpu_quota"):
             _parse_cpus_env("0.000001")
 
     @patch.dict(os.environ, {"SANDBOX_CAP_DROP": " , "}, clear=True)
@@ -335,13 +335,18 @@ class TestRuntimeConfigHelpers:
     @patch.dict(os.environ, {}, clear=True)
     def test_validate_backend_runtime_configs_rejects_kubernetes_runtime_configs(self) -> None:
         """Test Kubernetes backend rejects parsed runtime configs even without raw env vars present."""
-        with pytest.raises(ValueError, match="not supported for the Kubernetes backend"):
+        with pytest.raises(ValidationError, match="not supported for backend 'kubernetes'"):
             _validate_backend_runtime_configs(SandboxBackend.KUBERNETES, {"mem_limit": "512m"})
 
     @patch.dict(os.environ, {"SANDBOX_FOO": "bar"}, clear=True)
     def test_validate_backend_runtime_configs_ignores_unrelated_sandbox_envs(self) -> None:
         """Test Kubernetes backend ignores SANDBOX_* env vars unrelated to runtime_configs."""
         _validate_backend_runtime_configs(SandboxBackend.KUBERNETES)
+
+    @patch.dict(os.environ, {"SANDBOX_READ_ONLY": "true"}, clear=True)
+    def test_validate_backend_runtime_configs_allows_micromamba_runtime_configs(self) -> None:
+        """Test Micromamba backend accepts Docker-compatible runtime config env vars."""
+        _validate_backend_runtime_configs(SandboxBackend.MICROMAMBA)
 
 
 class TestSupportsVisualization:
@@ -727,7 +732,7 @@ class TestExecuteCode:
         assert isinstance(result[0], TextContent)
         result_data = json.loads(result[0].text)
         assert result_data["exit_code"] == 1
-        assert "not supported for the Kubernetes backend" in result_data["stderr"]
+        assert "not supported for backend 'kubernetes'" in result_data["stderr"]
 
     @patch.dict(os.environ, {"SANDBOX_CAP_DROP": " , "}, clear=True)
     @patch("llm_sandbox.mcp_server.server._get_backend")
@@ -741,7 +746,7 @@ class TestExecuteCode:
         assert isinstance(result[0], TextContent)
         result_data = json.loads(result[0].text)
         assert result_data["exit_code"] == 1
-        assert "not supported for the Kubernetes backend" in result_data["stderr"]
+        assert "not supported for backend 'kubernetes'" in result_data["stderr"]
 
     @patch.dict(os.environ, {"SANDBOX_READ_ONLY": "maybe"}, clear=True)
     @patch("llm_sandbox.mcp_server.server._get_backend")
@@ -755,7 +760,7 @@ class TestExecuteCode:
         assert isinstance(result[0], TextContent)
         result_data = json.loads(result[0].text)
         assert result_data["exit_code"] == 1
-        assert "not supported for the Kubernetes backend" in result_data["stderr"]
+        assert "not supported for backend 'kubernetes'" in result_data["stderr"]
 
 
 class TestGetSupportedLanguages:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -17,6 +17,7 @@ from llm_sandbox.mcp_server.server import (
     _get_commit_container,
     _get_keep_template,
     _get_kube_namespace,
+    _get_runtime_configs,
     _supports_visualization,
     execute_code,
     get_language_details,
@@ -209,6 +210,60 @@ class TestGetKubeNamespace:
         assert result == "default"
 
 
+class TestGetRuntimeConfigs:
+    """Test _get_runtime_configs function."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_get_runtime_configs_default_empty(self) -> None:
+        """Test that runtime configs default to empty when no env vars are set."""
+        assert _get_runtime_configs() == {}
+
+    @patch.dict(
+        os.environ,
+        {
+            "SANDBOX_NETWORK_MODE": "none",
+            "SANDBOX_READ_ONLY": "true",
+            "SANDBOX_MEMORY": "4g",
+            "SANDBOX_CPUS": "1.0",
+            "SANDBOX_CAP_DROP": "ALL,SYS_ADMIN",
+            "SANDBOX_SECURITY_OPT": "no-new-privileges:true,label=disable",
+            "SANDBOX_PRIVILEGED": "false",
+        },
+        clear=True,
+    )
+    def test_get_runtime_configs_from_env(self) -> None:
+        """Test building runtime configs from environment variables."""
+        assert _get_runtime_configs() == {
+            "network_mode": "none",
+            "read_only": True,
+            "mem_limit": "4g",
+            "cpu_count": 1,
+            "cap_drop": ["ALL", "SYS_ADMIN"],
+            "security_opt": ["no-new-privileges:true", "label=disable"],
+            "privileged": False,
+        }
+
+    @patch.dict(os.environ, {"SANDBOX_CPUS": "0.5"}, clear=True)
+    def test_get_runtime_configs_fractional_cpus(self) -> None:
+        """Test fractional CPU values are normalized into quota settings."""
+        assert _get_runtime_configs() == {
+            "cpu_period": 100000,
+            "cpu_quota": 50000,
+        }
+
+    @patch.dict(os.environ, {"SANDBOX_CPU_COUNT": "2.5"}, clear=True)
+    def test_get_runtime_configs_invalid_cpu_count(self) -> None:
+        """Test invalid cpu_count values raise a clear error."""
+        with pytest.raises(ValueError, match="SANDBOX_CPU_COUNT must be a whole number"):
+            _get_runtime_configs()
+
+    @patch.dict(os.environ, {"SANDBOX_READ_ONLY": "maybe"}, clear=True)
+    def test_get_runtime_configs_invalid_boolean(self) -> None:
+        """Test invalid boolean environment values raise a clear error."""
+        with pytest.raises(ValueError, match="SANDBOX_READ_ONLY must be one of"):
+            _get_runtime_configs()
+
+
 class TestSupportsVisualization:
     """Test _supports_visualization function."""
 
@@ -294,6 +349,61 @@ class TestExecuteCode:
         )
         mock_session.run.assert_called_once_with(
             code="print('Hello, World!')", libraries=[], timeout=30, clear_plots=True
+        )
+
+    @patch.dict(
+        os.environ,
+        {
+            "SANDBOX_NETWORK_MODE": "none",
+            "SANDBOX_READ_ONLY": "true",
+            "SANDBOX_MEMORY": "4g",
+            "SANDBOX_CPUS": "1.0",
+            "SANDBOX_CAP_DROP": "ALL",
+        },
+        clear=True,
+    )
+    @patch("llm_sandbox.mcp_server.server._get_backend")
+    @patch("llm_sandbox.mcp_server.server._get_commit_container")
+    @patch("llm_sandbox.mcp_server.server._get_keep_template")
+    @patch("llm_sandbox.mcp_server.server._get_kube_namespace")
+    @patch("llm_sandbox.mcp_server.server.ArtifactSandboxSession")
+    def test_execute_code_passes_runtime_configs(
+        self,
+        mock_session_cls: MagicMock,
+        mock_get_kube_namespace: MagicMock,
+        mock_get_keep_template: MagicMock,
+        mock_get_commit_container: MagicMock,
+        mock_get_backend: MagicMock,
+    ) -> None:
+        """Test runtime configs from env are passed into sandbox sessions."""
+        mock_backend = SandboxBackend.DOCKER
+        mock_get_backend.return_value = mock_backend
+        mock_get_commit_container.return_value = True
+        mock_get_keep_template.return_value = True
+        mock_get_kube_namespace.return_value = "default"
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_cls.return_value.__exit__ = MagicMock(return_value=None)
+        mock_session.run.return_value = ExecutionResult(exit_code=0, stdout="OK", stderr="")
+
+        _ = execute_code("print('Hello')", "python")
+
+        mock_session_cls.assert_called_once_with(
+            lang="python",
+            keep_template=True,
+            commit_container=True,
+            verbose=False,
+            backend=mock_backend,
+            session_timeout=30,
+            kube_namespace="default",
+            runtime_configs={
+                "network_mode": "none",
+                "read_only": True,
+                "mem_limit": "4g",
+                "cpu_count": 1,
+                "cap_drop": ["ALL"],
+            },
         )
 
     @patch("llm_sandbox.mcp_server.server._get_backend")
@@ -523,6 +633,20 @@ class TestExecuteCode:
         result_data = json.loads(result[0].text)
         assert result_data["exit_code"] == 1
         assert "Execution failed" in result_data["stderr"]
+
+    @patch.dict(os.environ, {"SANDBOX_READ_ONLY": "true"}, clear=True)
+    @patch("llm_sandbox.mcp_server.server._get_backend")
+    def test_execute_code_rejects_runtime_configs_for_kubernetes(self, mock_get_backend: MagicMock) -> None:
+        """Test runtime config env vars are rejected for Kubernetes backend."""
+        mock_get_backend.return_value = SandboxBackend.KUBERNETES
+
+        result = execute_code("print('Hello')", "python")
+
+        assert len(result) == 1
+        assert isinstance(result[0], TextContent)
+        result_data = json.loads(result[0].text)
+        assert result_data["exit_code"] == 1
+        assert "not supported for the Kubernetes backend" in result_data["stderr"]
 
 
 class TestGetSupportedLanguages:

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -1,0 +1,45 @@
+"""Tests for ContainerAPI protocol runtime checks."""
+from typing import Any
+
+from llm_sandbox.core.mixins import ContainerAPI
+
+
+class MockRuntime:
+    """Mock runtime that implements ContainerAPI."""
+
+    def create_container(self, config: Any) -> Any:
+        return {"config": config}
+
+    def start_container(self, container: Any) -> None:
+        pass
+
+    def stop_container(self, container: Any) -> None:
+        pass
+
+    def execute_command(self, container: Any, command: str, **kwargs: Any) -> tuple[int, Any]:
+        return 0, ("stdout", "stderr")
+
+    def copy_to_container(self, container: Any, src: str, dest: str, **kwargs: Any) -> None:
+        pass
+
+    def copy_from_container(self, container: Any, src: str, **kwargs: Any) -> tuple[bytes, dict]:
+        return b"data", {"size": 4}
+
+
+class IncompleteRuntime:
+    """Mock runtime missing methods."""
+
+    def create_container(self, config: Any) -> Any:
+        return {"config": config}
+
+
+def test_mock_runtime_satisfies_protocol():
+    """MockRuntime satisfies ContainerAPI protocol."""
+    runtime: ContainerAPI = MockRuntime()
+    assert isinstance(runtime, ContainerAPI)
+
+
+def test_incomplete_runtime_does_not_satisfy_protocol():
+    """IncompleteRuntime does not satisfy ContainerAPI."""
+    runtime = IncompleteRuntime()
+    assert not isinstance(runtime, ContainerAPI)

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -1,4 +1,5 @@
 """Tests for ContainerAPI protocol runtime checks."""
+
 from typing import Any
 
 from llm_sandbox.core.mixins import ContainerAPI
@@ -7,29 +8,29 @@ from llm_sandbox.core.mixins import ContainerAPI
 class MockRuntime:
     """Mock runtime that implements ContainerAPI."""
 
-    def create_container(self, config: Any) -> Any:
+    def create_container(self, config: Any) -> Any:  # noqa: D102
         return {"config": config}
 
-    def start_container(self, container: Any) -> None:
+    def start_container(self, container: Any) -> None:  # noqa: D102
         pass
 
-    def stop_container(self, container: Any) -> None:
+    def stop_container(self, container: Any) -> None:  # noqa: D102
         pass
 
-    def execute_command(self, container: Any, command: str, **kwargs: Any) -> tuple[int, Any]:
+    def execute_command(self, container: Any, command: str, **kwargs: Any) -> tuple[int, Any]:  # noqa: D102
         return 0, ("stdout", "stderr")
 
-    def copy_to_container(self, container: Any, src: str, dest: str, **kwargs: Any) -> None:
+    def copy_to_container(self, container: Any, src: str, dest: str, **kwargs: Any) -> None:  # noqa: D102
         pass
 
-    def copy_from_container(self, container: Any, src: str, **kwargs: Any) -> tuple[bytes, dict]:
+    def copy_from_container(self, container: Any, src: str, **kwargs: Any) -> tuple[bytes, dict]:  # noqa: D102
         return b"data", {"size": 4}
 
 
 class IncompleteRuntime:
     """Mock runtime missing methods."""
 
-    def create_container(self, config: Any) -> Any:
+    def create_container(self, config: Any) -> Any:  # noqa: D102
         return {"config": config}
 
 

--- a/tests/test_runtime_api.py
+++ b/tests/test_runtime_api.py
@@ -34,13 +34,13 @@ class IncompleteRuntime:
         return {"config": config}
 
 
-def test_mock_runtime_satisfies_protocol():
+def test_mock_runtime_satisfies_protocol() -> None:
     """MockRuntime satisfies ContainerAPI protocol."""
     runtime: ContainerAPI = MockRuntime()
     assert isinstance(runtime, ContainerAPI)
 
 
-def test_incomplete_runtime_does_not_satisfy_protocol():
+def test_incomplete_runtime_does_not_satisfy_protocol() -> None:
     """IncompleteRuntime does not satisfy ContainerAPI."""
     runtime = IncompleteRuntime()
     assert not isinstance(runtime, ContainerAPI)


### PR DESCRIPTION
## Summary
This draft PR fixes issue #153 by letting the MCP server read sandbox hardening settings from environment variables and pass them into sandbox session `runtime_configs`.

## What Changed
- added MCP env parsing for `SANDBOX_*` runtime config variables
- normalized memory and CPU env values into backend-safe runtime config keys
- reject `SANDBOX_*` runtime config env vars for Kubernetes with a clear error because Kubernetes must use `pod_manifest`
- documented the new MCP environment variables in the README and MCP integration docs
- added tests for env parsing, session pass-through, Kubernetes rejection, and runtime protocol checks

## Root Cause
The MCP server only read a small set of env vars like `BACKEND`, `COMMIT_CONTAINER`, and `KEEP_TEMPLATE`. It never built or forwarded `runtime_configs`, so sandbox hardening env vars had no effect.

## User Impact
Users can now harden Docker and Podman-backed MCP sandboxes without writing custom wrapper code.

## Validation
- `uv run pytest tests/test_runtime_api.py tests/test_mcp_server.py`

## Notes
- fixes #153
- this PR also repairs the stray protocol test so it points at the real `ContainerAPI` protocol instead of a nonexistent module


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed docs on mapping SANDBOX_* environment variables to per-session runtime configs, normalization rules (memory/CPU), Kubernetes guidance, and a security note warning against privileged mode.

* **New Features**
  * Support for expressing runtime options via SANDBOX_* env vars for Docker/Podman/Micromamba (memory, CPU normalization, network, read-only, capabilities, security, privileged).

* **Tests**
  * Added unit tests for env-var parsing, CPU validation, backend validation, and runtime-protocol compliance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->