### PR TITLE
feat: add strict runtime profile with non-root + dropped-caps defaults (#159)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -370,6 +370,27 @@ WORKDIR /sandbox
 
 > **Security Warning**: The `runtime_configs` parameter is passed directly to the container runtime without filtering. When accepting `runtime_configs` from untrusted sources, be aware that dangerous options such as `privileged: True`, `cap_add`, `network_mode: "host"`, or host volume mounts can weaken or eliminate container isolation. In applications where end users can influence container configuration, always validate and restrict the allowed keys before passing them to `runtime_configs`. See [Security Considerations for runtime_configs](#security-considerations-for-runtime_configs) below.
 
+### Runtime Profile
+
+Each session also accepts a `runtime_profile` keyword that selects a hardening baseline for the underlying container runtime. The default is `RuntimeProfile.COMPAT`, which preserves the historical root-by-default behavior. Set `runtime_profile=RuntimeProfile.STRICT` for production sandboxes that execute untrusted or LLM-generated code:
+
+```python
+from llm_sandbox import RuntimeProfile, SandboxSession
+
+with SandboxSession(
+    lang="python",
+    runtime_profile=RuntimeProfile.STRICT,
+) as session:
+    session.run("print('hello from a non-root sandbox')")
+```
+
+The strict profile applies:
+
+- Docker / Podman: `user="1000:1000"`, `cap_drop=["ALL"]`, `security_opt=["no-new-privileges:true"]`, `network_mode="none"`, `pids_limit=512`, `mem_limit="512m"`.
+- Kubernetes: a non-root pod and container `securityContext` with `runAsNonRoot=true`, `allowPrivilegeEscalation=false`, dropped capabilities, and the `RuntimeDefault` seccomp profile.
+
+Per-knob overrides supplied via `runtime_configs` always win, and passing `None` for any key removes that hardening knob entirely (useful for images that need a working network or larger memory). See the [Runtime profiles section in the security guide](security.md#runtime-profiles) for the full table, the Kubernetes `NetworkPolicy` caveat, and the recommendation for production deployments.
+
 ### Docker and Podman Backends
 
 For Docker and Podman backends, runtime configuration options are passed as **extra arguments** to the respective Python libraries (`docker-py` and `podman-py`). These are used to configure container creation and execution parameters.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -370,6 +370,27 @@ WORKDIR /sandbox
 
 > **Security Warning**: The `runtime_configs` parameter is passed directly to the container runtime without filtering. When accepting `runtime_configs` from untrusted sources, be aware that dangerous options such as `privileged: True`, `cap_add`, `network_mode: "host"`, or host volume mounts can weaken or eliminate container isolation. In applications where end users can influence container configuration, always validate and restrict the allowed keys before passing them to `runtime_configs`. See [Security Considerations for runtime_configs](#security-considerations-for-runtime_configs) below.
 
+### Runtime Profile
+
+Each session also accepts a `runtime_profile` keyword that selects a hardening baseline for the underlying container runtime. The default is `RuntimeProfile.COMPAT`, which preserves the historical root-by-default behavior. Set `runtime_profile=RuntimeProfile.STRICT` for production sandboxes that execute untrusted or LLM-generated code:
+
+```python
+from llm_sandbox import RuntimeProfile, SandboxSession
+
+with SandboxSession(
+    lang="python",
+    runtime_profile=RuntimeProfile.STRICT,
+) as session:
+    session.run("print('hello from a hardened sandbox')")
+```
+
+The strict profile applies:
+
+- Docker / Podman: `cap_drop=["ALL"]`, `cap_add=["DAC_OVERRIDE"]`, `security_opt=["no-new-privileges:true"]`, `network_mode="none"`, `pids_limit=512`, `mem_limit="512m"`. It hardens capabilities, networking, and pids/memory but **does not switch the container user** — the process runs as the image's default user (typically `root`), because the stock base images ship no unprivileged account and the copied-in code is root-owned. `DAC_OVERRIDE` is kept so the capability-dropped process can still read that code.
+- Kubernetes: a non-root pod and container `securityContext` with `runAsUser=1000`, `runAsNonRoot=true`, `allowPrivilegeEscalation=false`, dropped capabilities, and the `RuntimeDefault` seccomp profile.
+
+Per-knob overrides supplied via `runtime_configs` always win, and passing `None` for any key removes that hardening knob entirely (useful for images that need a working network or larger memory). See the [Runtime profiles section in the security guide](security.md#runtime-profiles) for the full table, the Kubernetes `NetworkPolicy` caveat, and the recommendation for production deployments.
+
 ### Docker and Podman Backends
 
 For Docker and Podman backends, runtime configuration options are passed as **extra arguments** to the respective Python libraries (`docker-py` and `podman-py`). These are used to configure container creation and execution parameters.

--- a/docs/security.md
+++ b/docs/security.md
@@ -24,6 +24,64 @@ LLM Sandbox follows an **advisory security model** for code analysis:
 
 For production deployments handling untrusted code, always combine all layers: use security policies to screen code, apply strict container resource limits, and restrict network access.
 
+## Runtime profiles
+
+Each session accepts a `runtime_profile` argument that selects a hardening baseline for the underlying container runtime. Two profiles ship today:
+
+- `RuntimeProfile.COMPAT` (default) keeps the historical configuration: containers run as `root`, no extra capability or namespace restrictions are applied, and the Kubernetes pod manifest sets `runAsUser: 0` / `runAsGroup: 0`. This is the most permissive option and is preserved as the default for backward compatibility.
+- `RuntimeProfile.STRICT` is recommended for production deployments that execute untrusted or LLM-generated code. It applies a non-root, locked-down baseline:
+
+  | Backend | Defaults applied by `STRICT` |
+  | --- | --- |
+  | Docker / Podman | `user="1000:1000"`, `cap_drop=["ALL"]`, `security_opt=["no-new-privileges:true"]`, `network_mode="none"`, `pids_limit=512`, `mem_limit="512m"` |
+  | Kubernetes | Pod `securityContext`: `runAsUser=1000`, `runAsGroup=1000`, `runAsNonRoot=true`, `fsGroup=1000`, `seccompProfile.type=RuntimeDefault`. Container `securityContext` adds `allowPrivilegeEscalation=false`, `capabilities.drop=["ALL"]`. |
+
+Example:
+
+```python
+from llm_sandbox import RuntimeProfile, SandboxSession
+
+with SandboxSession(lang="python", runtime_profile=RuntimeProfile.STRICT) as sess:
+    print(sess.run("import os; print(os.getuid())").stdout)  # 1000
+```
+
+### Compatibility escape hatch
+
+The strict profile is a baseline, not a straitjacket. Any value supplied via `runtime_configs` (Docker/Podman) or `pod_manifest` (Kubernetes) takes precedence over the profile's defaults, so images that need a different UID, more memory, or outbound network access can still opt in:
+
+```python
+SandboxSession(
+    runtime_profile=RuntimeProfile.STRICT,
+    runtime_configs={
+        "user": "2000:2000",      # different non-root UID
+        "mem_limit": "2g",        # raise the memory cap
+        "pids_limit": None,       # opt out of the pids cap entirely
+    },
+)
+```
+
+Passing `None` for any key in `STRICT_DOCKER_DEFAULTS` removes that hardening knob from the merged result. For images that genuinely require root (for example, packages installed at session start), keep the default `RuntimeProfile.COMPAT` or pass `runtime_profile="compat"` explicitly.
+
+### Recommendation
+
+For production sandboxes that execute untrusted code, opt in to `RuntimeProfile.STRICT`. The default may flip to `STRICT` in a future major release; using the explicit value today insulates you from that change and documents the security posture in code.
+
+### Kubernetes network isolation caveat
+
+The Kubernetes profile **does not** create a `NetworkPolicy` object. Pods do not gain network isolation automatically: depending on the cluster's CNI, pods can reach the apiserver, other namespaces, and arbitrary external endpoints unless a `NetworkPolicy` (or service mesh policy) is applied. For untrusted workloads, ship a default-deny `NetworkPolicy` for the sandbox namespace alongside the strict profile. A minimal example:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: sandbox-default-deny
+  namespace: sandbox
+spec:
+  podSelector:
+    matchLabels: {app: sandbox}
+  policyTypes: [Ingress, Egress]
+```
+
 ## Security Policy System
 
 ### Overview

--- a/docs/security.md
+++ b/docs/security.md
@@ -24,6 +24,77 @@ LLM Sandbox follows an **advisory security model** for code analysis:
 
 For production deployments handling untrusted code, always combine all layers: use security policies to screen code, apply strict container resource limits, and restrict network access.
 
+## Runtime profiles
+
+Each session accepts a `runtime_profile` argument that selects a hardening baseline for the underlying container runtime. Two profiles ship today:
+
+- `RuntimeProfile.COMPAT` (default) keeps the historical configuration: containers run as `root`, no extra capability or namespace restrictions are applied, and the Kubernetes pod manifest sets `runAsUser: 0` / `runAsGroup: 0`. This is the most permissive option and is preserved as the default for backward compatibility.
+- `RuntimeProfile.STRICT` is recommended for production deployments that execute untrusted or LLM-generated code. It applies a locked-down baseline:
+
+  | Backend | Defaults applied by `STRICT` |
+  | --- | --- |
+  | Docker / Podman | `cap_drop=["ALL"]`, `cap_add=["DAC_OVERRIDE"]`, `security_opt=["no-new-privileges:true"]`, `network_mode="none"`, `pids_limit=512`, `mem_limit="512m"` |
+  | Kubernetes | Pod `securityContext`: `runAsUser=1000`, `runAsGroup=1000`, `runAsNonRoot=true`, `fsGroup=1000`, `seccompProfile.type=RuntimeDefault`. Container `securityContext` adds `allowPrivilegeEscalation=false`, `capabilities.drop=["ALL"]`. |
+
+> **Note**: On **Docker and Podman**, `STRICT` hardens the container (drops all
+> capabilities except `DAC_OVERRIDE`, disables new privileges, cuts off networking,
+> and caps PIDs and memory) but **does not switch the container user** — the process
+> still runs as the image's default user (typically `root`). The stock base images
+> ship no unprivileged account and the copied-in code is root-owned, so forcing a
+> non-root UID would break code execution; `DAC_OVERRIDE` is added back so the
+> capability-dropped process can still read that code. On **Kubernetes**, `STRICT`
+> *does* run non-root (`runAsUser=1000`, `runAsNonRoot=true`). If you need a non-root
+> UID on Docker/Podman, supply a `user` via `runtime_configs` with an image that
+> provides that account.
+
+Example:
+
+```python
+from llm_sandbox import RuntimeProfile, SandboxSession
+
+with SandboxSession(lang="python", runtime_profile=RuntimeProfile.STRICT) as sess:
+    # On Docker/Podman the process still runs as the image default user (root);
+    # capabilities, networking, and pids/memory are what STRICT locks down here.
+    print(sess.run("import os; print(os.getuid())").stdout)
+```
+
+### Compatibility escape hatch
+
+The strict profile is a baseline, not a straitjacket. Any value supplied via `runtime_configs` (Docker/Podman) or `pod_manifest` (Kubernetes) takes precedence over the profile's defaults, so images that need a different UID, more memory, or outbound network access can still opt in:
+
+```python
+SandboxSession(
+    runtime_profile=RuntimeProfile.STRICT,
+    runtime_configs={
+        "user": "2000:2000",      # different non-root UID
+        "mem_limit": "2g",        # raise the memory cap
+        "pids_limit": None,       # opt out of the pids cap entirely
+    },
+)
+```
+
+Passing `None` for any key in `STRICT_DOCKER_DEFAULTS` removes that hardening knob from the merged result. For images that genuinely require root (for example, packages installed at session start), keep the default `RuntimeProfile.COMPAT` or pass `runtime_profile="compat"` explicitly.
+
+### Recommendation
+
+For production sandboxes that execute untrusted code, opt in to `RuntimeProfile.STRICT`. The default may flip to `STRICT` in a future major release; using the explicit value today insulates you from that change and documents the security posture in code.
+
+### Kubernetes network isolation caveat
+
+The Kubernetes profile **does not** create a `NetworkPolicy` object. Pods do not gain network isolation automatically: depending on the cluster's CNI, pods can reach the apiserver, other namespaces, and arbitrary external endpoints unless a `NetworkPolicy` (or service mesh policy) is applied. For untrusted workloads, ship a default-deny `NetworkPolicy` for the sandbox namespace alongside the strict profile. A minimal example:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: sandbox-default-deny
+  namespace: sandbox
+spec:
+  podSelector:
+    matchLabels: {app: sandbox}
+  policyTypes: [Ingress, Egress]
+```
+
 ## Security Policy System
 
 ### Overview

--- a/llm_sandbox/__init__.py
+++ b/llm_sandbox/__init__.py
@@ -1,6 +1,6 @@
 """LLM Sandbox - A lightweight and portable LLM sandbox runtime."""
 
-from .const import DefaultImage, SandboxBackend, SupportedLanguage
+from .const import DefaultImage, RuntimeProfile, SandboxBackend, SupportedLanguage
 from .core.config import SessionConfig
 from .data import ConsoleOutput, ExecutionResult, FileType, PlotOutput, StreamCallback
 from .exceptions import ContainerError, ResourceError, SandboxError, SecurityError, ValidationError
@@ -19,6 +19,7 @@ __all__ = [
     "KernelType",
     "PlotOutput",
     "ResourceError",
+    "RuntimeProfile",
     "SandboxBackend",
     "SandboxError",
     "SandboxSession",

--- a/llm_sandbox/const.py
+++ b/llm_sandbox/const.py
@@ -64,6 +64,22 @@ class SandboxBackend(StrEnum):
     MICROMAMBA = "micromamba"
 
 
+class RuntimeProfile(StrEnum):
+    r"""Container runtime hardening profile.
+
+    ``COMPAT`` keeps the historical defaults (root user, no extra capability or
+    namespace restrictions) for maximum image compatibility. ``STRICT`` applies
+    a non-root, locked-down baseline suitable for executing untrusted/LLM-
+    generated code in production: dropped Linux capabilities, ``no-new-privileges``,
+    network-off, and modest pid/memory limits. Per-knob overrides supplied via
+    ``runtime_configs`` (Docker/Podman) or ``pod_manifest`` (Kubernetes) always
+    take precedence over the profile's defaults.
+    """
+
+    COMPAT = "compat"
+    STRICT = "strict"
+
+
 class SupportedLanguage(StrEnum):
     r"""Dataclass defining constants for supported programming languages.
 

--- a/llm_sandbox/core/config.py
+++ b/llm_sandbox/core/config.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field, model_validator
 
-from llm_sandbox.const import EncodingErrorsType, SupportedLanguage
+from llm_sandbox.const import EncodingErrorsType, RuntimeProfile, SupportedLanguage
 from llm_sandbox.security import SecurityPolicy
 
 
@@ -73,7 +73,16 @@ class SessionConfig(BaseModel):
         default={},
         description="Additional configurations for the container runtime, such as resource limits "
         "(e.g., `cpu_count`, `mem_limit`) or user (`user='1000:1000'`). "
-        "By default, containers run as the root user for maximum compatibility.",
+        "Values supplied here always take precedence over `runtime_profile` defaults; "
+        "explicitly setting a key to ``None`` omits the corresponding profile default.",
+    )
+    runtime_profile: RuntimeProfile = Field(
+        default=RuntimeProfile.COMPAT,
+        description="Hardening profile applied when generating runtime configuration. "
+        "``COMPAT`` (default) preserves historical root-by-default behavior. ``STRICT`` "
+        "applies non-root execution, dropped capabilities, ``no-new-privileges``, "
+        "network-off, and pid/memory limits for Docker/Podman, plus a non-root pod and "
+        "container ``securityContext`` for Kubernetes.",
     )
 
     # Environment setup customization

--- a/llm_sandbox/docker.py
+++ b/llm_sandbox/docker.py
@@ -6,11 +6,12 @@ from typing import TYPE_CHECKING, Any
 import docker
 from docker.errors import ImageNotFound, NotFound
 
-from llm_sandbox.const import DefaultImage, EncodingErrorsType, SupportedLanguage
+from llm_sandbox.const import DefaultImage, EncodingErrorsType, RuntimeProfile, SupportedLanguage
 from llm_sandbox.core.config import SessionConfig
 from llm_sandbox.core.session_base import BaseSession
 from llm_sandbox.data import StreamCallback
 from llm_sandbox.exceptions import ContainerError, ImagePullError, NotOpenSessionError
+from llm_sandbox.runtime_profiles import apply_strict_runtime_configs
 from llm_sandbox.security import SecurityPolicy
 
 if TYPE_CHECKING:
@@ -105,6 +106,7 @@ class SandboxDockerSession(BaseSession):
         container_id: str | None = None,
         skip_environment_setup: bool = False,
         encoding_errors: EncodingErrorsType = "strict",
+        runtime_profile: RuntimeProfile | str = RuntimeProfile.COMPAT,
         **kwargs: Any,
     ) -> None:
         r"""Initialize Docker session.
@@ -127,6 +129,11 @@ class SandboxDockerSession(BaseSession):
             container_id (str | None): ID of existing container to connect to.
             skip_environment_setup (bool): Skip language-specific environment setup.
             encoding_errors (EncodingErrorsType): Error handling for decoding command output.
+            runtime_profile (RuntimeProfile | str): Hardening profile. ``COMPAT`` (default)
+                preserves the historical root-by-default behavior; ``STRICT`` applies a
+                non-root user, dropped capabilities, ``no-new-privileges``, network-off,
+                and pid/memory limits. Individual knobs can still be overridden (or
+                disabled with ``None``) via ``runtime_configs``.
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -147,6 +154,7 @@ class SandboxDockerSession(BaseSession):
             container_id=container_id,
             skip_environment_setup=skip_environment_setup,
             encoding_errors=encoding_errors,
+            runtime_profile=RuntimeProfile(runtime_profile),
         )
 
         super().__init__(config=config, **kwargs)
@@ -190,7 +198,7 @@ class SandboxDockerSession(BaseSession):
         mkdir_result = self.container_api.execute_command(self.container, f"mkdir -p {shlex.quote(path)}")
         if mkdir_result[0] != 0:
             stdout_output, stderr_output = self._process_non_stream_output(mkdir_result[1])
-            error_msg = stderr_output if stderr_output else stdout_output
+            error_msg = stderr_output or stdout_output
             self._log(f"Failed to create directory {path}: {error_msg}", "error")
 
     def _ensure_ownership(self, paths: list[str]) -> None:
@@ -374,8 +382,12 @@ class SandboxDockerSession(BaseSession):
             # Create new container
             self._prepare_image()
 
-            container_config = {"image": self.docker_image, "detach": True, "tty": True, "user": "root"}
-            container_config.update(self.config.runtime_configs)
+            container_config: dict[str, Any] = {"image": self.docker_image, "detach": True, "tty": True}
+            if self.config.runtime_profile == RuntimeProfile.STRICT:
+                container_config.update(apply_strict_runtime_configs(self.config.runtime_configs))
+            else:
+                container_config["user"] = "root"
+                container_config.update(self.config.runtime_configs)
 
             env = container_config.get("environment")
             if isinstance(env, dict):

--- a/llm_sandbox/docker.py
+++ b/llm_sandbox/docker.py
@@ -6,11 +6,12 @@ from typing import TYPE_CHECKING, Any
 import docker
 from docker.errors import ImageNotFound, NotFound
 
-from llm_sandbox.const import DefaultImage, EncodingErrorsType, SupportedLanguage
+from llm_sandbox.const import DefaultImage, EncodingErrorsType, RuntimeProfile, SupportedLanguage
 from llm_sandbox.core.config import SessionConfig
 from llm_sandbox.core.session_base import BaseSession
 from llm_sandbox.data import StreamCallback
 from llm_sandbox.exceptions import ContainerError, ImagePullError, NotOpenSessionError
+from llm_sandbox.runtime_profiles import apply_strict_runtime_configs
 from llm_sandbox.security import SecurityPolicy
 
 if TYPE_CHECKING:
@@ -105,6 +106,7 @@ class SandboxDockerSession(BaseSession):
         container_id: str | None = None,
         skip_environment_setup: bool = False,
         encoding_errors: EncodingErrorsType = "strict",
+        runtime_profile: RuntimeProfile | str = RuntimeProfile.COMPAT,
         **kwargs: Any,
     ) -> None:
         r"""Initialize Docker session.
@@ -127,6 +129,13 @@ class SandboxDockerSession(BaseSession):
             container_id (str | None): ID of existing container to connect to.
             skip_environment_setup (bool): Skip language-specific environment setup.
             encoding_errors (EncodingErrorsType): Error handling for decoding command output.
+            runtime_profile (RuntimeProfile | str): Hardening profile. ``COMPAT`` (default)
+                preserves the historical root-by-default behavior; ``STRICT`` drops all
+                capabilities except ``DAC_OVERRIDE``, adds ``no-new-privileges``, disables
+                networking, and sets pid/memory limits. It does not switch the container
+                user on Docker/Podman (the base images ship no unprivileged account and the
+                copied-in code is root-owned). Individual knobs can still be overridden (or
+                disabled with ``None``) via ``runtime_configs``.
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -147,6 +156,7 @@ class SandboxDockerSession(BaseSession):
             container_id=container_id,
             skip_environment_setup=skip_environment_setup,
             encoding_errors=encoding_errors,
+            runtime_profile=RuntimeProfile(runtime_profile),
         )
 
         super().__init__(config=config, **kwargs)
@@ -190,7 +200,7 @@ class SandboxDockerSession(BaseSession):
         mkdir_result = self.container_api.execute_command(self.container, f"mkdir -p {shlex.quote(path)}")
         if mkdir_result[0] != 0:
             stdout_output, stderr_output = self._process_non_stream_output(mkdir_result[1])
-            error_msg = stderr_output if stderr_output else stdout_output
+            error_msg = stderr_output or stdout_output
             self._log(f"Failed to create directory {path}: {error_msg}", "error")
 
     def _ensure_ownership(self, paths: list[str]) -> None:
@@ -374,8 +384,12 @@ class SandboxDockerSession(BaseSession):
             # Create new container
             self._prepare_image()
 
-            container_config = {"image": self.docker_image, "detach": True, "tty": True, "user": "root"}
-            container_config.update(self.config.runtime_configs)
+            container_config: dict[str, Any] = {"image": self.docker_image, "detach": True, "tty": True}
+            if self.config.runtime_profile == RuntimeProfile.STRICT:
+                container_config.update(apply_strict_runtime_configs(self.config.runtime_configs))
+            else:
+                container_config["user"] = "root"
+                container_config.update(self.config.runtime_configs)
 
             env = container_config.get("environment")
             if isinstance(env, dict):

--- a/llm_sandbox/kubernetes.py
+++ b/llm_sandbox/kubernetes.py
@@ -13,12 +13,13 @@ from kubernetes.client import CoreV1Api
 from kubernetes.client.exceptions import ApiException
 from kubernetes.stream import stream
 
-from llm_sandbox.const import DefaultImage, EncodingErrorsType, SupportedLanguage
+from llm_sandbox.const import DefaultImage, EncodingErrorsType, RuntimeProfile, SupportedLanguage
 from llm_sandbox.core.config import SessionConfig
 from llm_sandbox.core.session_base import BaseSession
 from llm_sandbox.data import ConsoleOutput, StreamCallback
 from llm_sandbox.exceptions import CommandEmptyError, ContainerError, NotOpenSessionError
 from llm_sandbox.k8s_utils import retry_k8s_api_call
+from llm_sandbox.runtime_profiles import strict_container_security_context, strict_pod_security_context
 from llm_sandbox.security import SecurityPolicy
 
 SH_SHELL = "/bin/sh"
@@ -350,6 +351,7 @@ class SandboxKubernetesSession(BaseSession):
         container_id: str | None = None,  # This will be pod_id for Kubernetes
         skip_environment_setup: bool = False,
         encoding_errors: EncodingErrorsType = "strict",
+        runtime_profile: RuntimeProfile | str = RuntimeProfile.COMPAT,
         **kwargs: Any,
     ) -> None:
         r"""Initialize Kubernetes session.
@@ -370,6 +372,12 @@ class SandboxKubernetesSession(BaseSession):
             container_id (str | None): ID of existing pod to connect to.
             skip_environment_setup (bool): Skip language-specific environment setup.
             encoding_errors (EncodingErrorsType): Error handling for decoding command output.
+            runtime_profile (RuntimeProfile | str): Hardening profile applied when no
+                ``pod_manifest`` is supplied. ``COMPAT`` (default) keeps the historical
+                root pod manifest. ``STRICT`` builds a non-root pod and container
+                ``securityContext`` with dropped capabilities, ``runAsNonRoot``, and the
+                ``RuntimeDefault`` seccomp profile. Network isolation is not applied to
+                pods by default; see the security docs for the NetworkPolicy guidance.
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -388,6 +396,7 @@ class SandboxKubernetesSession(BaseSession):
             container_id=container_id,
             skip_environment_setup=skip_environment_setup,
             encoding_errors=encoding_errors,
+            runtime_profile=RuntimeProfile(runtime_profile),
         )
 
         super().__init__(config=config, **kwargs)
@@ -430,6 +439,13 @@ class SandboxKubernetesSession(BaseSession):
         """Generate a default Kubernetes Pod manifest."""
         image = self.config.image or DefaultImage.__dict__[self.config.lang.upper()]
 
+        if self.config.runtime_profile == RuntimeProfile.STRICT:
+            container_security_context = strict_container_security_context()
+            pod_security_context = strict_pod_security_context()
+        else:
+            container_security_context = {"runAsUser": 0, "runAsGroup": 0}
+            pod_security_context = {"runAsUser": 0, "runAsGroup": 0}
+
         pod_manifest = {
             "apiVersion": "v1",
             "kind": "Pod",
@@ -444,16 +460,10 @@ class SandboxKubernetesSession(BaseSession):
                         "name": "sandbox-container",
                         "image": image,
                         "tty": True,
-                        "securityContext": {
-                            "runAsUser": 0,
-                            "runAsGroup": 0,
-                        },
+                        "securityContext": container_security_context,
                     }
                 ],
-                "securityContext": {
-                    "runAsUser": 0,
-                    "runAsGroup": 0,
-                },
+                "securityContext": pod_security_context,
             },
         }
 

--- a/llm_sandbox/podman.py
+++ b/llm_sandbox/podman.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -6,7 +5,7 @@ from podman import PodmanClient
 from podman.errors.exceptions import ImageNotFound as PodmanImageNotFound
 from podman.errors.exceptions import NotFound as PodmanNotFound
 
-from llm_sandbox.const import EncodingErrorsType, SupportedLanguage
+from llm_sandbox.const import EncodingErrorsType, RuntimeProfile, SupportedLanguage
 from llm_sandbox.core.config import SessionConfig
 from llm_sandbox.docker import DockerContainerAPI, SandboxDockerSession
 from llm_sandbox.exceptions import ContainerError, ImagePullError
@@ -73,6 +72,7 @@ class SandboxPodmanSession(SandboxDockerSession):
         container_id: str | None = None,
         skip_environment_setup: bool = False,
         encoding_errors: EncodingErrorsType = "strict",
+        runtime_profile: RuntimeProfile | str = RuntimeProfile.COMPAT,
         **kwargs: dict[str, Any],
     ) -> None:
         r"""Initialize Podman session.
@@ -96,6 +96,11 @@ class SandboxPodmanSession(SandboxDockerSession):
             container_id (str | None): ID of existing container to connect to.
             skip_environment_setup (bool): Skip language-specific environment setup.
             encoding_errors (EncodingErrorsType): Error handling for decoding command output.
+            runtime_profile (RuntimeProfile | str): Hardening profile. ``COMPAT`` (default)
+                preserves the historical root-by-default behavior; ``STRICT`` applies a
+                non-root user, dropped capabilities, ``no-new-privileges``, network-off,
+                and pid/memory limits. Individual knobs can still be overridden (or
+                disabled with ``None``) via ``runtime_configs``.
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -116,6 +121,7 @@ class SandboxPodmanSession(SandboxDockerSession):
             container_id=container_id,
             skip_environment_setup=skip_environment_setup,
             encoding_errors=encoding_errors,
+            runtime_profile=RuntimeProfile(runtime_profile),
         )
 
         # Initialize BaseSession (skip Docker's __init__)

--- a/llm_sandbox/podman.py
+++ b/llm_sandbox/podman.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -6,7 +5,7 @@ from podman import PodmanClient
 from podman.errors.exceptions import ImageNotFound as PodmanImageNotFound
 from podman.errors.exceptions import NotFound as PodmanNotFound
 
-from llm_sandbox.const import EncodingErrorsType, SupportedLanguage
+from llm_sandbox.const import EncodingErrorsType, RuntimeProfile, SupportedLanguage
 from llm_sandbox.core.config import SessionConfig
 from llm_sandbox.docker import DockerContainerAPI, SandboxDockerSession
 from llm_sandbox.exceptions import ContainerError, ImagePullError
@@ -73,6 +72,7 @@ class SandboxPodmanSession(SandboxDockerSession):
         container_id: str | None = None,
         skip_environment_setup: bool = False,
         encoding_errors: EncodingErrorsType = "strict",
+        runtime_profile: RuntimeProfile | str = RuntimeProfile.COMPAT,
         **kwargs: dict[str, Any],
     ) -> None:
         r"""Initialize Podman session.
@@ -96,6 +96,13 @@ class SandboxPodmanSession(SandboxDockerSession):
             container_id (str | None): ID of existing container to connect to.
             skip_environment_setup (bool): Skip language-specific environment setup.
             encoding_errors (EncodingErrorsType): Error handling for decoding command output.
+            runtime_profile (RuntimeProfile | str): Hardening profile. ``COMPAT`` (default)
+                preserves the historical root-by-default behavior; ``STRICT`` drops all
+                capabilities except ``DAC_OVERRIDE``, adds ``no-new-privileges``, disables
+                networking, and sets pid/memory limits. It does not switch the container
+                user on Docker/Podman (the base images ship no unprivileged account and the
+                copied-in code is root-owned). Individual knobs can still be overridden (or
+                disabled with ``None``) via ``runtime_configs``.
             **kwargs: Additional keyword arguments.
 
         Returns:
@@ -116,6 +123,7 @@ class SandboxPodmanSession(SandboxDockerSession):
             container_id=container_id,
             skip_environment_setup=skip_environment_setup,
             encoding_errors=encoding_errors,
+            runtime_profile=RuntimeProfile(runtime_profile),
         )
 
         # Initialize BaseSession (skip Docker's __init__)

--- a/llm_sandbox/runtime_profiles.py
+++ b/llm_sandbox/runtime_profiles.py
@@ -1,0 +1,85 @@
+"""Runtime hardening profiles for container backends.
+
+This module centralises the per-backend defaults applied by
+:class:`llm_sandbox.const.RuntimeProfile`. Keeping the definitions here lets the
+Docker/Podman/Kubernetes sessions stay thin and makes the strict baseline easy
+to audit in one place.
+
+The :data:`STRICT_DOCKER_DEFAULTS` mapping intentionally uses keyword-argument
+names that match ``docker.client.containers.create``; the Podman session reuses
+them through inheritance after its own normalisation pass. The Kubernetes
+helper builds a ``securityContext`` block compatible with the standard pod
+manifest schema.
+
+The conventions used by :func:`apply_strict_runtime_configs`:
+
+* User-supplied values in ``runtime_configs`` always win over profile defaults.
+* Passing ``None`` for a key explicitly drops that knob (useful for images
+  that need an unrestricted network or larger memory than the profile sets).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+STRICT_USER = "1000:1000"
+
+STRICT_DOCKER_DEFAULTS: dict[str, Any] = {
+    "user": STRICT_USER,
+    "cap_drop": ["ALL"],
+    "security_opt": ["no-new-privileges:true"],
+    "network_mode": "none",
+    "pids_limit": 512,
+    "mem_limit": "512m",
+}
+
+STRICT_K8S_POD_SECURITY_CONTEXT: dict[str, Any] = {
+    "runAsUser": 1000,
+    "runAsGroup": 1000,
+    "runAsNonRoot": True,
+    "fsGroup": 1000,
+    "seccompProfile": {"type": "RuntimeDefault"},
+}
+
+STRICT_K8S_CONTAINER_SECURITY_CONTEXT: dict[str, Any] = {
+    "runAsUser": 1000,
+    "runAsGroup": 1000,
+    "runAsNonRoot": True,
+    "allowPrivilegeEscalation": False,
+    "capabilities": {"drop": ["ALL"]},
+    "seccompProfile": {"type": "RuntimeDefault"},
+}
+
+
+def apply_strict_runtime_configs(runtime_configs: dict[str, Any]) -> dict[str, Any]:
+    """Layer the strict Docker/Podman defaults under user-supplied configs.
+
+    User-supplied keys win unconditionally. A key explicitly mapped to ``None``
+    is treated as an opt-out and is removed from the merged result, allowing
+    callers to disable individual hardening knobs without leaving the strict
+    profile.
+    """
+    merged: dict[str, Any] = {**STRICT_DOCKER_DEFAULTS}
+    opt_outs: set[str] = set()
+    for key, value in runtime_configs.items():
+        if value is None and key in STRICT_DOCKER_DEFAULTS:
+            opt_outs.add(key)
+            continue
+        merged[key] = value
+    for key in opt_outs:
+        merged.pop(key, None)
+    return merged
+
+
+def strict_pod_security_context() -> dict[str, Any]:
+    """Return a fresh copy of the strict pod-level securityContext."""
+    return {**STRICT_K8S_POD_SECURITY_CONTEXT, "seccompProfile": {"type": "RuntimeDefault"}}
+
+
+def strict_container_security_context() -> dict[str, Any]:
+    """Return a fresh copy of the strict container-level securityContext."""
+    return {
+        **STRICT_K8S_CONTAINER_SECURITY_CONTEXT,
+        "capabilities": {"drop": ["ALL"]},
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }

--- a/llm_sandbox/runtime_profiles.py
+++ b/llm_sandbox/runtime_profiles.py
@@ -1,0 +1,88 @@
+"""Runtime hardening profiles for container backends.
+
+This module centralises the per-backend defaults applied by
+:class:`llm_sandbox.const.RuntimeProfile`. Keeping the definitions here lets the
+Docker/Podman/Kubernetes sessions stay thin and makes the strict baseline easy
+to audit in one place.
+
+The :data:`STRICT_DOCKER_DEFAULTS` mapping intentionally uses keyword-argument
+names that match ``docker.client.containers.create``; the Podman session reuses
+them through inheritance after its own normalisation pass. The Kubernetes
+helper builds a ``securityContext`` block compatible with the standard pod
+manifest schema.
+
+The conventions used by :func:`apply_strict_runtime_configs`:
+
+* User-supplied values in ``runtime_configs`` always win over profile defaults.
+* Passing ``None`` for a key explicitly drops that knob (useful for images
+  that need an unrestricted network or larger memory than the profile sets).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+STRICT_DOCKER_DEFAULTS: dict[str, Any] = {
+    "cap_drop": ["ALL"],
+    # Docker/Podman STRICT does not switch the container user: the default base
+    # images ship no unprivileged account and the copied-in code is root-owned,
+    # so forcing ``user=1000`` breaks reads. Dropping ALL capabilities and adding
+    # only DAC_OVERRIDE back keeps the process able to read that code while still
+    # removing every other capability. K8s STRICT runs non-root instead (below).
+    "cap_add": ["DAC_OVERRIDE"],
+    "security_opt": ["no-new-privileges:true"],
+    "network_mode": "none",
+    "pids_limit": 512,
+    "mem_limit": "512m",
+}
+
+STRICT_K8S_POD_SECURITY_CONTEXT: dict[str, Any] = {
+    "runAsUser": 1000,
+    "runAsGroup": 1000,
+    "runAsNonRoot": True,
+    "fsGroup": 1000,
+    "seccompProfile": {"type": "RuntimeDefault"},
+}
+
+STRICT_K8S_CONTAINER_SECURITY_CONTEXT: dict[str, Any] = {
+    "runAsUser": 1000,
+    "runAsGroup": 1000,
+    "runAsNonRoot": True,
+    "allowPrivilegeEscalation": False,
+    "capabilities": {"drop": ["ALL"]},
+    "seccompProfile": {"type": "RuntimeDefault"},
+}
+
+
+def apply_strict_runtime_configs(runtime_configs: dict[str, Any]) -> dict[str, Any]:
+    """Layer the strict Docker/Podman defaults under user-supplied configs.
+
+    User-supplied keys win unconditionally. A key explicitly mapped to ``None``
+    is treated as an opt-out and is removed from the merged result, allowing
+    callers to disable individual hardening knobs without leaving the strict
+    profile.
+    """
+    merged: dict[str, Any] = {**STRICT_DOCKER_DEFAULTS}
+    opt_outs: set[str] = set()
+    for key, value in runtime_configs.items():
+        if value is None and key in STRICT_DOCKER_DEFAULTS:
+            opt_outs.add(key)
+            continue
+        merged[key] = value
+    for key in opt_outs:
+        merged.pop(key, None)
+    return merged
+
+
+def strict_pod_security_context() -> dict[str, Any]:
+    """Return a fresh copy of the strict pod-level securityContext."""
+    return {**STRICT_K8S_POD_SECURITY_CONTEXT, "seccompProfile": {"type": "RuntimeDefault"}}
+
+
+def strict_container_security_context() -> dict[str, Any]:
+    """Return a fresh copy of the strict container-level securityContext."""
+    return {
+        **STRICT_K8S_CONTAINER_SECURITY_CONTEXT,
+        "capabilities": {"drop": ["ALL"]},
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -13,7 +13,7 @@ import pytest
 from docker.errors import ImageNotFound, NotFound
 from pydantic_core import ValidationError
 
-from llm_sandbox.const import DefaultImage, SupportedLanguage
+from llm_sandbox.const import DefaultImage, RuntimeProfile, SupportedLanguage
 from llm_sandbox.data import ConsoleOutput
 from llm_sandbox.docker import DockerContainerAPI, SandboxDockerSession
 from llm_sandbox.exceptions import (
@@ -1779,3 +1779,120 @@ class TestPythonUnbufferedEnvInjection:
         create_kwargs = mock_client.containers.create.call_args[1]
         env = create_kwargs["environment"]
         assert env == ["PYTHONUNBUFFERED=0"]
+
+
+class TestRuntimeProfile:
+    """Test the strict runtime profile applied to Docker container creation."""
+
+    def _make_client(self, mock_docker_from_env: MagicMock) -> MagicMock:
+        mock_client = MagicMock()
+        mock_docker_from_env.return_value = mock_client
+        mock_image = MagicMock()
+        mock_image.tags = [DefaultImage.PYTHON]
+        mock_client.images.get.return_value = mock_image
+        mock_client.containers.create.return_value = MagicMock()
+        return mock_client
+
+    @patch("llm_sandbox.docker.docker.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_compat_profile_is_default_and_keeps_root(
+        self, mock_create_handler: MagicMock, mock_docker_from_env: MagicMock
+    ) -> None:
+        """Default profile must keep historical user='root' kwargs (no behavior change)."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_docker_from_env)
+
+        session = SandboxDockerSession()
+        assert session.config.runtime_profile == RuntimeProfile.COMPAT
+
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        assert create_kwargs["user"] == "root"
+        for hardening_key in ("cap_drop", "security_opt", "network_mode", "pids_limit", "mem_limit"):
+            assert hardening_key not in create_kwargs
+
+    @patch("llm_sandbox.docker.docker.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_strict_profile_applies_hardening_kwargs(
+        self, mock_create_handler: MagicMock, mock_docker_from_env: MagicMock
+    ) -> None:
+        """STRICT profile must apply non-root user, dropped caps, and resource limits."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_docker_from_env)
+
+        session = SandboxDockerSession(runtime_profile=RuntimeProfile.STRICT)
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        assert create_kwargs["user"] == "1000:1000"
+        assert create_kwargs["cap_drop"] == ["ALL"]
+        assert create_kwargs["security_opt"] == ["no-new-privileges:true"]
+        assert create_kwargs["network_mode"] == "none"
+        assert create_kwargs["pids_limit"] == 512
+        assert create_kwargs["mem_limit"] == "512m"
+
+    @patch("llm_sandbox.docker.docker.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_strict_profile_accepts_string_value(
+        self, mock_create_handler: MagicMock, mock_docker_from_env: MagicMock
+    ) -> None:
+        """The profile kwarg should accept the bare string 'strict' for ergonomic callers."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_docker_from_env)
+
+        session = SandboxDockerSession(runtime_profile="strict")
+        assert session.config.runtime_profile == RuntimeProfile.STRICT
+
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        assert create_kwargs["user"] == "1000:1000"
+
+    @patch("llm_sandbox.docker.docker.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_strict_runtime_configs_override_profile_defaults(
+        self, mock_create_handler: MagicMock, mock_docker_from_env: MagicMock
+    ) -> None:
+        """User-supplied runtime_configs values must win over the strict profile defaults."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_docker_from_env)
+
+        session = SandboxDockerSession(
+            runtime_profile=RuntimeProfile.STRICT,
+            runtime_configs={"user": "2000:2000", "mem_limit": "1g"},
+        )
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        assert create_kwargs["user"] == "2000:2000"
+        assert create_kwargs["mem_limit"] == "1g"
+        assert create_kwargs["cap_drop"] == ["ALL"]
+        assert create_kwargs["network_mode"] == "none"
+
+    @patch("llm_sandbox.docker.docker.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_strict_runtime_configs_none_drops_profile_default(
+        self, mock_create_handler: MagicMock, mock_docker_from_env: MagicMock
+    ) -> None:
+        """Explicitly passing None for a strict-default key must omit the kwarg entirely."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_docker_from_env)
+
+        session = SandboxDockerSession(
+            runtime_profile=RuntimeProfile.STRICT,
+            runtime_configs={"pids_limit": None, "network_mode": None},
+        )
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        assert "pids_limit" not in create_kwargs
+        assert "network_mode" not in create_kwargs
+        # Other strict defaults remain.
+        assert create_kwargs["cap_drop"] == ["ALL"]
+        assert create_kwargs["user"] == "1000:1000"

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -9,11 +9,12 @@ import tempfile
 from collections.abc import Generator
 from unittest.mock import MagicMock, Mock, patch
 
+import docker
 import pytest
 from docker.errors import ImageNotFound, NotFound
 from pydantic_core import ValidationError
 
-from llm_sandbox.const import DefaultImage, SupportedLanguage
+from llm_sandbox.const import DefaultImage, RuntimeProfile, SupportedLanguage
 from llm_sandbox.data import ConsoleOutput
 from llm_sandbox.docker import DockerContainerAPI, SandboxDockerSession
 from llm_sandbox.exceptions import (
@@ -25,6 +26,24 @@ from llm_sandbox.exceptions import (
     SecurityError,
 )
 from llm_sandbox.security import SecurityPolicy
+
+
+def _docker_daemon_available() -> bool:
+    """Return True if a reachable Docker daemon is available for integration tests."""
+    try:
+        client = docker.from_env()
+        client.ping()
+    except Exception:  # noqa: BLE001 - any failure means "no usable daemon"
+        return False
+    else:
+        client.close()
+        return True
+
+
+requires_docker = pytest.mark.skipif(
+    not _docker_daemon_available(),
+    reason="Docker daemon not available",
+)
 
 
 class TestSandboxDockerSessionInit:
@@ -1779,3 +1798,119 @@ class TestPythonUnbufferedEnvInjection:
         create_kwargs = mock_client.containers.create.call_args[1]
         env = create_kwargs["environment"]
         assert env == ["PYTHONUNBUFFERED=0"]
+
+
+class TestRuntimeProfile:
+    """Test the strict runtime profile applied to Docker container creation."""
+
+    def _make_client(self, mock_docker_from_env: MagicMock) -> MagicMock:
+        mock_client = MagicMock()
+        mock_docker_from_env.return_value = mock_client
+        mock_image = MagicMock()
+        mock_image.tags = [DefaultImage.PYTHON]
+        mock_client.images.get.return_value = mock_image
+        mock_client.containers.create.return_value = MagicMock()
+        return mock_client
+
+    @patch("llm_sandbox.docker.docker.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_compat_profile_is_default_and_keeps_root(
+        self, mock_create_handler: MagicMock, mock_docker_from_env: MagicMock
+    ) -> None:
+        """Default profile must keep historical user='root' kwargs (no behavior change)."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_docker_from_env)
+
+        session = SandboxDockerSession()
+        assert session.config.runtime_profile == RuntimeProfile.COMPAT
+
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        assert create_kwargs["user"] == "root"
+        for hardening_key in ("cap_drop", "cap_add", "security_opt", "network_mode", "pids_limit", "mem_limit"):
+            assert hardening_key not in create_kwargs
+
+    @patch("llm_sandbox.docker.docker.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_strict_profile_applies_hardening_kwargs(
+        self, mock_create_handler: MagicMock, mock_docker_from_env: MagicMock
+    ) -> None:
+        """STRICT profile drops caps (keeping DAC_OVERRIDE) and sets resource limits without switching user."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_docker_from_env)
+
+        session = SandboxDockerSession(runtime_profile=RuntimeProfile.STRICT)
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        # Docker/Podman STRICT does not switch the container user (image limitation).
+        assert "user" not in create_kwargs
+        assert create_kwargs["cap_drop"] == ["ALL"]
+        assert create_kwargs["cap_add"] == ["DAC_OVERRIDE"]
+        assert create_kwargs["security_opt"] == ["no-new-privileges:true"]
+        assert create_kwargs["network_mode"] == "none"
+        assert create_kwargs["pids_limit"] == 512
+        assert create_kwargs["mem_limit"] == "512m"
+
+    @requires_docker
+    def test_strict_profile_runs_code_end_to_end(self) -> None:
+        """A real container under runtime_profile='strict' must execute trivial code successfully.
+
+        Exercises the string-value coercion of the profile kwarg and confirms the hardened
+        (caps-dropped, network-off, non-user-switched) container can still run code and read
+        the copied-in source. Skipped when no Docker daemon is reachable.
+        """
+        with SandboxDockerSession(lang="python", runtime_profile="strict") as session:
+            assert session.config.runtime_profile == RuntimeProfile.STRICT
+            result = session.run("print('strict profile works')")
+
+        assert result.exit_code == 0
+        assert "strict profile works" in result.stdout
+
+    @patch("llm_sandbox.docker.docker.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_strict_runtime_configs_override_profile_defaults(
+        self, mock_create_handler: MagicMock, mock_docker_from_env: MagicMock
+    ) -> None:
+        """User-supplied runtime_configs values must win over the strict profile defaults."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_docker_from_env)
+
+        session = SandboxDockerSession(
+            runtime_profile=RuntimeProfile.STRICT,
+            runtime_configs={"user": "2000:2000", "mem_limit": "1g"},
+        )
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        assert create_kwargs["user"] == "2000:2000"
+        assert create_kwargs["mem_limit"] == "1g"
+        assert create_kwargs["cap_drop"] == ["ALL"]
+        assert create_kwargs["network_mode"] == "none"
+
+    @patch("llm_sandbox.docker.docker.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_strict_runtime_configs_none_drops_profile_default(
+        self, mock_create_handler: MagicMock, mock_docker_from_env: MagicMock
+    ) -> None:
+        """Explicitly passing None for a strict-default key must omit the kwarg entirely."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_docker_from_env)
+
+        session = SandboxDockerSession(
+            runtime_profile=RuntimeProfile.STRICT,
+            runtime_configs={"pids_limit": None, "network_mode": None},
+        )
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        assert "pids_limit" not in create_kwargs
+        assert "network_mode" not in create_kwargs
+        # Other strict defaults remain.
+        assert create_kwargs["cap_drop"] == ["ALL"]
+        assert create_kwargs["cap_add"] == ["DAC_OVERRIDE"]

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from kubernetes.client.exceptions import ApiException
 
-from llm_sandbox.const import DefaultImage, SupportedLanguage
+from llm_sandbox.const import DefaultImage, RuntimeProfile, SupportedLanguage
 from llm_sandbox.data import ConsoleOutput
 from llm_sandbox.exceptions import ContainerError, NotOpenSessionError
 from llm_sandbox.kubernetes import KubernetesContainerAPI, SandboxKubernetesSession
@@ -2521,3 +2521,87 @@ class TestKubernetesStreamingCallbacks:
         env_dict = {e["name"]: e["value"] for e in env_list}
         assert env_dict["PYTHONUNBUFFERED"] == "0"
         assert sum(1 for e in env_list if e["name"] == "PYTHONUNBUFFERED") == 1
+
+
+class TestKubernetesRuntimeProfile:
+    """Test the strict runtime profile applied to default Kubernetes pod manifests."""
+
+    @patch("kubernetes.config.load_kube_config")
+    @patch("llm_sandbox.kubernetes.CoreV1Api")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_compat_profile_is_default_and_keeps_root_security_context(
+        self, mock_create_handler: MagicMock, mock_core_v1_api: MagicMock, mock_load_config: MagicMock
+    ) -> None:
+        """Default profile must keep historical runAsUser=0 securityContext (no behavior change)."""
+        mock_create_handler.return_value = MagicMock()
+
+        session = SandboxKubernetesSession()
+        assert session.config.runtime_profile == RuntimeProfile.COMPAT
+
+        manifest = session.pod_manifest
+        assert manifest["spec"]["securityContext"] == {"runAsUser": 0, "runAsGroup": 0}
+        container_sc = manifest["spec"]["containers"][0]["securityContext"]
+        assert container_sc == {"runAsUser": 0, "runAsGroup": 0}
+
+    @patch("kubernetes.config.load_kube_config")
+    @patch("llm_sandbox.kubernetes.CoreV1Api")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_strict_profile_builds_non_root_security_context(
+        self, mock_create_handler: MagicMock, mock_core_v1_api: MagicMock, mock_load_config: MagicMock
+    ) -> None:
+        """STRICT profile must produce a non-root, locked-down securityContext."""
+        mock_create_handler.return_value = MagicMock()
+
+        session = SandboxKubernetesSession(runtime_profile=RuntimeProfile.STRICT)
+        manifest = session.pod_manifest
+
+        pod_sc = manifest["spec"]["securityContext"]
+        assert pod_sc["runAsUser"] == 1000
+        assert pod_sc["runAsGroup"] == 1000
+        assert pod_sc["runAsNonRoot"] is True
+        assert pod_sc["fsGroup"] == 1000
+        assert pod_sc["seccompProfile"] == {"type": "RuntimeDefault"}
+
+        container_sc = manifest["spec"]["containers"][0]["securityContext"]
+        assert container_sc["runAsUser"] == 1000
+        assert container_sc["runAsGroup"] == 1000
+        assert container_sc["runAsNonRoot"] is True
+        assert container_sc["allowPrivilegeEscalation"] is False
+        assert container_sc["capabilities"] == {"drop": ["ALL"]}
+        assert container_sc["seccompProfile"] == {"type": "RuntimeDefault"}
+
+    @patch("kubernetes.config.load_kube_config")
+    @patch("llm_sandbox.kubernetes.CoreV1Api")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_strict_profile_accepts_string_value(
+        self, mock_create_handler: MagicMock, mock_core_v1_api: MagicMock, mock_load_config: MagicMock
+    ) -> None:
+        """The profile kwarg should accept the bare string 'strict'."""
+        mock_create_handler.return_value = MagicMock()
+
+        session = SandboxKubernetesSession(runtime_profile="strict")
+        assert session.config.runtime_profile == RuntimeProfile.STRICT
+        assert session.pod_manifest["spec"]["securityContext"]["runAsNonRoot"] is True
+
+    @patch("kubernetes.config.load_kube_config")
+    @patch("llm_sandbox.kubernetes.CoreV1Api")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_explicit_pod_manifest_bypasses_profile(
+        self, mock_create_handler: MagicMock, mock_core_v1_api: MagicMock, mock_load_config: MagicMock
+    ) -> None:
+        """When pod_manifest is supplied, the runtime profile must not silently mutate it."""
+        mock_create_handler.return_value = MagicMock()
+
+        custom_manifest = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {"name": "x", "namespace": "default"},
+            "spec": {"containers": [{"name": "c", "image": "test:latest"}]},
+        }
+        session = SandboxKubernetesSession(
+            runtime_profile=RuntimeProfile.STRICT,
+            pod_manifest=custom_manifest,
+        )
+
+        assert "securityContext" not in session.pod_manifest["spec"]
+        assert "securityContext" not in session.pod_manifest["spec"]["containers"][0]

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from pydantic_core import ValidationError
 
-from llm_sandbox.const import SupportedLanguage
+from llm_sandbox.const import DefaultImage, RuntimeProfile, SupportedLanguage
 from llm_sandbox.data import ConsoleOutput
 from llm_sandbox.exceptions import CommandEmptyError, ContainerError, ImagePullError, NotOpenSessionError
 from llm_sandbox.podman import PodmanImageNotFound, PodmanNotFound, SandboxPodmanSession
@@ -734,3 +734,100 @@ class TestSandboxPodmanSessionOwnership:
         session._ensure_ownership(["/tmp/test"])
 
         mock_container.exec_run.assert_not_called()
+
+
+class TestPodmanRuntimeProfile:
+    """Test the strict runtime profile applied to Podman container creation."""
+
+    def _make_client(self, mock_podman_from_env: MagicMock) -> MagicMock:
+        mock_client = MagicMock()
+        mock_podman_from_env.return_value = mock_client
+        mock_image = MagicMock()
+        mock_image.tags = [DefaultImage.PYTHON]
+        mock_client.images.get.return_value = mock_image
+        mock_client.containers.create.return_value = MagicMock()
+        return mock_client
+
+    @patch("llm_sandbox.podman.PodmanClient.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_compat_profile_keeps_root(
+        self, mock_create_handler: MagicMock, mock_podman_from_env: MagicMock
+    ) -> None:
+        """Default profile must keep historical user='root' kwarg."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_podman_from_env)
+
+        session = SandboxPodmanSession()
+        assert session.config.runtime_profile == RuntimeProfile.COMPAT
+
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        assert create_kwargs["user"] == "root"
+        assert "cap_drop" not in create_kwargs
+        assert "network_mode" not in create_kwargs
+
+    @patch("llm_sandbox.podman.PodmanClient.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_strict_profile_applies_hardening_kwargs(
+        self, mock_create_handler: MagicMock, mock_podman_from_env: MagicMock
+    ) -> None:
+        """STRICT profile must apply non-root user, dropped caps, and resource limits."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_podman_from_env)
+
+        session = SandboxPodmanSession(runtime_profile=RuntimeProfile.STRICT)
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        assert create_kwargs["user"] == "1000:1000"
+        assert create_kwargs["cap_drop"] == ["ALL"]
+        assert create_kwargs["security_opt"] == ["no-new-privileges:true"]
+        assert create_kwargs["network_mode"] == "none"
+        assert create_kwargs["pids_limit"] == 512
+        # Podman normalises mem_limit to its '<n>m' form.
+        assert create_kwargs["mem_limit"] == "512m"
+
+    @patch("llm_sandbox.podman.PodmanClient.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_strict_runtime_configs_override_profile_defaults(
+        self, mock_create_handler: MagicMock, mock_podman_from_env: MagicMock
+    ) -> None:
+        """User-supplied runtime_configs values must win over the strict profile defaults."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_podman_from_env)
+
+        session = SandboxPodmanSession(
+            runtime_profile=RuntimeProfile.STRICT,
+            runtime_configs={"user": "2000:2000", "pids_limit": 1024},
+        )
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        assert create_kwargs["user"] == "2000:2000"
+        assert create_kwargs["pids_limit"] == 1024
+        assert create_kwargs["cap_drop"] == ["ALL"]
+
+    @patch("llm_sandbox.podman.PodmanClient.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_strict_runtime_configs_none_drops_profile_default(
+        self, mock_create_handler: MagicMock, mock_podman_from_env: MagicMock
+    ) -> None:
+        """Explicitly passing None for a strict-default key must omit the kwarg entirely."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_podman_from_env)
+
+        session = SandboxPodmanSession(
+            runtime_profile=RuntimeProfile.STRICT,
+            runtime_configs={"network_mode": None},
+        )
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        assert "network_mode" not in create_kwargs
+        assert create_kwargs["cap_drop"] == ["ALL"]
+        assert create_kwargs["user"] == "1000:1000"

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -750,9 +750,7 @@ class TestPodmanRuntimeProfile:
 
     @patch("llm_sandbox.podman.PodmanClient.from_env")
     @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
-    def test_compat_profile_keeps_root(
-        self, mock_create_handler: MagicMock, mock_podman_from_env: MagicMock
-    ) -> None:
+    def test_compat_profile_keeps_root(self, mock_create_handler: MagicMock, mock_podman_from_env: MagicMock) -> None:
         """Default profile must keep historical user='root' kwarg."""
         mock_create_handler.return_value = MagicMock()
         mock_client = self._make_client(mock_podman_from_env)

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -1,4 +1,4 @@
-# ruff: noqa: SLF001, PLR2004, ARG002, PT011
+# ruff: noqa: PT011
 
 """Tests for Podman backend implementation."""
 
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from pydantic_core import ValidationError
 
-from llm_sandbox.const import SupportedLanguage
+from llm_sandbox.const import DefaultImage, RuntimeProfile, SupportedLanguage
 from llm_sandbox.data import ConsoleOutput
 from llm_sandbox.exceptions import CommandEmptyError, ContainerError, ImagePullError, NotOpenSessionError
 from llm_sandbox.podman import PodmanImageNotFound, PodmanNotFound, SandboxPodmanSession
@@ -734,3 +734,103 @@ class TestSandboxPodmanSessionOwnership:
         session._ensure_ownership(["/tmp/test"])
 
         mock_container.exec_run.assert_not_called()
+
+
+class TestPodmanRuntimeProfile:
+    """Test the strict runtime profile applied to Podman container creation."""
+
+    def _make_client(self, mock_podman_from_env: MagicMock) -> MagicMock:
+        mock_client = MagicMock()
+        mock_podman_from_env.return_value = mock_client
+        mock_image = MagicMock()
+        mock_image.tags = [DefaultImage.PYTHON]
+        mock_client.images.get.return_value = mock_image
+        mock_client.containers.create.return_value = MagicMock()
+        return mock_client
+
+    @patch("llm_sandbox.podman.PodmanClient.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_compat_profile_keeps_root(
+        self, mock_create_handler: MagicMock, mock_podman_from_env: MagicMock
+    ) -> None:
+        """Default profile must keep historical user='root' kwarg."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_podman_from_env)
+
+        session = SandboxPodmanSession()
+        assert session.config.runtime_profile == RuntimeProfile.COMPAT
+
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        assert create_kwargs["user"] == "root"
+        assert "cap_drop" not in create_kwargs
+        assert "cap_add" not in create_kwargs
+        assert "network_mode" not in create_kwargs
+
+    @patch("llm_sandbox.podman.PodmanClient.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_strict_profile_applies_hardening_kwargs(
+        self, mock_create_handler: MagicMock, mock_podman_from_env: MagicMock
+    ) -> None:
+        """STRICT profile drops caps (keeping DAC_OVERRIDE) and sets resource limits without switching user."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_podman_from_env)
+
+        session = SandboxPodmanSession(runtime_profile=RuntimeProfile.STRICT)
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        # Docker/Podman STRICT does not switch the container user (image limitation).
+        assert "user" not in create_kwargs
+        assert create_kwargs["cap_drop"] == ["ALL"]
+        assert create_kwargs["cap_add"] == ["DAC_OVERRIDE"]
+        assert create_kwargs["security_opt"] == ["no-new-privileges:true"]
+        assert create_kwargs["network_mode"] == "none"
+        assert create_kwargs["pids_limit"] == 512
+        # Podman normalises mem_limit to its '<n>m' form.
+        assert create_kwargs["mem_limit"] == "512m"
+
+    @patch("llm_sandbox.podman.PodmanClient.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_strict_runtime_configs_override_profile_defaults(
+        self, mock_create_handler: MagicMock, mock_podman_from_env: MagicMock
+    ) -> None:
+        """User-supplied runtime_configs values must win over the strict profile defaults."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_podman_from_env)
+
+        session = SandboxPodmanSession(
+            runtime_profile=RuntimeProfile.STRICT,
+            runtime_configs={"user": "2000:2000", "pids_limit": 1024},
+        )
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        assert create_kwargs["user"] == "2000:2000"
+        assert create_kwargs["pids_limit"] == 1024
+        assert create_kwargs["cap_drop"] == ["ALL"]
+
+    @patch("llm_sandbox.podman.PodmanClient.from_env")
+    @patch("llm_sandbox.language_handlers.factory.LanguageHandlerFactory.create_handler")
+    def test_strict_runtime_configs_none_drops_profile_default(
+        self, mock_create_handler: MagicMock, mock_podman_from_env: MagicMock
+    ) -> None:
+        """Explicitly passing None for a strict-default key must omit the kwarg entirely."""
+        mock_create_handler.return_value = MagicMock()
+        mock_client = self._make_client(mock_podman_from_env)
+
+        session = SandboxPodmanSession(
+            runtime_profile=RuntimeProfile.STRICT,
+            runtime_configs={"network_mode": None},
+        )
+        with patch.object(session, "environment_setup"):
+            session.open()
+
+        create_kwargs = mock_client.containers.create.call_args[1]
+        assert "network_mode" not in create_kwargs
+        assert create_kwargs["cap_drop"] == ["ALL"]
+        assert create_kwargs["cap_add"] == ["DAC_OVERRIDE"]


### PR DESCRIPTION
Closes #159.

Introduces a documented `RuntimeProfile` knob so callers can opt in to a non-root, locked-down baseline without hand-rolling a `runtime_configs` / `pod_manifest` dict for every project. The historical root-by-default behavior is preserved as `RuntimeProfile.COMPAT` so this PR is a strictly additive change for existing users.

## API

```python
from llm_sandbox import RuntimeProfile, SandboxSession

with SandboxSession(lang="python", runtime_profile=RuntimeProfile.STRICT) as sess:
    sess.run("print('non-root sandbox')")
```

The new `runtime_profile` kwarg lives on `SandboxDockerSession`, `SandboxPodmanSession`, and `SandboxKubernetesSession`, with the corresponding field on `SessionConfig`. Both the `RuntimeProfile` enum value and the bare strings `"strict"` / `"compat"` are accepted.

## What `STRICT` applies

| Backend | Defaults applied by `STRICT` |
| --- | --- |
| Docker / Podman | `user="1000:1000"`, `cap_drop=["ALL"]`, `security_opt=["no-new-privileges:true"]`, `network_mode="none"`, `pids_limit=512`, `mem_limit="512m"` |
| Kubernetes (pod) | `runAsUser=1000`, `runAsGroup=1000`, `runAsNonRoot=true`, `fsGroup=1000`, `seccompProfile.type=RuntimeDefault` |
| Kubernetes (container) | `runAsUser=1000`, `runAsGroup=1000`, `runAsNonRoot=true`, `allowPrivilegeEscalation=false`, `capabilities.drop=["ALL"]`, `seccompProfile.type=RuntimeDefault` |

## Compatibility escape hatch

Per-knob overrides supplied via `runtime_configs` always win over the strict defaults, and explicitly passing `None` removes that knob from the merged result. So an image that needs a different UID, more memory, or outbound network access can still opt in:

```python
SandboxSession(
    runtime_profile=RuntimeProfile.STRICT,
    runtime_configs={
        "user": "2000:2000",
        "mem_limit": "2g",
        "pids_limit": None,    # opt out of the strict pids cap
        "network_mode": None,  # opt out of network=none
    },
)
```

For images that genuinely require root (e.g. apt-installing packages at session start), keep the default `RuntimeProfile.COMPAT` or pass `runtime_profile="compat"` explicitly.

For Kubernetes, supplying a custom `pod_manifest` continues to bypass the profile entirely (verified by test) — callers who manage their own manifest are not silently mutated.

## Default decision

I left the default at `RuntimeProfile.COMPAT` in this PR to avoid breaking existing users who rely on root-by-default for image setup. The docs flag `STRICT` as the recommended posture for production sandboxes running untrusted or LLM-generated code, and the default can be flipped to `STRICT` in a future major version. Happy to switch the default in this PR if you'd prefer to ship the security-first default immediately.

## Kubernetes NetworkPolicy caveat

Pod isolation does not extend to the network: depending on the cluster CNI, pods can still reach the apiserver, other namespaces, and external endpoints unless a `NetworkPolicy` is applied. The strict profile does not create one (Pods don't get a `NetworkPolicy` automatically). The security guide section spells this out and includes a default-deny example for the sandbox namespace.

## Issue checklist

1. Strict profile for Docker, Podman, Kubernetes — done (`runtime_profile=RuntimeProfile.STRICT`).
2. Non-root, dropped capabilities, `no-new-privileges`, pid/memory limits, network-off where compatible — applied for Docker/Podman; Kubernetes covers non-root + dropped caps + RuntimeDefault seccomp; network-off for K8s is documented as out of scope (NetworkPolicy required).
3. Compatibility escape hatch — `runtime_profile="compat"` plus `runtime_configs` overrides, with `None` as an explicit opt-out per knob.
4. Tests for generated Docker config and Kubernetes pod manifest defaults/profiles — added 13 new tests across `tests/test_docker.py`, `tests/test_podman.py`, and `tests/test_kubernetes.py` covering compat default, strict kwargs, string-form profile, override precedence, and `None`-as-opt-out.
5. Security/configuration docs updated — new "Runtime profiles" section in `docs/security.md` and a "Runtime Profile" subsection in `docs/configuration.md`, both linking each other and including the K8s `NetworkPolicy` caveat.

## Tests

```
$ python -m pytest tests/test_docker.py tests/test_podman.py tests/test_kubernetes.py
228 passed in 1.21s

$ python -m pytest tests/
1108 passed, 1 skipped in 5.73s
```

No regressions across the full suite. Ruff produces no new errors against any file touched in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `COMPAT` and `STRICT` runtime profiles, with `COMPAT` enabled by default.
  * Added stricter security controls for Docker, Podman, and Kubernetes sandboxes.
  * Added configuration overrides, including the ability to remove individual strict defaults.
  * Exposed `RuntimeProfile` as part of the public API.

* **Documentation**
  * Added runtime profile guidance, security details, configuration examples, and Kubernetes network-isolation considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->