### PR TITLE
fix(mcp): make container and template persistence opt-in (#161)

### DIFF
--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -162,15 +162,29 @@ If you encounter connection issues with your backend, you may need to specify ad
 - `DOCKER_HOST`: Specify the Docker daemon socket (default: `unix:///var/run/docker.sock`)
 - `KUBECONFIG`: Path to your Kubernetes configuration file
 - `BACKEND`: Choose your container backend (`docker`, `podman`, or `kubernetes`)
-- `COMMIT_CONTAINER`: Control whether container changes are saved to the image (default: `true`)
-- `KEEP_TEMPLATE`: Control whether template containers are preserved (default: `true`)
+- `COMMIT_CONTAINER`: Control whether container changes are saved to the image (default: `false`)
+- `KEEP_TEMPLATE`: Control whether template images are preserved between sessions (default: `true`)
 - `NAMESPACE`: Specify Kubernetes namespace for pod creation (default: `default`)
 
-### Container Behavior Control
+### Persistence and security
 
-The MCP server provides fine-grained control over container behavior through environment variables:
+The MCP server runs code that an AI client supplied, which means the code is effectively
+attacker-controlled from the sandbox's point of view. Persisting state from one request
+into the next can carry side effects of one request into another, so the defaults are
+chosen to make persistence opt-in:
 
-**Prevent Container Image Changes:**
+- `COMMIT_CONTAINER` defaults to `false`. When you opt in, the server commits to a
+  unique tag of the form `llm-sandbox-mcp/<lang>:<short-hex>` instead of overwriting
+  the source image's tag. The pristine source image (e.g. `python:3.11-bullseye`) is
+  never modified, so a poisoned commit cannot silently land in a future session that
+  pulls the source tag.
+- `KEEP_TEMPLATE` defaults to `true`. The template image here is the upstream base
+  image, not container state, so reusing it between requests is safe and avoids
+  re-pulling on every call. If you would rather pay the pull cost for stricter
+  hygiene, set `KEEP_TEMPLATE=false`.
+
+If you want commit support, opt in explicitly:
+
 ```json
 {
   "mcpServers": {
@@ -179,14 +193,15 @@ The MCP server provides fine-grained control over container behavior through env
       "args": ["-m", "llm_sandbox.mcp_server.server"],
       "env": {
         "BACKEND": "docker",
-        "COMMIT_CONTAINER": "false"
+        "COMMIT_CONTAINER": "true"
       }
     }
   }
 }
 ```
 
-**Prevent Template Container Preservation:**
+To also drop the template image after each session:
+
 ```json
 {
   "mcpServers": {
@@ -202,22 +217,8 @@ The MCP server provides fine-grained control over container behavior through env
 }
 ```
 
-**Both Settings for Minimal Container Footprint:**
-```json
-{
-  "mcpServers": {
-    "llm-sandbox": {
-      "command": "python3",
-      "args": ["-m", "llm_sandbox.mcp_server.server"],
-      "env": {
-        "BACKEND": "docker",
-        "COMMIT_CONTAINER": "false",
-        "KEEP_TEMPLATE": "false"
-      }
-    }
-  }
-}
-```
+The Kubernetes and Podman backends ignore the unique-tag commit logic; only Docker
+and Micromamba support `commit_image_tag` in this version.
 
 ### Runtime Configuration via Environment Variables
 
@@ -271,10 +272,11 @@ Both `COMMIT_CONTAINER` and `KEEP_TEMPLATE` accept:
 - `"false"`, `"0"`, `"no"`, `"off"` → `False`
 
 **Use Cases:**
-- `COMMIT_CONTAINER=false`: Prevent Docker images from growing over time, useful in CI/CD or automated environments
-- `KEEP_TEMPLATE=false`: Clean up template containers automatically, reduces Docker container clutter
+- `COMMIT_CONTAINER=true`: Persist incremental container state across MCP requests
+  (e.g. shared package installs). Commits land on a unique tag, never on the source image.
+- `KEEP_TEMPLATE=false`: Drop the template image after every session. Slower (re-pulls
+  on each call) but leaves nothing behind on disk.
 - `NAMESPACE="custom-namespace"`: Organize Kubernetes pods in specific namespaces for multi-tenant environments
-- Both disabled: Minimal resource usage, ideal for ephemeral environments
 
 ## Available Tools
 

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -175,15 +175,34 @@ If you encounter connection issues with your backend, you may need to specify ad
 - `DOCKER_HOST`: Specify the Docker daemon socket (default: `unix:///var/run/docker.sock`)
 - `KUBECONFIG`: Path to your Kubernetes configuration file
 - `BACKEND`: Choose your container backend (`docker`, `podman`, or `kubernetes`)
-- `COMMIT_CONTAINER`: Control whether container changes are saved to the image (default: `true`)
-- `KEEP_TEMPLATE`: Control whether template containers are preserved (default: `true`)
+- `COMMIT_CONTAINER`: Control whether container changes are saved to the image (default: `false`)
+- `KEEP_TEMPLATE`: Control whether template images are preserved between sessions (default: `true`)
 - `NAMESPACE`: Specify Kubernetes namespace for pod creation (default: `default`)
 
-### Container Behavior Control
+### Persistence and security
 
-The MCP server provides fine-grained control over container behavior through environment variables:
+The MCP server runs code that an AI client supplied, which means the code is effectively
+attacker-controlled from the sandbox's point of view. Persisting state from one request
+into the next can carry side effects of one request into another, so the defaults are
+chosen to make persistence opt-in:
 
-**Prevent Container Image Changes:**
+> **Behaviour change**: previous versions committed the container after every call by
+> default, so libraries installed in one MCP request (e.g. via `pip install`) persisted
+> into subsequent requests. Persistence is now off by default — set
+> `COMMIT_CONTAINER=true` to restore the previous behaviour.
+
+- `COMMIT_CONTAINER` defaults to `false`. When you opt in, the server commits to a
+  unique tag of the form `llm-sandbox-mcp/<lang>:<short-hex>` instead of overwriting
+  the source image's tag. The pristine source image (e.g. `python:3.11-bullseye`) is
+  never modified, so a poisoned commit cannot silently land in a future session that
+  pulls the source tag.
+- `KEEP_TEMPLATE` defaults to `true`. The template image here is the upstream base
+  image, not container state, so reusing it between requests is safe and avoids
+  re-pulling on every call. If you would rather pay the pull cost for stricter
+  hygiene, set `KEEP_TEMPLATE=false`.
+
+If you want commit support, opt in explicitly:
+
 ```json
 {
   "mcpServers": {
@@ -192,14 +211,15 @@ The MCP server provides fine-grained control over container behavior through env
       "args": ["-m", "llm_sandbox.mcp_server.server"],
       "env": {
         "BACKEND": "docker",
-        "COMMIT_CONTAINER": "false"
+        "COMMIT_CONTAINER": "true"
       }
     }
   }
 }
 ```
 
-**Prevent Template Container Preservation:**
+To also drop the template image after each session:
+
 ```json
 {
   "mcpServers": {
@@ -208,6 +228,7 @@ The MCP server provides fine-grained control over container behavior through env
       "args": ["-m", "llm_sandbox.mcp_server.server"],
       "env": {
         "BACKEND": "docker",
+        "COMMIT_CONTAINER": "true",
         "KEEP_TEMPLATE": "false"
       }
     }
@@ -215,22 +236,8 @@ The MCP server provides fine-grained control over container behavior through env
 }
 ```
 
-**Both Settings for Minimal Container Footprint:**
-```json
-{
-  "mcpServers": {
-    "llm-sandbox": {
-      "command": "python3",
-      "args": ["-m", "llm_sandbox.mcp_server.server"],
-      "env": {
-        "BACKEND": "docker",
-        "COMMIT_CONTAINER": "false",
-        "KEEP_TEMPLATE": "false"
-      }
-    }
-  }
-}
-```
+The Kubernetes and Podman backends ignore the unique-tag commit logic; only Docker
+and Micromamba support `commit_image_tag` in this version.
 
 ### Runtime Configuration via Environment Variables
 
@@ -284,10 +291,11 @@ Both `COMMIT_CONTAINER` and `KEEP_TEMPLATE` accept:
 - `"false"`, `"0"`, `"no"`, `"off"` → `False`
 
 **Use Cases:**
-- `COMMIT_CONTAINER=false`: Prevent Docker images from growing over time, useful in CI/CD or automated environments
-- `KEEP_TEMPLATE=false`: Clean up template containers automatically, reduces Docker container clutter
+- `COMMIT_CONTAINER=true`: Persist incremental container state across MCP requests
+  (e.g. shared package installs). Commits land on a unique tag, never on the source image.
+- `KEEP_TEMPLATE=false`: Drop the template image after every session. Slower (re-pulls
+  on each call) but leaves nothing behind on disk.
 - `NAMESPACE="custom-namespace"`: Organize Kubernetes pods in specific namespaces for multi-tenant environments
-- Both disabled: Minimal resource usage, ideal for ephemeral environments
 
 ## Available Tools
 

--- a/llm_sandbox/docker.py
+++ b/llm_sandbox/docker.py
@@ -94,6 +94,7 @@ class SandboxDockerSession(BaseSession):
         lang: str = SupportedLanguage.PYTHON,
         keep_template: bool = False,
         commit_container: bool = False,
+        commit_image_tag: str | None = None,
         verbose: bool = False,
         stream: bool = False,
         runtime_configs: dict | None = None,
@@ -116,6 +117,10 @@ class SandboxDockerSession(BaseSession):
             lang (str): The language to use.
             keep_template (bool): Whether to keep the template image.
             commit_container (bool): Whether to commit the container to a new image.
+            commit_image_tag (str | None): Optional explicit ``repository:tag`` target for commit.
+                When set and ``commit_container`` is True, the container is committed to this tag
+                instead of the source image's existing tag, so untrusted execution side effects
+                never overwrite the source image.
             verbose (bool): Whether to enable verbose output.
             stream (bool): Whether to stream the output.
             runtime_configs (dict | None): The runtime configurations to use.
@@ -164,6 +169,7 @@ class SandboxDockerSession(BaseSession):
         self.docker_image: Image
         self.keep_template: bool = keep_template
         self.commit_container: bool = commit_container
+        self.commit_image_tag: str | None = commit_image_tag
         self.is_create_template: bool = False
         self.stream: bool = stream
 
@@ -433,8 +439,16 @@ class SandboxDockerSession(BaseSession):
 
     def _commit_container(self) -> None:
         """Commit container to new image."""
-        if self.docker_image and self.docker_image.tags:
+        full_tag: str | None = None
+        # ``getattr`` keeps subclasses (e.g. SandboxPodmanSession) working without
+        # forcing every subclass to wire the new opt-in commit-tag through __init__.
+        explicit_tag = getattr(self, "commit_image_tag", None)
+        if explicit_tag:
+            full_tag = explicit_tag
+        elif self.docker_image and self.docker_image.tags:
             full_tag = self.docker_image.tags[-1]
+
+        if full_tag:
             repository, tag = full_tag.rsplit(":", 1) if ":" in full_tag else (full_tag, "latest")
             try:
                 self.container.commit(repository=repository, tag=tag)

--- a/llm_sandbox/mcp_server/server.py
+++ b/llm_sandbox/mcp_server/server.py
@@ -6,6 +6,7 @@ A Model Context Protocol server that provides secure code execution capabilities
 import json
 import logging
 import os
+import uuid
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
@@ -53,15 +54,37 @@ def _get_backend() -> SandboxBackend:
 
 
 def _get_commit_container() -> bool:
-    """Get the commit_container setting from environment variable."""
-    commit_container_env = os.environ.get("COMMIT_CONTAINER", "true").lower()
+    """Get the commit_container setting from environment variable.
+
+    Defaults to ``False`` because MCP clients pass attacker-controlled code into the
+    sandbox; persisting container state to the source image by default would let one
+    request's side effects bleed into later sessions.
+    """
+    commit_container_env = os.environ.get("COMMIT_CONTAINER", "false").lower()
     return commit_container_env in _TRUE_ENV_VALUES
 
 
 def _get_keep_template() -> bool:
-    """Get the keep_template setting from environment variable."""
+    """Get the keep_template setting from environment variable.
+
+    Defaults to ``True``: the template image is the pristine upstream base image
+    (e.g. ``python:3.11-bullseye``). It contains no untrusted state, and reusing it
+    between MCP requests avoids re-pulling on every call. Untrusted state is gated
+    separately by ``COMMIT_CONTAINER``.
+    """
     keep_template_env = os.environ.get("KEEP_TEMPLATE", "true").lower()
     return keep_template_env in _TRUE_ENV_VALUES
+
+
+def _build_commit_image_tag(language: str) -> str:
+    """Build a unique opt-in commit tag so commits never overwrite the source image.
+
+    Format: ``llm-sandbox-mcp/<language>:<short-uuid>``. A fresh tag per session means
+    one request's persisted state can never silently land in another session that
+    happened to reuse the same base image.
+    """
+    short = uuid.uuid4().hex[:12]
+    return f"llm-sandbox-mcp/{language.lower()}:{short}"
 
 
 def _get_kube_namespace() -> str:
@@ -249,15 +272,18 @@ def execute_code(
         use_artifact_session = _supports_visualization(language)
         session_cls = ArtifactSandboxSession if use_artifact_session else SandboxSession
 
+        commit_container = _get_commit_container()
         session_kwargs: dict[str, Any] = {
             "lang": language,
             "keep_template": _get_keep_template(),
-            "commit_container": _get_commit_container(),
+            "commit_container": commit_container,
             "verbose": False,
             "backend": backend,
             "session_timeout": timeout,
             "kube_namespace": _get_kube_namespace(),
         }
+        if commit_container and backend in {SandboxBackend.DOCKER, SandboxBackend.MICROMAMBA}:
+            session_kwargs["commit_image_tag"] = _build_commit_image_tag(language)
         if runtime_configs:
             session_kwargs["runtime_configs"] = runtime_configs
 

--- a/llm_sandbox/mcp_server/server.py
+++ b/llm_sandbox/mcp_server/server.py
@@ -6,6 +6,7 @@ A Model Context Protocol server that provides secure code execution capabilities
 import json
 import logging
 import os
+import uuid
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
@@ -66,15 +67,37 @@ def _get_backend() -> SandboxBackend:
 
 
 def _get_commit_container() -> bool:
-    """Get the commit_container setting from environment variable."""
-    commit_container_env = os.environ.get("COMMIT_CONTAINER", "true").lower()
+    """Get the commit_container setting from environment variable.
+
+    Defaults to ``False`` because MCP clients pass attacker-controlled code into the
+    sandbox; persisting container state to the source image by default would let one
+    request's side effects bleed into later sessions.
+    """
+    commit_container_env = os.environ.get("COMMIT_CONTAINER", "false").lower()
     return commit_container_env in _TRUE_ENV_VALUES
 
 
 def _get_keep_template() -> bool:
-    """Get the keep_template setting from environment variable."""
+    """Get the keep_template setting from environment variable.
+
+    Defaults to ``True``: the template image is the pristine upstream base image
+    (e.g. ``python:3.11-bullseye``). It contains no untrusted state, and reusing it
+    between MCP requests avoids re-pulling on every call. Untrusted state is gated
+    separately by ``COMMIT_CONTAINER``.
+    """
     keep_template_env = os.environ.get("KEEP_TEMPLATE", "true").lower()
     return keep_template_env in _TRUE_ENV_VALUES
+
+
+def _build_commit_image_tag(language: str) -> str:
+    """Build a unique opt-in commit tag so commits never overwrite the source image.
+
+    Format: ``llm-sandbox-mcp/<language>:<short-uuid>``. A fresh tag per session means
+    one request's persisted state can never silently land in another session that
+    happened to reuse the same base image.
+    """
+    short = uuid.uuid4().hex[:12]
+    return f"llm-sandbox-mcp/{language.lower()}:{short}"
 
 
 def _get_kube_namespace() -> str:
@@ -262,15 +285,18 @@ def execute_code(
         use_artifact_session = _supports_visualization(language)
         session_cls = ArtifactSandboxSession if use_artifact_session else SandboxSession
 
+        commit_container = _get_commit_container()
         session_kwargs: dict[str, Any] = {
             "lang": language,
             "keep_template": _get_keep_template(),
-            "commit_container": _get_commit_container(),
+            "commit_container": commit_container,
             "verbose": False,
             "backend": backend,
             "session_timeout": timeout,
             "kube_namespace": _get_kube_namespace(),
         }
+        if commit_container and backend in {SandboxBackend.DOCKER, SandboxBackend.MICROMAMBA}:
+            session_kwargs["commit_image_tag"] = _build_commit_image_tag(language)
         if runtime_configs:
             session_kwargs["runtime_configs"] = runtime_configs
 

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1168,6 +1168,54 @@ class TestSandboxDockerSessionEdgeCases:
 
     @patch("llm_sandbox.docker.docker.from_env")
     @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_commit_container_uses_explicit_commit_image_tag(
+        self, mock_create_handler: MagicMock, mock_docker_from_env: MagicMock
+    ) -> None:
+        """Explicit commit_image_tag overrides the source image tag at commit time."""
+        mock_handler = MagicMock()
+        mock_create_handler.return_value = mock_handler
+
+        session = SandboxDockerSession(commit_image_tag="llm-sandbox-mcp/python:abc123")
+        mock_container = MagicMock()
+        mock_image = MagicMock()
+        # Source image still has its upstream tag.
+        mock_image.tags = ["python:3.11-bullseye"]
+
+        session.container = mock_container
+        session.docker_image = mock_image
+
+        session._commit_container()
+
+        # Commit must target the unique tag, never the source image tag.
+        mock_container.commit.assert_called_once_with(
+            repository="llm-sandbox-mcp/python", tag="abc123"
+        )
+
+    @patch("llm_sandbox.docker.docker.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_commit_container_explicit_tag_works_without_source_tags(
+        self, mock_create_handler: MagicMock, mock_docker_from_env: MagicMock
+    ) -> None:
+        """commit_image_tag also rescues the no-source-tags case (e.g. dangling image)."""
+        mock_handler = MagicMock()
+        mock_create_handler.return_value = mock_handler
+
+        session = SandboxDockerSession(commit_image_tag="llm-sandbox-mcp/python:xyz")
+        mock_container = MagicMock()
+        mock_image = MagicMock()
+        mock_image.tags = []  # No upstream tag at all.
+
+        session.container = mock_container
+        session.docker_image = mock_image
+
+        session._commit_container()
+
+        mock_container.commit.assert_called_once_with(
+            repository="llm-sandbox-mcp/python", tag="xyz"
+        )
+
+    @patch("llm_sandbox.docker.docker.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
     def test_cleanup_image_with_containers_using_it(
         self, mock_create_handler: MagicMock, mock_docker_from_env: MagicMock
     ) -> None:

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1187,9 +1187,7 @@ class TestSandboxDockerSessionEdgeCases:
         session._commit_container()
 
         # Commit must target the unique tag, never the source image tag.
-        mock_container.commit.assert_called_once_with(
-            repository="llm-sandbox-mcp/python", tag="abc123"
-        )
+        mock_container.commit.assert_called_once_with(repository="llm-sandbox-mcp/python", tag="abc123")
 
     @patch("llm_sandbox.docker.docker.from_env")
     @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
@@ -1210,9 +1208,7 @@ class TestSandboxDockerSessionEdgeCases:
 
         session._commit_container()
 
-        mock_container.commit.assert_called_once_with(
-            repository="llm-sandbox-mcp/python", tag="xyz"
-        )
+        mock_container.commit.assert_called_once_with(repository="llm-sandbox-mcp/python", tag="xyz")
 
     @patch("llm_sandbox.docker.docker.from_env")
     @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -13,6 +13,7 @@ from llm_sandbox.data import ExecutionResult, FileType, PlotOutput
 from llm_sandbox.exceptions import MissingDependencyError
 from llm_sandbox.mcp_server.const import LANGUAGE_RESOURCES
 from llm_sandbox.mcp_server.server import (
+    _build_commit_image_tag,
     _get_backend,
     _get_commit_container,
     _get_keep_template,
@@ -123,9 +124,9 @@ class TestGetCommitContainer:
 
     @patch.dict(os.environ, {}, clear=True)
     def test_get_commit_container_default(self) -> None:
-        """Test getting commit_container=True when no environment variable is set."""
+        """Test commit_container defaults to False when no environment variable is set."""
         result = _get_commit_container()
-        assert result is True
+        assert result is False
 
 
 class TestGetKeepTemplate:
@@ -403,7 +404,7 @@ class TestExecuteCode:
         # Setup
         mock_backend = SandboxBackend.DOCKER
         mock_get_backend.return_value = mock_backend
-        mock_get_commit_container.return_value = True
+        mock_get_commit_container.return_value = False
         mock_get_keep_template.return_value = True
         mock_get_kube_namespace.return_value = "default"
 
@@ -426,7 +427,7 @@ class TestExecuteCode:
         mock_session_cls.assert_called_once_with(
             lang="python",
             keep_template=True,
-            commit_container=True,
+            commit_container=False,
             verbose=False,
             backend=mock_backend,
             session_timeout=30,
@@ -463,7 +464,7 @@ class TestExecuteCode:
         """Test runtime configs from env are passed into sandbox sessions."""
         mock_backend = SandboxBackend.DOCKER
         mock_get_backend.return_value = mock_backend
-        mock_get_commit_container.return_value = True
+        mock_get_commit_container.return_value = False
         mock_get_keep_template.return_value = True
         mock_get_kube_namespace.return_value = "default"
 
@@ -477,7 +478,7 @@ class TestExecuteCode:
         mock_session_cls.assert_called_once_with(
             lang="python",
             keep_template=True,
-            commit_container=True,
+            commit_container=False,
             verbose=False,
             backend=mock_backend,
             session_timeout=30,
@@ -509,7 +510,7 @@ class TestExecuteCode:
         # Setup
         mock_backend = SandboxBackend.DOCKER
         mock_get_backend.return_value = mock_backend
-        mock_get_commit_container.return_value = True
+        mock_get_commit_container.return_value = False
         mock_get_keep_template.return_value = True
         mock_get_kube_namespace.return_value = "default"
 
@@ -544,7 +545,7 @@ class TestExecuteCode:
         mock_session_cls.assert_called_once_with(
             lang="python",
             keep_template=True,
-            commit_container=True,
+            commit_container=False,
             verbose=False,
             backend=mock_backend,
             session_timeout=30,
@@ -568,7 +569,7 @@ class TestExecuteCode:
         # Setup
         mock_backend = SandboxBackend.DOCKER
         mock_get_backend.return_value = mock_backend
-        mock_get_commit_container.return_value = True
+        mock_get_commit_container.return_value = False
         mock_get_keep_template.return_value = True
         mock_get_kube_namespace.return_value = "default"
 
@@ -597,7 +598,7 @@ class TestExecuteCode:
         mock_session_cls.assert_called_once_with(
             lang="python",
             keep_template=True,
-            commit_container=True,
+            commit_container=False,
             verbose=False,
             backend=mock_backend,
             session_timeout=60,
@@ -621,7 +622,7 @@ class TestExecuteCode:
         # Setup
         mock_backend = SandboxBackend.DOCKER
         mock_get_backend.return_value = mock_backend
-        mock_get_commit_container.return_value = True
+        mock_get_commit_container.return_value = False
         mock_get_keep_template.return_value = True
         mock_get_kube_namespace.return_value = "default"
 
@@ -643,7 +644,7 @@ class TestExecuteCode:
         mock_session_cls.assert_called_once_with(
             lang="javascript",
             keep_template=True,
-            commit_container=True,
+            commit_container=False,
             verbose=False,
             backend=mock_backend,
             session_timeout=30,
@@ -667,7 +668,7 @@ class TestExecuteCode:
         # Setup
         mock_backend = SandboxBackend.DOCKER
         mock_get_backend.return_value = mock_backend
-        mock_get_commit_container.return_value = True
+        mock_get_commit_container.return_value = False
         mock_get_keep_template.return_value = True
         mock_get_kube_namespace.return_value = "default"
 
@@ -701,7 +702,7 @@ class TestExecuteCode:
         # Setup
         mock_backend = SandboxBackend.DOCKER
         mock_get_backend.return_value = mock_backend
-        mock_get_commit_container.return_value = True
+        mock_get_commit_container.return_value = False
         mock_get_keep_template.return_value = True
         mock_get_kube_namespace.return_value = "default"
 
@@ -761,6 +762,126 @@ class TestExecuteCode:
         result_data = json.loads(result[0].text)
         assert result_data["exit_code"] == 1
         assert "not supported for backend 'kubernetes'" in result_data["stderr"]
+
+    @patch("llm_sandbox.mcp_server.server._get_backend")
+    @patch("llm_sandbox.mcp_server.server._get_commit_container")
+    @patch("llm_sandbox.mcp_server.server._get_keep_template")
+    @patch("llm_sandbox.mcp_server.server._get_kube_namespace")
+    @patch("llm_sandbox.mcp_server.server.ArtifactSandboxSession")
+    def test_execute_code_opt_in_commit_passes_unique_tag(
+        self,
+        mock_session_cls: MagicMock,
+        mock_get_kube_namespace: MagicMock,
+        mock_get_keep_template: MagicMock,
+        mock_get_commit_container: MagicMock,
+        mock_get_backend: MagicMock,
+    ) -> None:
+        """When commit is opted in, a unique commit_image_tag is passed (never the source tag)."""
+        mock_get_backend.return_value = SandboxBackend.DOCKER
+        mock_get_commit_container.return_value = True
+        mock_get_keep_template.return_value = True
+        mock_get_kube_namespace.return_value = "default"
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_cls.return_value.__exit__ = MagicMock(return_value=None)
+        mock_session.run.return_value = ExecutionResult(exit_code=0, stdout="OK", stderr="")
+
+        _ = execute_code("print('Hello')", "python")
+
+        kwargs = mock_session_cls.call_args.kwargs
+        assert kwargs["commit_container"] is True
+        commit_tag = kwargs["commit_image_tag"]
+        assert commit_tag.startswith("llm-sandbox-mcp/python:")
+        # Exactly one ":" separator and a non-empty unique suffix.
+        repo, _, suffix = commit_tag.partition(":")
+        assert repo == "llm-sandbox-mcp/python"
+        assert len(suffix) >= 8
+        # Must not collide with any common upstream source tag.
+        assert "bullseye" not in commit_tag
+        assert "latest" not in commit_tag
+
+    @patch("llm_sandbox.mcp_server.server._get_backend")
+    @patch("llm_sandbox.mcp_server.server._get_commit_container")
+    @patch("llm_sandbox.mcp_server.server._get_keep_template")
+    @patch("llm_sandbox.mcp_server.server._get_kube_namespace")
+    @patch("llm_sandbox.mcp_server.server.ArtifactSandboxSession")
+    def test_execute_code_opt_in_commit_unique_tag_is_per_call(
+        self,
+        mock_session_cls: MagicMock,
+        mock_get_kube_namespace: MagicMock,
+        mock_get_keep_template: MagicMock,
+        mock_get_commit_container: MagicMock,
+        mock_get_backend: MagicMock,
+    ) -> None:
+        """Every opt-in commit produces a fresh unique tag, so requests can't bleed into each other."""
+        mock_get_backend.return_value = SandboxBackend.DOCKER
+        mock_get_commit_container.return_value = True
+        mock_get_keep_template.return_value = True
+        mock_get_kube_namespace.return_value = "default"
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_cls.return_value.__exit__ = MagicMock(return_value=None)
+        mock_session.run.return_value = ExecutionResult(exit_code=0, stdout="OK", stderr="")
+
+        _ = execute_code("print('a')", "python")
+        _ = execute_code("print('b')", "python")
+
+        first_tag = mock_session_cls.call_args_list[0].kwargs["commit_image_tag"]
+        second_tag = mock_session_cls.call_args_list[1].kwargs["commit_image_tag"]
+        assert first_tag != second_tag
+
+    @patch("llm_sandbox.mcp_server.server._get_backend")
+    @patch("llm_sandbox.mcp_server.server._get_commit_container")
+    @patch("llm_sandbox.mcp_server.server._get_keep_template")
+    @patch("llm_sandbox.mcp_server.server._get_kube_namespace")
+    @patch("llm_sandbox.mcp_server.server.ArtifactSandboxSession")
+    def test_execute_code_no_commit_omits_commit_image_tag(
+        self,
+        mock_session_cls: MagicMock,
+        mock_get_kube_namespace: MagicMock,
+        mock_get_keep_template: MagicMock,
+        mock_get_commit_container: MagicMock,
+        mock_get_backend: MagicMock,
+    ) -> None:
+        """Default (commit disabled) path must not pass commit_image_tag."""
+        mock_get_backend.return_value = SandboxBackend.DOCKER
+        mock_get_commit_container.return_value = False
+        mock_get_keep_template.return_value = True
+        mock_get_kube_namespace.return_value = "default"
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_cls.return_value.__exit__ = MagicMock(return_value=None)
+        mock_session.run.return_value = ExecutionResult(exit_code=0, stdout="OK", stderr="")
+
+        _ = execute_code("print('Hello')", "python")
+
+        kwargs = mock_session_cls.call_args.kwargs
+        assert kwargs["commit_container"] is False
+        assert "commit_image_tag" not in kwargs
+
+
+class TestBuildCommitImageTag:
+    """Test _build_commit_image_tag helper."""
+
+    def test_build_commit_image_tag_format(self) -> None:
+        """Tag uses dedicated MCP repository plus a hex suffix."""
+        tag = _build_commit_image_tag("python")
+        repo, _, suffix = tag.partition(":")
+        assert repo == "llm-sandbox-mcp/python"
+        assert len(suffix) >= 8
+        assert all(c in "0123456789abcdef" for c in suffix)
+
+    def test_build_commit_image_tag_lowercases_language(self) -> None:
+        """Repository segment is lowercase to match Docker tag rules."""
+        tag = _build_commit_image_tag("PYTHON")
+        assert tag.startswith("llm-sandbox-mcp/python:")
+
+    def test_build_commit_image_tag_unique_per_call(self) -> None:
+        """Two calls produce different tags."""
+        assert _build_commit_image_tag("python") != _build_commit_image_tag("python")
 
 
 class TestGetSupportedLanguages:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -13,6 +13,7 @@ from llm_sandbox.data import ExecutionResult, FileType, PlotOutput
 from llm_sandbox.exceptions import MissingDependencyError
 from llm_sandbox.mcp_server.const import LANGUAGE_RESOURCES
 from llm_sandbox.mcp_server.server import (
+    _build_commit_image_tag,
     _get_backend,
     _get_commit_container,
     _get_keep_template,
@@ -123,9 +124,9 @@ class TestGetCommitContainer:
 
     @patch.dict(os.environ, {}, clear=True)
     def test_get_commit_container_default(self) -> None:
-        """Test getting commit_container=True when no environment variable is set."""
+        """Test commit_container defaults to False when no environment variable is set."""
         result = _get_commit_container()
-        assert result is True
+        assert result is False
 
 
 class TestGetKeepTemplate:
@@ -403,7 +404,7 @@ class TestExecuteCode:
         # Setup
         mock_backend = SandboxBackend.DOCKER
         mock_get_backend.return_value = mock_backend
-        mock_get_commit_container.return_value = True
+        mock_get_commit_container.return_value = False
         mock_get_keep_template.return_value = True
         mock_get_kube_namespace.return_value = "default"
 
@@ -426,7 +427,7 @@ class TestExecuteCode:
         mock_session_cls.assert_called_once_with(
             lang="python",
             keep_template=True,
-            commit_container=True,
+            commit_container=False,
             verbose=False,
             backend=mock_backend,
             session_timeout=30,
@@ -463,7 +464,7 @@ class TestExecuteCode:
         """Test runtime configs from env are passed into sandbox sessions."""
         mock_backend = SandboxBackend.DOCKER
         mock_get_backend.return_value = mock_backend
-        mock_get_commit_container.return_value = True
+        mock_get_commit_container.return_value = False
         mock_get_keep_template.return_value = True
         mock_get_kube_namespace.return_value = "default"
 
@@ -477,7 +478,7 @@ class TestExecuteCode:
         mock_session_cls.assert_called_once_with(
             lang="python",
             keep_template=True,
-            commit_container=True,
+            commit_container=False,
             verbose=False,
             backend=mock_backend,
             session_timeout=30,
@@ -509,7 +510,7 @@ class TestExecuteCode:
         # Setup
         mock_backend = SandboxBackend.DOCKER
         mock_get_backend.return_value = mock_backend
-        mock_get_commit_container.return_value = True
+        mock_get_commit_container.return_value = False
         mock_get_keep_template.return_value = True
         mock_get_kube_namespace.return_value = "default"
 
@@ -549,7 +550,7 @@ class TestExecuteCode:
         mock_session_cls.assert_called_once_with(
             lang="python",
             keep_template=True,
-            commit_container=True,
+            commit_container=False,
             verbose=False,
             backend=mock_backend,
             session_timeout=30,
@@ -573,7 +574,7 @@ class TestExecuteCode:
         # Setup
         mock_backend = SandboxBackend.DOCKER
         mock_get_backend.return_value = mock_backend
-        mock_get_commit_container.return_value = True
+        mock_get_commit_container.return_value = False
         mock_get_keep_template.return_value = True
         mock_get_kube_namespace.return_value = "default"
 
@@ -602,7 +603,7 @@ class TestExecuteCode:
         mock_session_cls.assert_called_once_with(
             lang="python",
             keep_template=True,
-            commit_container=True,
+            commit_container=False,
             verbose=False,
             backend=mock_backend,
             session_timeout=60,
@@ -626,7 +627,7 @@ class TestExecuteCode:
         # Setup
         mock_backend = SandboxBackend.DOCKER
         mock_get_backend.return_value = mock_backend
-        mock_get_commit_container.return_value = True
+        mock_get_commit_container.return_value = False
         mock_get_keep_template.return_value = True
         mock_get_kube_namespace.return_value = "default"
 
@@ -648,7 +649,7 @@ class TestExecuteCode:
         mock_session_cls.assert_called_once_with(
             lang="javascript",
             keep_template=True,
-            commit_container=True,
+            commit_container=False,
             verbose=False,
             backend=mock_backend,
             session_timeout=30,
@@ -672,7 +673,7 @@ class TestExecuteCode:
         # Setup
         mock_backend = SandboxBackend.DOCKER
         mock_get_backend.return_value = mock_backend
-        mock_get_commit_container.return_value = True
+        mock_get_commit_container.return_value = False
         mock_get_keep_template.return_value = True
         mock_get_kube_namespace.return_value = "default"
 
@@ -706,7 +707,7 @@ class TestExecuteCode:
         # Setup
         mock_backend = SandboxBackend.DOCKER
         mock_get_backend.return_value = mock_backend
-        mock_get_commit_container.return_value = True
+        mock_get_commit_container.return_value = False
         mock_get_keep_template.return_value = True
         mock_get_kube_namespace.return_value = "default"
 
@@ -766,6 +767,126 @@ class TestExecuteCode:
         result_data = json.loads(result[0].text)
         assert result_data["exit_code"] == 1
         assert "not supported for backend 'kubernetes'" in result_data["stderr"]
+
+    @patch("llm_sandbox.mcp_server.server._get_backend")
+    @patch("llm_sandbox.mcp_server.server._get_commit_container")
+    @patch("llm_sandbox.mcp_server.server._get_keep_template")
+    @patch("llm_sandbox.mcp_server.server._get_kube_namespace")
+    @patch("llm_sandbox.mcp_server.server.ArtifactSandboxSession")
+    def test_execute_code_opt_in_commit_passes_unique_tag(
+        self,
+        mock_session_cls: MagicMock,
+        mock_get_kube_namespace: MagicMock,
+        mock_get_keep_template: MagicMock,
+        mock_get_commit_container: MagicMock,
+        mock_get_backend: MagicMock,
+    ) -> None:
+        """When commit is opted in, a unique commit_image_tag is passed (never the source tag)."""
+        mock_get_backend.return_value = SandboxBackend.DOCKER
+        mock_get_commit_container.return_value = True
+        mock_get_keep_template.return_value = True
+        mock_get_kube_namespace.return_value = "default"
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_cls.return_value.__exit__ = MagicMock(return_value=None)
+        mock_session.run.return_value = ExecutionResult(exit_code=0, stdout="OK", stderr="")
+
+        _ = execute_code("print('Hello')", "python")
+
+        kwargs = mock_session_cls.call_args.kwargs
+        assert kwargs["commit_container"] is True
+        commit_tag = kwargs["commit_image_tag"]
+        assert commit_tag.startswith("llm-sandbox-mcp/python:")
+        # Exactly one ":" separator and a non-empty unique suffix.
+        repo, _, suffix = commit_tag.partition(":")
+        assert repo == "llm-sandbox-mcp/python"
+        assert len(suffix) >= 8
+        # Must not collide with any common upstream source tag.
+        assert "bullseye" not in commit_tag
+        assert "latest" not in commit_tag
+
+    @patch("llm_sandbox.mcp_server.server._get_backend")
+    @patch("llm_sandbox.mcp_server.server._get_commit_container")
+    @patch("llm_sandbox.mcp_server.server._get_keep_template")
+    @patch("llm_sandbox.mcp_server.server._get_kube_namespace")
+    @patch("llm_sandbox.mcp_server.server.ArtifactSandboxSession")
+    def test_execute_code_opt_in_commit_unique_tag_is_per_call(
+        self,
+        mock_session_cls: MagicMock,
+        mock_get_kube_namespace: MagicMock,
+        mock_get_keep_template: MagicMock,
+        mock_get_commit_container: MagicMock,
+        mock_get_backend: MagicMock,
+    ) -> None:
+        """Every opt-in commit produces a fresh unique tag, so requests can't bleed into each other."""
+        mock_get_backend.return_value = SandboxBackend.DOCKER
+        mock_get_commit_container.return_value = True
+        mock_get_keep_template.return_value = True
+        mock_get_kube_namespace.return_value = "default"
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_cls.return_value.__exit__ = MagicMock(return_value=None)
+        mock_session.run.return_value = ExecutionResult(exit_code=0, stdout="OK", stderr="")
+
+        _ = execute_code("print('a')", "python")
+        _ = execute_code("print('b')", "python")
+
+        first_tag = mock_session_cls.call_args_list[0].kwargs["commit_image_tag"]
+        second_tag = mock_session_cls.call_args_list[1].kwargs["commit_image_tag"]
+        assert first_tag != second_tag
+
+    @patch("llm_sandbox.mcp_server.server._get_backend")
+    @patch("llm_sandbox.mcp_server.server._get_commit_container")
+    @patch("llm_sandbox.mcp_server.server._get_keep_template")
+    @patch("llm_sandbox.mcp_server.server._get_kube_namespace")
+    @patch("llm_sandbox.mcp_server.server.ArtifactSandboxSession")
+    def test_execute_code_no_commit_omits_commit_image_tag(
+        self,
+        mock_session_cls: MagicMock,
+        mock_get_kube_namespace: MagicMock,
+        mock_get_keep_template: MagicMock,
+        mock_get_commit_container: MagicMock,
+        mock_get_backend: MagicMock,
+    ) -> None:
+        """Default (commit disabled) path must not pass commit_image_tag."""
+        mock_get_backend.return_value = SandboxBackend.DOCKER
+        mock_get_commit_container.return_value = False
+        mock_get_keep_template.return_value = True
+        mock_get_kube_namespace.return_value = "default"
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_session_cls.return_value.__exit__ = MagicMock(return_value=None)
+        mock_session.run.return_value = ExecutionResult(exit_code=0, stdout="OK", stderr="")
+
+        _ = execute_code("print('Hello')", "python")
+
+        kwargs = mock_session_cls.call_args.kwargs
+        assert kwargs["commit_container"] is False
+        assert "commit_image_tag" not in kwargs
+
+
+class TestBuildCommitImageTag:
+    """Test _build_commit_image_tag helper."""
+
+    def test_build_commit_image_tag_format(self) -> None:
+        """Tag uses dedicated MCP repository plus a hex suffix."""
+        tag = _build_commit_image_tag("python")
+        repo, _, suffix = tag.partition(":")
+        assert repo == "llm-sandbox-mcp/python"
+        assert len(suffix) >= 8
+        assert all(c in "0123456789abcdef" for c in suffix)
+
+    def test_build_commit_image_tag_lowercases_language(self) -> None:
+        """Repository segment is lowercase to match Docker tag rules."""
+        tag = _build_commit_image_tag("PYTHON")
+        assert tag.startswith("llm-sandbox-mcp/python:")
+
+    def test_build_commit_image_tag_unique_per_call(self) -> None:
+        """Two calls produce different tags."""
+        assert _build_commit_image_tag("python") != _build_commit_image_tag("python")
 
 
 class TestGetSupportedLanguages:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -886,7 +886,9 @@ class TestBuildCommitImageTag:
 
     def test_build_commit_image_tag_unique_per_call(self) -> None:
         """Two calls produce different tags."""
-        assert _build_commit_image_tag("python") != _build_commit_image_tag("python")
+        first_tag = _build_commit_image_tag("python")
+        second_tag = _build_commit_image_tag("python")
+        assert first_tag != second_tag
 
 
 class TestGetSupportedLanguages:


### PR DESCRIPTION
Closes #161.

The MCP server defaulted both `COMMIT_CONTAINER` and `KEEP_TEMPLATE` to true and committed the container straight back to the source image's tag. Since MCP clients are running attacker-controlled code, that quietly turned every successful run into a write-back to the base image, so persisted side effects from one request could be inherited by the next session.

This PR makes persistence opt-in and isolates opt-in commits to a dedicated tag.

## Acceptance criteria

1. **Default `COMMIT_CONTAINER` to false.** Done. `_get_commit_container()` now reads `os.environ.get("COMMIT_CONTAINER", "false")`. The function's docstring spells out why.
2. **Decide `KEEP_TEMPLATE`.** Kept at `True`, with the rationale documented inline and in `docs/mcp-integration.md`. The template image at this layer is the pristine upstream base image (e.g. `python:3.11-bullseye`), not container state. It contains no untrusted execution side effects, and reusing it between MCP requests avoids re-pulling on every call. The actual untrusted-state gate is `COMMIT_CONTAINER`, which is now off by default. Users who prefer stricter hygiene can set `KEEP_TEMPLATE=false` and pay the pull cost; the docs say so.
3. **Commit to an explicit or unique opt-in tag.** Done. When commit is opted in on Docker or Micromamba, the MCP server generates a per-call tag of the form `llm-sandbox-mcp/<lang>:<short-hex>` (`uuid4().hex[:12]`) and passes it through a new `commit_image_tag` parameter on `SandboxDockerSession`. `_commit_container` prefers that tag when set, so commits land on the dedicated MCP repository instead of overwriting the source tag. Existing callers that don't set `commit_image_tag` keep the old behavior. `_commit_container` also reads the attribute via `getattr` so `SandboxPodmanSession` (which inherits `__init__` but doesn't wire the new param) is unaffected.
4. **Tests for MCP env-var defaults.** Existing default test flipped to assert `False`; new tests cover env-var-true override, env-var-false override, the unique-tag wiring (per-call tag, format `llm-sandbox-mcp/<lang>:<hex>`, freshness), and the commit-off path that must omit `commit_image_tag`. New `_commit_container` tests in `tests/test_docker.py` verify the explicit-tag branch (with and without source tags). 81 MCP tests pass; full suite is 1103 passed / 1 skipped.
5. **Doc update.** `docs/mcp-integration.md` gets a "Persistence and security" subsection that describes the new defaults, the unique-tag scheme, and what to flip if you want stricter or more permissive behavior. The "Use Cases" bullets and the env-var defaults block were updated to match.

## Unique-tag scheme

Format: `llm-sandbox-mcp/<lang>:<short-hex>` where `<short-hex>` is the first 12 hex chars of `uuid4()`. Per call, never reused, never collides with common upstream tags (`bullseye`, `latest`, etc. are not in the suffix). Only applied for backends where the attribute is honored (Docker and Micromamba in this version); Podman and Kubernetes ignore it harmlessly.

## Smallest-diff notes

- `llm_sandbox/security/` is untouched.
- `SandboxDockerSession` gains one optional kwarg (`commit_image_tag`) plus three lines in `_commit_container`. No behavior change for existing callers that don't set it.
- `SandboxPodmanSession` is untouched; the `getattr` guard means it doesn't need to know about the new field.

## Test plan

- [x] `python -m pytest tests/test_mcp_server.py -v` -> 81 passed
- [x] `python -m pytest tests/test_docker.py -v` -> 81 passed
- [x] Full suite `python -m pytest` -> 1103 passed, 1 skipped
- [x] `python -m ruff check --no-fix llm_sandbox/mcp_server/server.py tests/test_mcp_server.py` -> clean
- [x] `python -m ruff check --no-fix llm_sandbox/docker.py tests/test_docker.py` -> only pre-existing PLC0415/FURB110 warnings (verified by stashing the diff and re-running on the unchanged file). No new findings introduced by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unique, language-scoped image tags for explicitly enabled container persistence, preventing source images from being overwritten.
  * Container commits can now target an explicitly specified image tag.

* **Bug Fixes**
  * Container persistence is now disabled by default, improving security and predictability.
  * Commits work even when the source image has no existing tags.

* **Documentation**
  * Clarified persistence configuration, security guidance, template behavior, examples, and backend limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->