### PR TITLE
fix: use correct parameter name `container_id` for Kubernetes pooled …

### DIFF
--- a/llm_sandbox/pool/session.py
+++ b/llm_sandbox/pool/session.py
@@ -261,7 +261,7 @@ class PooledSandboxSession:
                     default_timeout=self._default_timeout,
                     execution_timeout=self._execution_timeout,
                     session_timeout=self._session_timeout,
-                    pod_id=container_id,  # Connect to existing pooled pod
+                    container_id=container_id,  # Connect to existing pooled pod
                     skip_environment_setup=True,
                     encoding_errors=self._encoding_errors,
                     **session_kwargs,

--- a/llm_sandbox/pool/session.py
+++ b/llm_sandbox/pool/session.py
@@ -252,7 +252,7 @@ class PooledSandboxSession:
 
                 return SandboxKubernetesSession(
                     client=self._pool_manager.client,
-                    namespace=namespace,
+                    kube_namespace=namespace,
                     image=self._image,
                     lang=self._lang,
                     verbose=self._verbose,

--- a/tests/test_pool_session.py
+++ b/tests/test_pool_session.py
@@ -526,7 +526,8 @@ class TestPooledSessionBackendCreation:
             # Verify Kubernetes session was created
             mock_k8s_session.assert_called_once()
             call_kwargs = mock_k8s_session.call_args[1]
-            assert call_kwargs["namespace"] == "custom-ns"
+            assert call_kwargs["kube_namespace"] == "custom-ns"
+            assert call_kwargs["container_id"] == "test-pod"
             assert call_kwargs["skip_environment_setup"] is True
         finally:
             pool.close()


### PR DESCRIPTION
## Summary

Fix two incorrect keyword argument names in `PooledSandboxSession._create_backend_session()` for the Kubernetes backend.

## Problem

When creating a `SandboxKubernetesSession` for an existing pooled pod, two keyword arguments are passed with wrong names:

```python
# session.py (before fix)
return SandboxKubernetesSession(
    client=self._pool_manager.client,
    namespace=namespace,          # ← Bug 1: should be kube_namespace
    ...
    pod_id=container_id,          # ← Bug 2: should be container_id
    ...
)
```

`SandboxKubernetesSession.__init__` expects `kube_namespace` and `container_id`, not `namespace` and `pod_id`.

Because these are not recognized parameters, they fall through to `**kwargs` and are **silently ignored**:

- `container_id` defaults to `None` → `using_existing_container` is `False` → instead of connecting to the existing pooled pod, **a brand new pod is created with the default manifest** on every `session.open()` call
- `kube_namespace` defaults to `"default"` → pooled sessions in non-default namespaces silently use the wrong namespace

## Impact

- Pooled pods are never reused (new pod created every time)
- Custom `pod_manifest` (volumes, security context, resources, labels) is ignored for these new pods — the default manifest is used instead
- Container startup latency on every request (~15-20s) instead of instant reuse
- Non-default namespace configurations are silently broken

## Fix

```diff
  return SandboxKubernetesSession(
      client=self._pool_manager.client,
-     namespace=namespace,
+     kube_namespace=namespace,
      image=self._image,
      ...
-     pod_id=container_id,  # Connect to existing pooled pod
+     container_id=container_id,  # Connect to existing pooled pod
      skip_environment_setup=True,
      ...
  )
```

The Docker and Podman backends already use the correct parameter names. This fix aligns the Kubernetes backend with them:

| Backend | container param | namespace param | Status |
|---------|----------------|-----------------|--------|
| Docker | `container_id` | N/A | ✅ Correct |
| **Kubernetes** | ~~`pod_id`~~ → `container_id` | ~~`namespace`~~ → `kube_namespace` | 🔧 **Fixed** |
| Podman | `container_id` | N/A | ✅ Correct |

## How to reproduce

1. Create a `KubernetesPoolManager` with a custom `pod_manifest` (e.g., with PVC volumes)
2. Create a `PooledSandboxSession` with the pool manager
3. Call `session.open()`
4. Observe that a **new pod** is created with the default manifest instead of connecting to a warm pod from the pool

## Note

The `kube_namespace` issue was identified by CodeRabbit during the review of the initial `container_id` fix. Both bugs share the same root cause — parameter name mismatch between `_create_backend_session()` and `SandboxKubernetesSession.__init__()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected argument mapping when creating pooled Kubernetes sessions so the pooled container identifier and namespace are passed to session initialization correctly, preventing startup mismatches and improving stability.

* **Tests**
  * Updated tests to assert the corrected identifier and namespace parameters for pooled backend sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->