### PR TITLE
fix: address documentation and tooling drift (#163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,16 @@ pip install 'llm-sandbox[docker,k8s,podman]'
 ```
 
 ### Development Installation
+
+Dev dependencies live in the `dev` [uv dependency group](https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups), so install them with `uv` (or the `make install` shortcut):
+
 ```bash
 git clone https://github.com/vndee/llm-sandbox.git
 cd llm-sandbox
-pip install -e '.[dev]'
+make install   # uv sync + pre-commit install
 ```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
 
 ## 🏃‍♂️ Quick Start
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -295,6 +295,26 @@ Common exceptions include:
 
 ---
 
+## Container Pooling
+
+### ContainerPoolManager
+
+::: llm_sandbox.pool.base.ContainerPoolManager
+
+### PoolConfig
+
+::: llm_sandbox.pool.config.PoolConfig
+
+### PooledSandboxSession
+
+::: llm_sandbox.pool.session.PooledSandboxSession
+
+### create_pool_manager
+
+::: llm_sandbox.pool.factory.create_pool_manager
+
+---
+
 ## Type Hints
 
 ### StreamCallback

--- a/docs/container-pooling.md
+++ b/docs/container-pooling.md
@@ -1137,4 +1137,4 @@ For detailed API documentation, see:
 - [Configuration Guide](configuration.md) - General session configuration
 - [Container Backends](backends.md) - Docker, Kubernetes, and Podman setup
 - [Security](security.md) - Security considerations for pooled containers
-- [Performance Optimization](configuration.md#performance-optimization) - Additional optimization tips
+- [Container Pooling Configuration](configuration.md#container-pooling-configuration) - Pool tuning and best practices

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,13 +42,15 @@ pip install 'llm-sandbox[docker,k8s,podman]'
 
 ### Development Installation
 
-For contributing or development:
+For contributing or development, dev dependencies are managed as a [uv dependency group](https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups). Use `uv` (or the `make install` shortcut) instead of `pip install -e '.[dev]'`:
 
 ```bash
 git clone https://github.com/vndee/llm-sandbox.git
 cd llm-sandbox
-pip install -e '.[dev]'
+make install   # runs `uv sync` and installs pre-commit hooks
 ```
+
+See [Contributing](contributing.md) for the full workflow.
 
 ## Quick Start
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - Container Pooling: container-pooling.md
       - Security: security.md
       - Container Backends: backends.md
+      - Custom Images: custom-images.md
       - Supported Languages: languages.md
       - Interactive Sessions: interactive-sessions.md
       - LLM Integrations: integrations.md


### PR DESCRIPTION
Closes #163.

### 1. README + docs dev-install command

`pip install -e '.[dev]'` stopped working when dev deps moved from `[project.optional-dependencies]` into the `dev` [uv dependency group](https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups) (current `pyproject.toml`). Both `README.md` and `docs/getting-started.md` now point at `make install`, which is what `CONTRIBUTING.md` and the `Makefile` already canonicalize to (`uv sync` + `pre-commit install`).

`docs/mcp-integration.md` still uses `pip install -e '.[mcp-docker]'` — left alone because `mcp-docker` is a real `[project.optional-dependencies]` extra, so that command still works.

### 2. `custom-images.md` in nav

Added under **User Guide** between Container Backends and Supported Languages. The file already has substantive content covering custom images, Dockerfiles, and pre-installed libraries, so merging into another page would have lost structure. One-line change in `mkdocs.yml`.

### 3. `container-pooling.md` stale anchors

Two distinct issues:

- API Reference section linked to `api-reference.md#llm_sandbox.pool.{base.ContainerPoolManager,config.PoolConfig,session.PooledSandboxSession,factory.create_pool_manager}`, but `docs/api-reference.md` had no `:::` directives for those modules — anchors never existed. Added a **Container Pooling** section to `api-reference.md` with the four mkdocstrings entries; anchors now resolve.
- Related Documentation pointed at `configuration.md#performance-optimization`, which doesn't exist. Repointed at `configuration.md#container-pooling-configuration` (real anchor, more relevant to the link text anyway).

### 4. Fail CI on doc warnings

Already done — `.github/workflows/main.yml` `check-docs` job runs `uv run mkdocs build -s` and `Makefile` exposes the same as `make docs-test`. No workflow changes needed.

### 5. `mkdocs build -s` warning count

| | before | after |
|---|---|---|
| `mkdocs build -s` warnings | 6 | 0 |

Six pre-existing INFO-level drift messages (1 unlisted nav page + 5 unresolved anchor links from `container-pooling.md`) — all gone:

```
$ uv run mkdocs build -s
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: .../site
INFO    -  Documentation built in 3.39 seconds
```

### Diffstat

```
 README.md                 |  7 ++++++-
 docs/api-reference.md     | 20 ++++++++++++++++++++
 docs/container-pooling.md |  2 +-
 docs/getting-started.md   |  6 ++++--
 mkdocs.yml                |  1 +
 5 files changed, 32 insertions(+), 4 deletions(-)
```

Did **not** touch `docs/security.md` (recently rewritten in #165).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated development setup instructions to use `uv` and `make install` instead of pip.
* Added Container Pooling section to API reference documenting pooled execution capabilities.
* Added new "Custom Images" documentation page to user guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->