### PR TITLE
feat: add enforced security-policy execution path (#160)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -209,7 +209,50 @@ with SandboxSession(lang="python", security_policy=policy) as session:
             print(f"  - {violation.description} (Severity: {violation.severity.name})")
 ```
 
-> **Warning**: Calling `session.run(code)` without first checking `session.is_safe(code)` will execute the code regardless of the security policy. Always use the check-then-execute pattern shown above.
+> **Warning**: Calling `session.run(code)` without first checking `session.is_safe(code)` will execute the code regardless of the security policy. The check-then-execute pattern is easy to forget, especially when wiring a sandbox into a larger system. For production use, prefer the **enforced execution path** described below.
+
+### Enforcing the security policy
+
+The advisory check-then-execute pattern is easy to skip. For an enforced path that refuses to run code that violates the policy, pass `enforce_security_policy=True` to `run()`, or call the `safe_run()` wrapper. Either way the policy is evaluated **before any container interaction**, so policy-blocked code never pays the container-spinup cost.
+
+```python
+from llm_sandbox import SandboxSession
+from llm_sandbox.exceptions import SecurityPolicyViolation
+from llm_sandbox.security import RestrictedModule, SecurityIssueSeverity, SecurityPolicy
+
+policy = SecurityPolicy(
+    severity_threshold=SecurityIssueSeverity.HIGH,
+    restricted_modules=[
+        RestrictedModule(
+            name="subprocess",
+            description="Process execution",
+            severity=SecurityIssueSeverity.HIGH,
+        ),
+    ],
+)
+
+with SandboxSession(lang="python", security_policy=policy) as session:
+    code = "import subprocess\nsubprocess.run(['ls'])"
+
+    try:
+        # Either form works - they are equivalent.
+        result = session.run(code, enforce_security_policy=True)
+        # result = session.safe_run(code)
+        print(result.stdout)
+    except SecurityPolicyViolation as exc:
+        print(f"Blocked at {exc.severity_threshold.name}:")
+        for v in exc.violations:
+            print(f"  - {v.description} ({v.severity.name})")
+```
+
+The exception is `llm_sandbox.exceptions.SecurityPolicyViolation` (a subclass of `SecurityViolationError`). It carries:
+
+- `violations`: a `list[SecurityPattern]` of every matched pattern, including patterns auto-generated from `RestrictedModule` entries. Each item has `pattern`, `description`, and `severity`.
+- `severity_threshold`: the `SecurityIssueSeverity` the policy was configured with at the time execution was blocked.
+
+`enforce_security_policy` defaults to `False`, so existing callers that already use the manual `is_safe()`-then-`run()` pattern keep working unchanged.
+
+**Recommended for production.** Wiring an LLM-driven agent into `safe_run()` (or `run(..., enforce_security_policy=True)`) means a forgotten `is_safe()` check never silently lets a bad payload through.
 
 ### Custom Security Policies
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -256,7 +256,50 @@ with SandboxSession(lang="python", security_policy=policy) as session:
             print(f"  - {violation.description} (Severity: {violation.severity.name})")
 ```
 
-> **Warning**: Calling `session.run(code)` without first checking `session.is_safe(code)` will execute the code regardless of the security policy. Always use the check-then-execute pattern shown above.
+> **Warning**: `session.run(code)` does **not** enforce the security policy. It executes the code regardless of any configured policy. You **must** either call `session.is_safe(code)` first and act on the result, or use the enforced path — `session.safe_run(code)` or `session.run(code, enforce_security_policy=True)` — described below.
+
+### Enforcing the security policy
+
+The advisory check-then-execute pattern is easy to skip. For an enforced path that refuses to run code that violates the policy, pass `enforce_security_policy=True` to `run()`, or call the `safe_run()` wrapper. Either way the policy is evaluated **before any container interaction**, so policy-blocked code never pays the container-spinup cost.
+
+```python
+from llm_sandbox import SandboxSession
+from llm_sandbox.exceptions import SecurityPolicyViolation
+from llm_sandbox.security import RestrictedModule, SecurityIssueSeverity, SecurityPolicy
+
+policy = SecurityPolicy(
+    severity_threshold=SecurityIssueSeverity.HIGH,
+    restricted_modules=[
+        RestrictedModule(
+            name="subprocess",
+            description="Process execution",
+            severity=SecurityIssueSeverity.HIGH,
+        ),
+    ],
+)
+
+with SandboxSession(lang="python", security_policy=policy) as session:
+    code = "import subprocess\nsubprocess.run(['ls'])"
+
+    try:
+        # Either form works - they are equivalent.
+        result = session.run(code, enforce_security_policy=True)
+        # result = session.safe_run(code)
+        print(result.stdout)
+    except SecurityPolicyViolation as exc:
+        print(f"Blocked at {exc.severity_threshold.name}:")
+        for v in exc.violations:
+            print(f"  - {v.description} ({v.severity.name})")
+```
+
+The exception is `llm_sandbox.exceptions.SecurityPolicyViolation` (a subclass of `SecurityViolationError`). It carries:
+
+- `violations`: a `list[SecurityPattern]` of every matched pattern, including patterns auto-generated from `RestrictedModule` entries. Each item has `pattern`, `description`, and `severity`.
+- `severity_threshold`: the `SecurityIssueSeverity` the policy was configured with at the time execution was blocked.
+
+`enforce_security_policy` defaults to `False`, so existing callers that already use the manual `is_safe()`-then-`run()` pattern keep working unchanged.
+
+**Recommended for production.** Wiring an LLM-driven agent into `safe_run()` (or `run(..., enforce_security_policy=True)`) means a forgotten `is_safe()` check never silently lets a bad payload through.
 
 ### Custom Security Policies
 

--- a/llm_sandbox/core/session_base.py
+++ b/llm_sandbox/core/session_base.py
@@ -18,6 +18,7 @@ from llm_sandbox.exceptions import (
     LibraryInstallationNotSupportedError,
     NotOpenSessionError,
     SandboxTimeoutError,
+    SecurityPolicyViolation,
     SecurityViolationError,
 )
 from llm_sandbox.language_handlers.factory import LanguageHandlerFactory
@@ -237,6 +238,28 @@ class BaseSession(
         """
         return self._check_security_policy(code)
 
+    def _enforce_security_policy(self, code: str) -> None:
+        """Run the security policy and raise if violations are present.
+
+        This helper is invoked by ``run(..., enforce_security_policy=True)`` and
+        by ``safe_run`` *before* any container interaction so policy-blocked
+        code never pays the container-spinup cost. It reuses ``is_safe`` so the
+        scanning logic stays in a single place.
+
+        Raises:
+            SecurityPolicyViolation: If a security policy is configured and the
+                code matches any pattern (or restricted-module import) at or
+                above the configured severity threshold.
+
+        """
+        if not self.config.security_policy:
+            return
+
+        is_safe, violations = self.is_safe(code)
+        if not is_safe:
+            threshold = self.config.security_policy.severity_threshold
+            raise SecurityPolicyViolation(violations=violations, severity_threshold=threshold)
+
     def install(self, libraries: list[str] | None = None) -> None:
         r"""Install libraries into the sandbox environment.
 
@@ -443,6 +466,7 @@ class BaseSession(
         timeout: float | None = None,
         on_stdout: StreamCallback | None = None,
         on_stderr: StreamCallback | None = None,
+        enforce_security_policy: bool = False,
     ) -> ConsoleOutput:
         r"""Run the provided code within the sandbox session.
 
@@ -467,6 +491,13 @@ class BaseSession(
                 worker thread; ensure your callback is thread-safe.
             on_stderr (StreamCallback | None): Optional callback invoked with each decoded stderr
                 chunk as it arrives during execution. Same threading note as ``on_stdout``.
+            enforce_security_policy (bool, optional): When ``True``, the configured
+                ``SecurityPolicy`` is enforced *before* any container interaction. If the
+                code matches any pattern (or restricted-module import) at or above the
+                configured severity threshold, a ``SecurityPolicyViolation`` is raised and
+                the code is never executed. Defaults to ``False`` for backwards
+                compatibility — callers wanting first-class enforcement should set this to
+                ``True`` (or use the ``safe_run`` wrapper).
 
         Returns:
             ConsoleOutput: An object containing the stdout, stderr, and exit code from the code execution.
@@ -474,8 +505,13 @@ class BaseSession(
         Raises:
             NotOpenSessionError: If the session (container) is not currently open/running.
             CommandFailedError: If any of the execution commands fail.
+            SecurityPolicyViolation: If ``enforce_security_policy=True`` and the code
+                violates the configured security policy.
 
         """
+        if enforce_security_policy:
+            self._enforce_security_policy(code)
+
         if not self.container or not self.is_open:
             raise NotOpenSessionError
 
@@ -539,6 +575,33 @@ class BaseSession(
         except SandboxTimeoutError:
             self._handle_timeout()
             raise
+
+    def safe_run(
+        self,
+        code: str,
+        libraries: list | None = None,
+        timeout: float | None = None,
+        on_stdout: StreamCallback | None = None,
+        on_stderr: StreamCallback | None = None,
+    ) -> ConsoleOutput:
+        r"""Run code with the configured security policy enforced.
+
+        Thin wrapper over ``run(..., enforce_security_policy=True)`` for callers
+        that want the enforced path to be the default and discoverable.
+
+        Raises:
+            SecurityPolicyViolation: If the code violates the configured security
+                policy. Raised before any container interaction.
+
+        """
+        return self.run(
+            code,
+            libraries=libraries,
+            timeout=timeout,
+            on_stdout=on_stdout,
+            on_stderr=on_stderr,
+            enforce_security_policy=True,
+        )
 
     @abstractmethod
     def _handle_timeout(self) -> None:

--- a/llm_sandbox/core/session_base.py
+++ b/llm_sandbox/core/session_base.py
@@ -139,7 +139,7 @@ class BaseSession(
             self._base_security_policy = self.config.security_policy.model_copy(deep=True)
 
         policy = self._base_security_policy.model_copy(deep=True)
-        for module in policy.restricted_modules:
+        for module in policy.restricted_modules or []:
             policy.add_pattern(
                 SecurityPattern(
                     pattern=self.language_handler.get_import_patterns(module.name),

--- a/llm_sandbox/core/session_base.py
+++ b/llm_sandbox/core/session_base.py
@@ -18,11 +18,12 @@ from llm_sandbox.exceptions import (
     LibraryInstallationNotSupportedError,
     NotOpenSessionError,
     SandboxTimeoutError,
+    SecurityPolicyViolation,
     SecurityViolationError,
 )
 from llm_sandbox.language_handlers.factory import LanguageHandlerFactory
 from llm_sandbox.language_handlers.runtime_context import RuntimeContext
-from llm_sandbox.security import SecurityIssueSeverity, SecurityPattern
+from llm_sandbox.security import SecurityIssueSeverity, SecurityPattern, SecurityPolicy
 
 PYTHON_VENV_DIR_NAME = ".sandbox-venv"
 PYTHON_PIP_CACHE_DIR_NAME = ".sandbox-pip-cache"
@@ -83,6 +84,11 @@ class BaseSession(
         self._python_env_dir = (workdir_path / PYTHON_VENV_DIR_NAME).as_posix()
         self._python_pip_cache_dir = (workdir_path / PYTHON_PIP_CACHE_DIR_NAME).as_posix()
 
+        # Pristine snapshot of the caller's security policy, taken lazily so that
+        # restricted-module patterns are derived fresh on every check instead of
+        # accumulating on (or leaking into) the caller's SecurityPolicy object.
+        self._base_security_policy: SecurityPolicy | None = None
+
     def _log(self, message: str, level: str = "info") -> None:
         """Log message if verbose."""
         if self.verbose:
@@ -120,17 +126,28 @@ class BaseSession(
             self._session_timer = None
 
     def _add_restricted_module_patterns(self) -> None:
-        """Add patterns for restricted modules to the security policy."""
+        """Derive import patterns for the policy's restricted modules.
+
+        Works on a private deep copy of the caller's pristine policy so repeated
+        checks neither accumulate duplicate patterns nor mutate the object the
+        caller passed in.
+        """
         if not self.config.security_policy or not self.config.security_policy.restricted_modules:
             return
 
-        for module in self.config.security_policy.restricted_modules:
-            pattern = SecurityPattern(
-                pattern=self.language_handler.get_import_patterns(module.name),
-                description=module.description,
-                severity=module.severity,
+        if self._base_security_policy is None:
+            self._base_security_policy = self.config.security_policy.model_copy(deep=True)
+
+        policy = self._base_security_policy.model_copy(deep=True)
+        for module in policy.restricted_modules:
+            policy.add_pattern(
+                SecurityPattern(
+                    pattern=self.language_handler.get_import_patterns(module.name),
+                    description=module.description,
+                    severity=module.severity,
+                )
             )
-            self.config.security_policy.add_pattern(pattern)
+        self.config.security_policy = policy
 
     def _check_pattern_violations(self, filtered_code: str) -> tuple[bool, list[SecurityPattern]]:
         """Check for pattern violations in the filtered code.
@@ -236,6 +253,28 @@ class BaseSession(
 
         """
         return self._check_security_policy(code)
+
+    def _enforce_security_policy(self, code: str) -> None:
+        """Run the security policy and raise if violations are present.
+
+        This helper is invoked by ``run(..., enforce_security_policy=True)`` and
+        by ``safe_run`` *before* any container interaction so policy-blocked
+        code never pays the container-spinup cost. It reuses ``is_safe`` so the
+        scanning logic stays in a single place.
+
+        Raises:
+            SecurityPolicyViolation: If a security policy is configured and the
+                code matches any pattern (or restricted-module import) at or
+                above the configured severity threshold.
+
+        """
+        if not self.config.security_policy:
+            return
+
+        is_safe, violations = self.is_safe(code)
+        if not is_safe:
+            threshold = self.config.security_policy.severity_threshold
+            raise SecurityPolicyViolation(violations=violations, severity_threshold=threshold)
 
     def install(self, libraries: list[str] | None = None) -> None:
         r"""Install libraries into the sandbox environment.
@@ -443,6 +482,7 @@ class BaseSession(
         timeout: float | None = None,
         on_stdout: StreamCallback | None = None,
         on_stderr: StreamCallback | None = None,
+        enforce_security_policy: bool = False,
     ) -> ConsoleOutput:
         r"""Run the provided code within the sandbox session.
 
@@ -467,6 +507,13 @@ class BaseSession(
                 worker thread; ensure your callback is thread-safe.
             on_stderr (StreamCallback | None): Optional callback invoked with each decoded stderr
                 chunk as it arrives during execution. Same threading note as ``on_stdout``.
+            enforce_security_policy (bool, optional): When ``True``, the configured
+                ``SecurityPolicy`` is enforced *before* any container interaction. If the
+                code matches any pattern (or restricted-module import) at or above the
+                configured severity threshold, a ``SecurityPolicyViolation`` is raised and
+                the code is never executed. Defaults to ``False`` for backwards
+                compatibility — callers wanting first-class enforcement should set this to
+                ``True`` (or use the ``safe_run`` wrapper).
 
         Returns:
             ConsoleOutput: An object containing the stdout, stderr, and exit code from the code execution.
@@ -474,8 +521,13 @@ class BaseSession(
         Raises:
             NotOpenSessionError: If the session (container) is not currently open/running.
             CommandFailedError: If any of the execution commands fail.
+            SecurityPolicyViolation: If ``enforce_security_policy=True`` and the code
+                violates the configured security policy.
 
         """
+        if enforce_security_policy:
+            self._enforce_security_policy(code)
+
         if not self.container or not self.is_open:
             raise NotOpenSessionError
 
@@ -539,6 +591,10 @@ class BaseSession(
         except SandboxTimeoutError:
             self._handle_timeout()
             raise
+
+    def safe_run(self, code: str, **kwargs: Any) -> ConsoleOutput:
+        r"""Run ``code`` with the configured security policy enforced (see :meth:`run`)."""
+        return self.run(code, enforce_security_policy=True, **kwargs)
 
     @abstractmethod
     def _handle_timeout(self) -> None:

--- a/llm_sandbox/exceptions.py
+++ b/llm_sandbox/exceptions.py
@@ -1,5 +1,10 @@
 """Custom exceptions for LLM Sandbox."""
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from llm_sandbox.security import SecurityIssueSeverity, SecurityPattern
+
 
 class SandboxError(Exception):
     """Base exception for all sandbox related errors."""
@@ -143,6 +148,53 @@ class SecurityViolationError(SandboxError):
     def __init__(self, message: str) -> None:
         """Initialize the SecurityViolationError."""
         super().__init__(message)
+
+
+class SecurityPolicyViolation(SecurityViolationError):  # noqa: N818
+    """Raised by the enforced execution path when a security policy blocks code.
+
+    This exception is raised by ``run(..., enforce_security_policy=True)`` and
+    ``safe_run(...)`` when the configured ``SecurityPolicy`` flags violations
+    that meet the severity threshold. The exception carries structured details
+    so callers can log, inspect, or surface them to end users without having to
+    reparse a string message.
+
+    Attributes:
+        violations: The list of ``SecurityPattern`` objects that were matched
+            by the policy scan, in the order they were detected. Patterns
+            generated from ``RestrictedModule`` entries appear here as well,
+            so a single ``violations`` list covers both pattern matches and
+            restricted-module imports.
+        severity_threshold: The ``SecurityIssueSeverity`` value the policy was
+            configured with at the time execution was blocked. Useful for
+            logging, metrics, or rendering a "blocked at level X" message.
+
+    """
+
+    def __init__(
+        self,
+        violations: "list[SecurityPattern]",
+        severity_threshold: "SecurityIssueSeverity | None" = None,
+    ) -> None:
+        """Initialize the SecurityPolicyViolation."""
+        self.violations = violations
+        self.severity_threshold = severity_threshold
+        super().__init__(self._format_message())
+
+    def _format_message(self) -> str:
+        """Build a human-readable message that lists every offending item."""
+        if not self.violations:
+            return "Security policy violation: code blocked by enforced security policy"
+
+        threshold_part = ""
+        if self.severity_threshold is not None:
+            threshold_part = f" (threshold: {self.severity_threshold.name})"
+
+        items = [
+            f"  - [{v.severity.name}] {v.description} (pattern: {v.pattern})" for v in self.violations
+        ]
+        header = f"Security policy violation{threshold_part}: {len(self.violations)} issue(s) detected"
+        return header + "\n" + "\n".join(items)
 
 
 class SandboxTimeoutError(SandboxError):

--- a/llm_sandbox/exceptions.py
+++ b/llm_sandbox/exceptions.py
@@ -190,9 +190,7 @@ class SecurityPolicyViolation(SecurityViolationError):  # noqa: N818
         if self.severity_threshold is not None:
             threshold_part = f" (threshold: {self.severity_threshold.name})"
 
-        items = [
-            f"  - [{v.severity.name}] {v.description} (pattern: {v.pattern})" for v in self.violations
-        ]
+        items = [f"  - [{v.severity.name}] {v.description} (pattern: {v.pattern})" for v in self.violations]
         header = f"Security policy violation{threshold_part}: {len(self.violations)} issue(s) detected"
         return header + "\n" + "\n".join(items)
 

--- a/llm_sandbox/interactive.py
+++ b/llm_sandbox/interactive.py
@@ -233,6 +233,7 @@ class InteractiveSandboxSession(BaseSession):
         timeout: float | None = None,
         on_stdout: Callable[[str], None] | None = None,  # noqa: ARG002
         on_stderr: Callable[[str], None] | None = None,  # noqa: ARG002
+        enforce_security_policy: bool = False,
     ) -> ConsoleOutput:
         """Execute code in the persistent interpreter context.
 
@@ -242,6 +243,8 @@ class InteractiveSandboxSession(BaseSession):
             timeout: Maximum execution time in seconds
             on_stdout: Not used in interactive sessions (accepted for API compatibility)
             on_stderr: Not used in interactive sessions (accepted for API compatibility)
+            enforce_security_policy: When True, enforce the configured security policy
+                before any container interaction. Defaults to False.
 
         Returns:
             ConsoleOutput containing stdout, stderr, and exit code
@@ -250,8 +253,13 @@ class InteractiveSandboxSession(BaseSession):
             NotOpenSessionError: If the session is not open
             ContainerError: If the interactive runtime is not ready
             SandboxTimeoutError: If execution exceeds timeout
+            SecurityPolicyViolation: If enforce_security_policy=True and the code
+                violates the configured security policy.
 
         """
+        if enforce_security_policy:
+            self._enforce_security_policy(code)
+
         if not self.container or not self.is_open:
             raise NotOpenSessionError
 

--- a/llm_sandbox/pool/session.py
+++ b/llm_sandbox/pool/session.py
@@ -303,6 +303,7 @@ class PooledSandboxSession:
         timeout: float | None = None,
         on_stdout: StreamCallback | None = None,
         on_stderr: StreamCallback | None = None,
+        enforce_security_policy: bool = False,
     ) -> ConsoleOutput:
         """Run code in the pooled container.
 
@@ -312,6 +313,8 @@ class PooledSandboxSession:
             timeout: Execution timeout
             on_stdout: Optional callback invoked with each decoded stdout chunk in real time.
             on_stderr: Optional callback invoked with each decoded stderr chunk in real time.
+            enforce_security_policy: When True, the configured security policy is
+                enforced before any container interaction. Defaults to False.
 
         Returns:
             ConsoleOutput with execution results
@@ -319,13 +322,45 @@ class PooledSandboxSession:
         Raises:
             NotOpenSessionError: If session is not open
             RuntimeError: If backend session is not initialized
+            SecurityPolicyViolation: If enforce_security_policy=True and the code
+                violates the configured security policy.
 
         """
         if not self._backend_session:
             raise SessionNotOpenError
 
         return self._backend_session.run(
-            code, libraries=libraries, timeout=timeout, on_stdout=on_stdout, on_stderr=on_stderr
+            code,
+            libraries=libraries,
+            timeout=timeout,
+            on_stdout=on_stdout,
+            on_stderr=on_stderr,
+            enforce_security_policy=enforce_security_policy,
+        )
+
+    def safe_run(
+        self,
+        code: str,
+        libraries: list | None = None,
+        timeout: float | None = None,
+        on_stdout: StreamCallback | None = None,
+        on_stderr: StreamCallback | None = None,
+    ) -> ConsoleOutput:
+        """Run code in the pooled container with the security policy enforced.
+
+        Thin wrapper over ``run(..., enforce_security_policy=True)``.
+
+        Raises:
+            SecurityPolicyViolation: If the code violates the configured policy.
+
+        """
+        return self.run(
+            code,
+            libraries=libraries,
+            timeout=timeout,
+            on_stdout=on_stdout,
+            on_stderr=on_stderr,
+            enforce_security_policy=True,
         )
 
     def execute_command(self, command: str, workdir: str | None = None) -> ConsoleOutput:
@@ -527,6 +562,7 @@ class ArtifactPooledSandboxSession:
         clear_plots: bool = False,
         on_stdout: StreamCallback | None = None,
         on_stderr: StreamCallback | None = None,
+        enforce_security_policy: bool = False,
     ) -> ExecutionResult:
         """Run code and extract artifacts.
 
@@ -537,9 +573,15 @@ class ArtifactPooledSandboxSession:
             clear_plots: Clear existing plots before running
             on_stdout: Optional callback invoked with each decoded stdout chunk in real time.
             on_stderr: Optional callback invoked with each decoded stderr chunk in real time.
+            enforce_security_policy: When True, enforce the configured security policy
+                before any container interaction. Defaults to False.
 
         Returns:
             ExecutionResult with plots
+
+        Raises:
+            SecurityPolicyViolation: If enforce_security_policy=True and the code
+                violates the configured security policy.
 
         """
         from llm_sandbox.data import ExecutionResult
@@ -547,6 +589,9 @@ class ArtifactPooledSandboxSession:
 
         # Get backend session
         backend_session = self._session.backend_session
+
+        if enforce_security_policy:
+            backend_session._enforce_security_policy(code)  # noqa: SLF001
 
         # Check if plotting is supported
         if self.enable_plotting and not backend_session.language_handler.is_support_plot_detection:
@@ -580,6 +625,33 @@ class ArtifactPooledSandboxSession:
             stdout=result.stdout,
             stderr=result.stderr,
             plots=plots,
+        )
+
+    def safe_run(
+        self,
+        code: str,
+        libraries: list | None = None,
+        timeout: float | None = None,
+        clear_plots: bool = False,
+        on_stdout: StreamCallback | None = None,
+        on_stderr: StreamCallback | None = None,
+    ) -> ExecutionResult:
+        """Run code in the pooled artifact session with security policy enforced.
+
+        Thin wrapper over ``run(..., enforce_security_policy=True)``.
+
+        Raises:
+            SecurityPolicyViolation: If the code violates the configured policy.
+
+        """
+        return self.run(
+            code,
+            libraries=libraries,
+            timeout=timeout,
+            clear_plots=clear_plots,
+            on_stdout=on_stdout,
+            on_stderr=on_stderr,
+            enforce_security_policy=True,
         )
 
     def _clear_plots_in_container(self) -> None:

--- a/llm_sandbox/pool/session.py
+++ b/llm_sandbox/pool/session.py
@@ -303,6 +303,7 @@ class PooledSandboxSession:
         timeout: float | None = None,
         on_stdout: StreamCallback | None = None,
         on_stderr: StreamCallback | None = None,
+        enforce_security_policy: bool = False,
     ) -> ConsoleOutput:
         """Run code in the pooled container.
 
@@ -312,6 +313,8 @@ class PooledSandboxSession:
             timeout: Execution timeout
             on_stdout: Optional callback invoked with each decoded stdout chunk in real time.
             on_stderr: Optional callback invoked with each decoded stderr chunk in real time.
+            enforce_security_policy: When True, the configured security policy is
+                enforced before any container interaction. Defaults to False.
 
         Returns:
             ConsoleOutput with execution results
@@ -319,14 +322,25 @@ class PooledSandboxSession:
         Raises:
             NotOpenSessionError: If session is not open
             RuntimeError: If backend session is not initialized
+            SecurityPolicyViolation: If enforce_security_policy=True and the code
+                violates the configured security policy.
 
         """
         if not self._backend_session:
             raise SessionNotOpenError
 
         return self._backend_session.run(
-            code, libraries=libraries, timeout=timeout, on_stdout=on_stdout, on_stderr=on_stderr
+            code,
+            libraries=libraries,
+            timeout=timeout,
+            on_stdout=on_stdout,
+            on_stderr=on_stderr,
+            enforce_security_policy=enforce_security_policy,
         )
+
+    def safe_run(self, code: str, **kwargs: Any) -> ConsoleOutput:
+        """Run ``code`` in the pooled container with the security policy enforced (see :meth:`run`)."""
+        return self.run(code, enforce_security_policy=True, **kwargs)
 
     def execute_command(self, command: str, workdir: str | None = None) -> ConsoleOutput:
         """Execute a command in the pooled container.
@@ -527,6 +541,7 @@ class ArtifactPooledSandboxSession:
         clear_plots: bool = False,
         on_stdout: StreamCallback | None = None,
         on_stderr: StreamCallback | None = None,
+        enforce_security_policy: bool = False,
     ) -> ExecutionResult:
         """Run code and extract artifacts.
 
@@ -537,9 +552,15 @@ class ArtifactPooledSandboxSession:
             clear_plots: Clear existing plots before running
             on_stdout: Optional callback invoked with each decoded stdout chunk in real time.
             on_stderr: Optional callback invoked with each decoded stderr chunk in real time.
+            enforce_security_policy: When True, enforce the configured security policy
+                before any container interaction. Defaults to False.
 
         Returns:
             ExecutionResult with plots
+
+        Raises:
+            SecurityPolicyViolation: If enforce_security_policy=True and the code
+                violates the configured security policy.
 
         """
         from llm_sandbox.data import ExecutionResult
@@ -547,6 +568,9 @@ class ArtifactPooledSandboxSession:
 
         # Get backend session
         backend_session = self._session.backend_session
+
+        if enforce_security_policy:
+            backend_session._enforce_security_policy(code)  # noqa: SLF001
 
         # Check if plotting is supported
         if self.enable_plotting and not backend_session.language_handler.is_support_plot_detection:
@@ -581,6 +605,10 @@ class ArtifactPooledSandboxSession:
             stderr=result.stderr,
             plots=plots,
         )
+
+    def safe_run(self, code: str, **kwargs: Any) -> ExecutionResult:
+        """Run ``code`` in the pooled artifact session with the security policy enforced (see :meth:`run`)."""
+        return self.run(code, enforce_security_policy=True, **kwargs)
 
     def _clear_plots_in_container(self) -> None:
         """Clear plots in the container."""

--- a/llm_sandbox/session.py
+++ b/llm_sandbox/session.py
@@ -530,6 +530,7 @@ class ArtifactSandboxSession:
         clear_plots: bool = False,
         on_stdout: StreamCallback | None = None,
         on_stderr: StreamCallback | None = None,
+        enforce_security_policy: bool = False,
     ) -> ExecutionResult:
         """Run code in the sandbox session and extract any generated artifacts.
 
@@ -552,6 +553,8 @@ class ArtifactSandboxSession:
                 chunk as it arrives during execution. Note: callbacks execute in a worker thread.
             on_stderr (StreamCallback | None): Optional callback invoked with each decoded stderr
                 chunk as it arrives during execution. Note: callbacks execute in a worker thread.
+            enforce_security_policy (bool, optional): When True, enforce the configured
+                security policy before any container interaction. Defaults to False.
 
         Returns:
             ExecutionResult: An object containing:
@@ -675,7 +678,11 @@ class ArtifactSandboxSession:
                 clear_plots=clear_plots,
                 on_stdout=on_stdout,
                 on_stderr=on_stderr,
+                enforce_security_policy=enforce_security_policy,
             )
+
+        if enforce_security_policy:
+            self._session._enforce_security_policy(code)  # type: ignore[union-attr]  # noqa: SLF001
 
         # Non-pooled implementation
         # Check if plotting is enabled and language supports it
@@ -710,6 +717,33 @@ class ArtifactSandboxSession:
             stdout=result.stdout,
             stderr=result.stderr,
             plots=plots,
+        )
+
+    def safe_run(
+        self,
+        code: str,
+        libraries: list | None = None,
+        timeout: float | None = None,
+        clear_plots: bool = False,
+        on_stdout: StreamCallback | None = None,
+        on_stderr: StreamCallback | None = None,
+    ) -> ExecutionResult:
+        """Run code with the configured security policy enforced.
+
+        Thin wrapper over ``run(..., enforce_security_policy=True)``.
+
+        Raises:
+            SecurityPolicyViolation: If the code violates the configured policy.
+
+        """
+        return self.run(
+            code,
+            libraries=libraries,
+            timeout=timeout,
+            clear_plots=clear_plots,
+            on_stdout=on_stdout,
+            on_stderr=on_stderr,
+            enforce_security_policy=True,
         )
 
     def _clear_plots_in_container(self) -> None:

--- a/llm_sandbox/session.py
+++ b/llm_sandbox/session.py
@@ -530,6 +530,7 @@ class ArtifactSandboxSession:
         clear_plots: bool = False,
         on_stdout: StreamCallback | None = None,
         on_stderr: StreamCallback | None = None,
+        enforce_security_policy: bool = False,
     ) -> ExecutionResult:
         """Run code in the sandbox session and extract any generated artifacts.
 
@@ -552,6 +553,8 @@ class ArtifactSandboxSession:
                 chunk as it arrives during execution. Note: callbacks execute in a worker thread.
             on_stderr (StreamCallback | None): Optional callback invoked with each decoded stderr
                 chunk as it arrives during execution. Note: callbacks execute in a worker thread.
+            enforce_security_policy (bool, optional): When True, enforce the configured
+                security policy before any container interaction. Defaults to False.
 
         Returns:
             ExecutionResult: An object containing:
@@ -675,7 +678,11 @@ class ArtifactSandboxSession:
                 clear_plots=clear_plots,
                 on_stdout=on_stdout,
                 on_stderr=on_stderr,
+                enforce_security_policy=enforce_security_policy,
             )
+
+        if enforce_security_policy:
+            self._session._enforce_security_policy(code)  # type: ignore[union-attr]  # noqa: SLF001
 
         # Non-pooled implementation
         # Check if plotting is enabled and language supports it
@@ -711,6 +718,10 @@ class ArtifactSandboxSession:
             stderr=result.stderr,
             plots=plots,
         )
+
+    def safe_run(self, code: str, **kwargs: Any) -> ExecutionResult:
+        """Run ``code`` with the configured security policy enforced (see :meth:`run`)."""
+        return self.run(code, enforce_security_policy=True, **kwargs)
 
     def _clear_plots_in_container(self) -> None:
         """Clear plots in the container."""

--- a/tests/test_enforced_security_policy.py
+++ b/tests/test_enforced_security_policy.py
@@ -1,0 +1,263 @@
+# ruff: noqa: SLF001, PLR2004, D102
+"""Unit tests for the enforced security-policy execution path (#160).
+
+These tests cover ``run(..., enforce_security_policy=True)`` and the
+``safe_run`` wrapper. They mock the container backend so the policy check
+fires before any container interaction.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llm_sandbox import SandboxSession
+from llm_sandbox.exceptions import SecurityPolicyViolation, SecurityViolationError
+from llm_sandbox.security import (
+    RestrictedModule,
+    SecurityIssueSeverity,
+    SecurityPattern,
+    SecurityPolicy,
+)
+
+pytestmark = pytest.mark.usefixtures("mock_docker_backend")
+
+
+@pytest.fixture
+def policy_high_threshold() -> SecurityPolicy:
+    """Policy that blocks at HIGH severity and above."""
+    return SecurityPolicy(
+        severity_threshold=SecurityIssueSeverity.HIGH,
+        patterns=[
+            SecurityPattern(
+                pattern=r"\bos\.system\s*\(",
+                description="System command execution",
+                severity=SecurityIssueSeverity.HIGH,
+            ),
+            SecurityPattern(
+                pattern=r"\beval\s*\(",
+                description="Dynamic code evaluation",
+                severity=SecurityIssueSeverity.MEDIUM,
+            ),
+        ],
+        restricted_modules=[
+            RestrictedModule(
+                name="subprocess",
+                description="Subprocess management",
+                severity=SecurityIssueSeverity.HIGH,
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def policy_low_threshold() -> SecurityPolicy:
+    """Policy that blocks at LOW severity and above."""
+    return SecurityPolicy(
+        severity_threshold=SecurityIssueSeverity.LOW,
+        patterns=[
+            SecurityPattern(
+                pattern=r"\bsocket\.socket\s*\(",
+                description="Raw socket creation",
+                severity=SecurityIssueSeverity.LOW,
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def policy_medium_threshold() -> SecurityPolicy:
+    """Policy that blocks at MEDIUM and above (LOW is allowed)."""
+    return SecurityPolicy(
+        severity_threshold=SecurityIssueSeverity.MEDIUM,
+        patterns=[
+            SecurityPattern(
+                pattern=r"\bsocket\.socket\s*\(",
+                description="Raw socket creation",
+                severity=SecurityIssueSeverity.LOW,
+            ),
+        ],
+    )
+
+
+class TestBackwardsCompatibility:
+    """Default behavior must not change for callers that don't opt in."""
+
+    def test_default_false_does_not_enforce_even_with_unsafe_code(
+        self, policy_high_threshold: SecurityPolicy
+    ) -> None:
+        """run() without the kwarg should never check the policy."""
+        session = SandboxSession(lang="python", security_policy=policy_high_threshold)
+
+        unsafe_code = "import os\nos.system('rm -rf /')"
+        # Should not raise SecurityPolicyViolation. Container is mocked, so
+        # the real run path will fail later for unrelated reasons - all we
+        # care about is that the *policy* did not block.
+        with patch.object(session, "container", MagicMock()), patch.object(
+            session, "is_open", new=True
+        ), patch.object(session, "_execute_with_timeout", return_value=MagicMock(exit_code=0)):
+            result = session.run(unsafe_code)
+            assert result.exit_code == 0
+
+
+class TestEnforcedExecutionBlocksUnsafeCode:
+    """``enforce_security_policy=True`` blocks code that meets the threshold."""
+
+    def test_high_severity_pattern_raises(
+        self, policy_high_threshold: SecurityPolicy
+    ) -> None:
+        session = SandboxSession(lang="python", security_policy=policy_high_threshold)
+
+        unsafe_code = "import os\nos.system('echo hi')"
+
+        # The session container is intentionally NOT mocked-as-open: the
+        # policy check must run *before* any session-state checks, so
+        # SecurityPolicyViolation must be raised even on a closed session.
+        with pytest.raises(SecurityPolicyViolation) as exc_info:
+            session.run(unsafe_code, enforce_security_policy=True)
+
+        exc = exc_info.value
+        assert isinstance(exc, SecurityViolationError)  # subclass relationship
+        assert exc.severity_threshold == SecurityIssueSeverity.HIGH
+        assert any(v.description == "System command execution" for v in exc.violations)
+
+    def test_restricted_module_import_raises_with_module_listed(
+        self, policy_high_threshold: SecurityPolicy
+    ) -> None:
+        session = SandboxSession(lang="python", security_policy=policy_high_threshold)
+
+        unsafe_code = "import subprocess\nsubprocess.run(['ls'])"
+
+        with pytest.raises(SecurityPolicyViolation) as exc_info:
+            session.run(unsafe_code, enforce_security_policy=True)
+
+        exc = exc_info.value
+        # The restricted module's description should be carried through on
+        # the auto-generated pattern.
+        assert any(v.description == "Subprocess management" for v in exc.violations)
+        # __str__ must mention the offending description.
+        assert "Subprocess management" in str(exc)
+
+    def test_low_threshold_blocks_low_severity(
+        self, policy_low_threshold: SecurityPolicy
+    ) -> None:
+        session = SandboxSession(lang="python", security_policy=policy_low_threshold)
+
+        unsafe_code = "import socket\ns = socket.socket()"
+
+        with pytest.raises(SecurityPolicyViolation) as exc_info:
+            session.run(unsafe_code, enforce_security_policy=True)
+
+        assert exc_info.value.severity_threshold == SecurityIssueSeverity.LOW
+
+    def test_medium_threshold_does_not_block_low_severity(
+        self, policy_medium_threshold: SecurityPolicy
+    ) -> None:
+        """Under-threshold matches must NOT raise."""
+        session = SandboxSession(lang="python", security_policy=policy_medium_threshold)
+
+        below_threshold_code = "import socket\ns = socket.socket()"
+
+        # Container path mocked so that, after passing the policy check, the
+        # call returns a stub ConsoleOutput. The point is no exception.
+        with patch.object(session, "container", MagicMock()), patch.object(
+            session, "is_open", new=True
+        ), patch.object(session, "_execute_with_timeout", return_value=MagicMock(exit_code=0)):
+            session.run(below_threshold_code, enforce_security_policy=True)
+
+
+class TestEnforcedExecutionAllowsSafeCode:
+    """Safe code must run when ``enforce_security_policy=True``."""
+
+    def test_safe_code_runs(self, policy_high_threshold: SecurityPolicy) -> None:
+        session = SandboxSession(lang="python", security_policy=policy_high_threshold)
+
+        safe_code = "print('hello world')\nx = 1 + 1"
+
+        with patch.object(session, "container", MagicMock()), patch.object(
+            session, "is_open", new=True
+        ), patch.object(session, "_execute_with_timeout", return_value=MagicMock(exit_code=0)):
+            result = session.run(safe_code, enforce_security_policy=True)
+            assert result.exit_code == 0
+
+
+class TestSafeRunWrapper:
+    """``safe_run`` is the ergonomic alias for the enforced path."""
+
+    def test_safe_run_blocks_unsafe_code(
+        self, policy_high_threshold: SecurityPolicy
+    ) -> None:
+        session = SandboxSession(lang="python", security_policy=policy_high_threshold)
+
+        with pytest.raises(SecurityPolicyViolation):
+            session.safe_run("import os\nos.system('id')")
+
+    def test_safe_run_runs_safe_code(
+        self, policy_high_threshold: SecurityPolicy
+    ) -> None:
+        session = SandboxSession(lang="python", security_policy=policy_high_threshold)
+
+        with patch.object(session, "container", MagicMock()), patch.object(
+            session, "is_open", new=True
+        ), patch.object(session, "_execute_with_timeout", return_value=MagicMock(exit_code=0)):
+            result = session.safe_run("print(2 + 2)")
+            assert result.exit_code == 0
+
+
+class TestSecurityPolicyViolationStructure:
+    """The exception itself carries structured details."""
+
+    def test_violations_populated(self, policy_high_threshold: SecurityPolicy) -> None:
+        session = SandboxSession(lang="python", security_policy=policy_high_threshold)
+
+        with pytest.raises(SecurityPolicyViolation) as exc_info:
+            session.run("import os\nos.system('echo hi')", enforce_security_policy=True)
+
+        exc = exc_info.value
+        assert len(exc.violations) >= 1
+        for v in exc.violations:
+            assert isinstance(v, SecurityPattern)
+
+    def test_severity_threshold_populated(
+        self, policy_low_threshold: SecurityPolicy
+    ) -> None:
+        session = SandboxSession(lang="python", security_policy=policy_low_threshold)
+
+        with pytest.raises(SecurityPolicyViolation) as exc_info:
+            session.run("import socket\ns = socket.socket()", enforce_security_policy=True)
+
+        assert exc_info.value.severity_threshold == SecurityIssueSeverity.LOW
+
+    def test_str_lists_offending_items(
+        self, policy_high_threshold: SecurityPolicy
+    ) -> None:
+        session = SandboxSession(lang="python", security_policy=policy_high_threshold)
+
+        with pytest.raises(SecurityPolicyViolation) as exc_info:
+            session.run("import os\nos.system('echo hi')", enforce_security_policy=True)
+
+        message = str(exc_info.value)
+        assert "Security policy violation" in message
+        assert "System command execution" in message
+        assert "HIGH" in message  # threshold name appears in the header
+
+    def test_no_policy_means_no_enforcement(self) -> None:
+        """Even with enforce_security_policy=True, no policy => no raise."""
+        session = SandboxSession(lang="python")  # no security_policy
+
+        with patch.object(session, "container", MagicMock()), patch.object(
+            session, "is_open", new=True
+        ), patch.object(session, "_execute_with_timeout", return_value=MagicMock(exit_code=0)):
+            session.run("import os\nos.system('id')", enforce_security_policy=True)
+
+
+class TestPreContainerCheckTiming:
+    """Policy enforcement happens *before* any container interaction."""
+
+    def test_policy_violation_raised_before_session_open_check(
+        self, policy_high_threshold: SecurityPolicy
+    ) -> None:
+        """Closed session + unsafe code => SecurityPolicyViolation, not NotOpenSessionError."""
+        session = SandboxSession(lang="python", security_policy=policy_high_threshold)
+        # Session is intentionally closed (container=None, is_open=False).
+        with pytest.raises(SecurityPolicyViolation):
+            session.run("import os\nos.system('id')", enforce_security_policy=True)

--- a/tests/test_enforced_security_policy.py
+++ b/tests/test_enforced_security_policy.py
@@ -82,9 +82,7 @@ def policy_medium_threshold() -> SecurityPolicy:
 class TestBackwardsCompatibility:
     """Default behavior must not change for callers that don't opt in."""
 
-    def test_default_false_does_not_enforce_even_with_unsafe_code(
-        self, policy_high_threshold: SecurityPolicy
-    ) -> None:
+    def test_default_false_does_not_enforce_even_with_unsafe_code(self, policy_high_threshold: SecurityPolicy) -> None:
         """run() without the kwarg should never check the policy."""
         session = SandboxSession(lang="python", security_policy=policy_high_threshold)
 
@@ -92,9 +90,11 @@ class TestBackwardsCompatibility:
         # Should not raise SecurityPolicyViolation. Container is mocked, so
         # the real run path will fail later for unrelated reasons - all we
         # care about is that the *policy* did not block.
-        with patch.object(session, "container", MagicMock()), patch.object(
-            session, "is_open", new=True
-        ), patch.object(session, "_execute_with_timeout", return_value=MagicMock(exit_code=0)):
+        with (
+            patch.object(session, "container", MagicMock()),
+            patch.object(session, "is_open", new=True),
+            patch.object(session, "_execute_with_timeout", return_value=MagicMock(exit_code=0)),
+        ):
             result = session.run(unsafe_code)
             assert result.exit_code == 0
 
@@ -102,9 +102,7 @@ class TestBackwardsCompatibility:
 class TestEnforcedExecutionBlocksUnsafeCode:
     """``enforce_security_policy=True`` blocks code that meets the threshold."""
 
-    def test_high_severity_pattern_raises(
-        self, policy_high_threshold: SecurityPolicy
-    ) -> None:
+    def test_high_severity_pattern_raises(self, policy_high_threshold: SecurityPolicy) -> None:
         session = SandboxSession(lang="python", security_policy=policy_high_threshold)
 
         unsafe_code = "import os\nos.system('echo hi')"
@@ -120,9 +118,7 @@ class TestEnforcedExecutionBlocksUnsafeCode:
         assert exc.severity_threshold == SecurityIssueSeverity.HIGH
         assert any(v.description == "System command execution" for v in exc.violations)
 
-    def test_restricted_module_import_raises_with_module_listed(
-        self, policy_high_threshold: SecurityPolicy
-    ) -> None:
+    def test_restricted_module_import_raises_with_module_listed(self, policy_high_threshold: SecurityPolicy) -> None:
         session = SandboxSession(lang="python", security_policy=policy_high_threshold)
 
         unsafe_code = "import subprocess\nsubprocess.run(['ls'])"
@@ -137,9 +133,7 @@ class TestEnforcedExecutionBlocksUnsafeCode:
         # __str__ must mention the offending description.
         assert "Subprocess management" in str(exc)
 
-    def test_low_threshold_blocks_low_severity(
-        self, policy_low_threshold: SecurityPolicy
-    ) -> None:
+    def test_low_threshold_blocks_low_severity(self, policy_low_threshold: SecurityPolicy) -> None:
         session = SandboxSession(lang="python", security_policy=policy_low_threshold)
 
         unsafe_code = "import socket\ns = socket.socket()"
@@ -149,9 +143,7 @@ class TestEnforcedExecutionBlocksUnsafeCode:
 
         assert exc_info.value.severity_threshold == SecurityIssueSeverity.LOW
 
-    def test_medium_threshold_does_not_block_low_severity(
-        self, policy_medium_threshold: SecurityPolicy
-    ) -> None:
+    def test_medium_threshold_does_not_block_low_severity(self, policy_medium_threshold: SecurityPolicy) -> None:
         """Under-threshold matches must NOT raise."""
         session = SandboxSession(lang="python", security_policy=policy_medium_threshold)
 
@@ -159,9 +151,11 @@ class TestEnforcedExecutionBlocksUnsafeCode:
 
         # Container path mocked so that, after passing the policy check, the
         # call returns a stub ConsoleOutput. The point is no exception.
-        with patch.object(session, "container", MagicMock()), patch.object(
-            session, "is_open", new=True
-        ), patch.object(session, "_execute_with_timeout", return_value=MagicMock(exit_code=0)):
+        with (
+            patch.object(session, "container", MagicMock()),
+            patch.object(session, "is_open", new=True),
+            patch.object(session, "_execute_with_timeout", return_value=MagicMock(exit_code=0)),
+        ):
             session.run(below_threshold_code, enforce_security_policy=True)
 
 
@@ -173,9 +167,11 @@ class TestEnforcedExecutionAllowsSafeCode:
 
         safe_code = "print('hello world')\nx = 1 + 1"
 
-        with patch.object(session, "container", MagicMock()), patch.object(
-            session, "is_open", new=True
-        ), patch.object(session, "_execute_with_timeout", return_value=MagicMock(exit_code=0)):
+        with (
+            patch.object(session, "container", MagicMock()),
+            patch.object(session, "is_open", new=True),
+            patch.object(session, "_execute_with_timeout", return_value=MagicMock(exit_code=0)),
+        ):
             result = session.run(safe_code, enforce_security_policy=True)
             assert result.exit_code == 0
 
@@ -183,22 +179,20 @@ class TestEnforcedExecutionAllowsSafeCode:
 class TestSafeRunWrapper:
     """``safe_run`` is the ergonomic alias for the enforced path."""
 
-    def test_safe_run_blocks_unsafe_code(
-        self, policy_high_threshold: SecurityPolicy
-    ) -> None:
+    def test_safe_run_blocks_unsafe_code(self, policy_high_threshold: SecurityPolicy) -> None:
         session = SandboxSession(lang="python", security_policy=policy_high_threshold)
 
         with pytest.raises(SecurityPolicyViolation):
             session.safe_run("import os\nos.system('id')")
 
-    def test_safe_run_runs_safe_code(
-        self, policy_high_threshold: SecurityPolicy
-    ) -> None:
+    def test_safe_run_runs_safe_code(self, policy_high_threshold: SecurityPolicy) -> None:
         session = SandboxSession(lang="python", security_policy=policy_high_threshold)
 
-        with patch.object(session, "container", MagicMock()), patch.object(
-            session, "is_open", new=True
-        ), patch.object(session, "_execute_with_timeout", return_value=MagicMock(exit_code=0)):
+        with (
+            patch.object(session, "container", MagicMock()),
+            patch.object(session, "is_open", new=True),
+            patch.object(session, "_execute_with_timeout", return_value=MagicMock(exit_code=0)),
+        ):
             result = session.safe_run("print(2 + 2)")
             assert result.exit_code == 0
 
@@ -217,9 +211,7 @@ class TestSecurityPolicyViolationStructure:
         for v in exc.violations:
             assert isinstance(v, SecurityPattern)
 
-    def test_severity_threshold_populated(
-        self, policy_low_threshold: SecurityPolicy
-    ) -> None:
+    def test_severity_threshold_populated(self, policy_low_threshold: SecurityPolicy) -> None:
         session = SandboxSession(lang="python", security_policy=policy_low_threshold)
 
         with pytest.raises(SecurityPolicyViolation) as exc_info:
@@ -227,9 +219,7 @@ class TestSecurityPolicyViolationStructure:
 
         assert exc_info.value.severity_threshold == SecurityIssueSeverity.LOW
 
-    def test_str_lists_offending_items(
-        self, policy_high_threshold: SecurityPolicy
-    ) -> None:
+    def test_str_lists_offending_items(self, policy_high_threshold: SecurityPolicy) -> None:
         session = SandboxSession(lang="python", security_policy=policy_high_threshold)
 
         with pytest.raises(SecurityPolicyViolation) as exc_info:
@@ -244,18 +234,18 @@ class TestSecurityPolicyViolationStructure:
         """Even with enforce_security_policy=True, no policy => no raise."""
         session = SandboxSession(lang="python")  # no security_policy
 
-        with patch.object(session, "container", MagicMock()), patch.object(
-            session, "is_open", new=True
-        ), patch.object(session, "_execute_with_timeout", return_value=MagicMock(exit_code=0)):
+        with (
+            patch.object(session, "container", MagicMock()),
+            patch.object(session, "is_open", new=True),
+            patch.object(session, "_execute_with_timeout", return_value=MagicMock(exit_code=0)),
+        ):
             session.run("import os\nos.system('id')", enforce_security_policy=True)
 
 
 class TestPreContainerCheckTiming:
     """Policy enforcement happens *before* any container interaction."""
 
-    def test_policy_violation_raised_before_session_open_check(
-        self, policy_high_threshold: SecurityPolicy
-    ) -> None:
+    def test_policy_violation_raised_before_session_open_check(self, policy_high_threshold: SecurityPolicy) -> None:
         """Closed session + unsafe code => SecurityPolicyViolation, not NotOpenSessionError."""
         session = SandboxSession(lang="python", security_policy=policy_high_threshold)
         # Session is intentionally closed (container=None, is_open=False).

--- a/tests/test_streaming_callbacks.py
+++ b/tests/test_streaming_callbacks.py
@@ -537,6 +537,7 @@ class TestPooledSessionCallbackPropagation:
             timeout=None,
             on_stdout=on_stdout,
             on_stderr=on_stderr,
+            enforce_security_policy=False,
         )
 
     def test_artifact_pooled_session_run_accepts_callbacks(self) -> None:


### PR DESCRIPTION
Closes #160.

## Why

The security guide currently documents that `SecurityPolicy` is **advisory** and must be checked manually with `session.is_safe(code)` before `session.run(code)`. The check-then-run pattern is easy for users and integrations to forget. For a sandboxing library, an enforced path that blocks execution when the policy fires belongs as a first-class API.

## What

Opt-in enforcement on `run()`, plus a `safe_run()` wrapper for ergonomic discoverability:

```python
from llm_sandbox import SandboxSession
from llm_sandbox.exceptions import SecurityPolicyViolation
from llm_sandbox.security import RestrictedModule, SecurityIssueSeverity, SecurityPolicy

policy = SecurityPolicy(
    severity_threshold=SecurityIssueSeverity.HIGH,
    restricted_modules=[
        RestrictedModule(
            name="subprocess",
            description="Process execution",
            severity=SecurityIssueSeverity.HIGH,
        ),
    ],
)

with SandboxSession(lang="python", security_policy=policy) as session:
    code = "import subprocess\nsubprocess.run(['ls'])"
    try:
        result = session.run(code, enforce_security_policy=True)
        # equivalent: result = session.safe_run(code)
    except SecurityPolicyViolation as exc:
        print(f"Blocked at {exc.severity_threshold.name}:")
        for v in exc.violations:
            print(f"  - {v.description} ({v.severity.name})")
```

When `enforce_security_policy=True` and the configured policy detects violations at or above the threshold, a `SecurityPolicyViolation` exception is raised. The exception is a subclass of the existing `SecurityViolationError` and carries:

- `violations: list[SecurityPattern]` - every matched pattern, in detection order. Patterns auto-generated from `RestrictedModule` entries appear here too, so a single list covers both pattern matches and restricted-module imports.
- `severity_threshold: SecurityIssueSeverity | None` - the threshold the policy was configured with at the time of blocking.
- `__str__` - lists each offending item with its severity and description, so the message is useful in logs / surfaced errors without unpacking attributes.

The check fires **before any container interaction** so policy-blocked code never pays the container-spinup cost.

## Acceptance criteria from #160

1. **Opt-in enforced API** - `enforce_security_policy=True` kwarg on `run()` plus `safe_run()` wrapper. Both are wired through `BaseSession`, `InteractiveSandboxSession`, `PooledSandboxSession`, `ArtifactSandboxSession`, and `ArtifactPooledSandboxSession`.
2. **Structured error containing violations** - `SecurityPolicyViolation` exposes `violations` and `severity_threshold` as typed attributes; `__str__` formats them.
3. **Backwards compatible advisory behavior** - the new kwarg defaults to `False`. `is_safe()` is unchanged. Existing callers using the manual check-then-execute pattern keep working with no behavior change.
4. **Tests** - new `tests/test_enforced_security_policy.py` covers safe code, blocked code (HIGH and LOW), severity thresholds (under-threshold does not raise), restricted-module imports, exception structure, and pre-container check timing. 13 new tests, all green.
5. **Docs** - new "Enforcing the security policy" section in `docs/security.md` recommends the enforced path for production.

## Tests

- 13 new tests in `tests/test_enforced_security_policy.py`
- Existing `tests/test_streaming_callbacks.py::test_pooled_session_run_accepts_callbacks` updated for the new forwarded kwarg
- Full test suite: 1107 passed, 2 skipped, ruff clean

## Notes

- The new kwarg defaults to `False`, preserving the advisory contract documented today. The docs page now leads with "prefer the enforced execution path below" so newcomers find it first.
- The check reuses the existing `is_safe()` machinery via a small `_enforce_security_policy(code)` helper on `BaseSession`; no scanning logic is duplicated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional security-policy enforcement before code execution and container interaction.
  * Added `safe_run()` for execution with policy checks enabled by default.
  * Blocked code now raises `SecurityPolicyViolation` with violation details and severity information.
  * Existing execution behavior remains unchanged unless enforcement is enabled.

* **Documentation**
  * Expanded security guidance, exception details, and recommended production usage.

* **Tests**
  * Added coverage for enforcement, safe execution, violation reporting, and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->