### PR TITLE
Add .zenodo.json for LLM Sandbox project metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,39 @@
+{
+  "upload_type": "software",
+  "title": "LLM Sandbox: a portable runtime for securely executing LLM-generated code",
+  "description": "<p>LLM Sandbox is a lightweight, portable sandbox runtime (code interpreter) for executing Large Language Model generated code in isolation. It provides pluggable container backends (Docker, Podman, Kubernetes, Micromamba), configurable security policies with static pre-execution analysis, resource and network limits, multi-language execution (Python, JavaScript, Java, C++, Go, R, Ruby), automatic artifact and plot extraction, container pooling for low-latency reuse, interactive notebook-style sessions, and a Model Context Protocol (MCP) server for AI assistants.</p><p>Documentation: https://vndee.github.io/llm-sandbox/</p>",
+  "access_right": "open",
+  "license": "MIT",
+  "creators": [
+    {
+      "name": "Huynh, Duy V.",
+      "affiliation": "University of Science, Vietnam National University Ho Chi Minh City"
+    }
+  ],
+  "keywords": [
+    "large language models",
+    "code interpreter",
+    "sandbox",
+    "secure code execution",
+    "AI agents",
+    "containers",
+    "Model Context Protocol"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/vndee/llm-sandbox",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://pypi.org/project/llm-sandbox/",
+      "relation": "isIdenticalTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://vndee.github.io/llm-sandbox/",
+      "relation": "isDocumentedBy",
+      "scheme": "url"
+    }
+  ]
+}


### PR DESCRIPTION
Added metadata for LLM Sandbox project including title, description, access rights, license, creators, keywords, and related identifiers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added software metadata for LLM Sandbox, including licensing, capabilities, creator information, keywords, documentation, source repository, and PyPI references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->