### PR TITLE
Keep CITATION.cff in sync with releases automatically

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -31,6 +31,43 @@ jobs:
           name: pyproject-toml
           path: pyproject.toml
 
+  update-citation:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      # Unlike the pyproject.toml bump above, which only feeds the build via an
+      # artifact, CITATION.cff has to be committed back: GitHub's "Cite this
+      # repository" widget and cffconvert both read it from the default branch.
+      - name: Check out default branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Update CITATION.cff to the released version
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
+          RELEASE_PUBLISHED_AT: ${{ github.event.release.published_at }}
+        run: |
+          set -euo pipefail
+          release_date="${RELEASE_PUBLISHED_AT%%T*}"
+          sed -i "s/^version: \".*\"/version: \"${RELEASE_VERSION}\"/" CITATION.cff
+          sed -i "s/^date-released: \".*\"/date-released: \"${release_date}\"/" CITATION.cff
+          grep -E '^(version|date-released):' CITATION.cff
+
+      - name: Commit and push if changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- CITATION.cff; then
+            echo "CITATION.cff already up to date; nothing to commit."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add CITATION.cff
+          git commit -m "Update CITATION.cff for ${{ github.event.release.tag_name }}"
+          git push
+
   publish:
     runs-on: ubuntu-latest
     needs: [set-version]

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,9 +18,6 @@ identifiers:
   - type: doi
     value: "10.5281/zenodo.21760525"
     description: "Concept DOI - always resolves to the latest release"
-  - type: doi
-    value: "10.5281/zenodo.21760526"
-    description: "DOI for version 0.3.40"
   - type: url
     value: "https://github.com/vndee/llm-sandbox"
     description: "The GitHub repository"
@@ -31,7 +28,7 @@ repository-code: "https://github.com/vndee/llm-sandbox"
 url: "https://vndee.github.io/llm-sandbox/"
 repository-artifact: "https://pypi.org/project/llm-sandbox/"
 license: MIT
-version: "0.3.40"
+version: "0.3.42"
 date-released: "2026-08-02"
 keywords:
   - "large language models"


### PR DESCRIPTION
`CITATION.cff` had drifted to `0.3.40` while PyPI reached `0.3.42`. Fixes the drift and the cause.

## Why the existing pattern doesn't work here

The release workflow already bumps a version — but look at what it does with it:

```yaml
- name: Update project version
  run: sed -i "s/^version = \".*\"/version = \"$RELEASE_VERSION\"/" pyproject.toml
- name: Upload updated pyproject.toml
  uses: actions/upload-artifact@v4
```

It rewrites `pyproject.toml` into an **artifact** that the `publish` job downloads to build the wheel. It never commits it back — which is why `pyproject.toml` still reads `version = "0.3.13"` in git and nobody notices.

`CITATION.cff` can't work that way. GitHub's "Cite this repository" widget and `cffconvert` both read it **from the default branch**, so an artifact-only update would be invisible. It has to be committed.

## What this adds

An `update-citation` job that checks out the default branch, rewrites `version` and `date-released` from `github.event.release.tag_name` / `published_at`, and pushes only if something actually changed.

It declares no `needs`, so it runs in parallel with `set-version` and **a failure here cannot block the PyPI publish** — metadata upkeep shouldn't be able to break a release.

## Also: dropping the version-specific DOI

```diff
-  - type: doi
-    value: "10.5281/zenodo.21760526"
-    description: "DOI for version 0.3.40"
```

This pointed at 0.3.40 and would need hand-updating every release — a second staleness source with no upside. The concept DOI (`10.5281/zenodo.21760525`) already resolves to the latest version and is what the README badge, `pyproject.toml`, and `paper/paper.md` all cite. Anyone needing a version-specific DOI gets it from the Zenodo record, which the remaining entry links to.

## Verification

- `cffconvert --validate` → *"Citation metadata are valid according to schema version 1.2.0"*
- Ran the sed expressions against the real file with a simulated `0.3.43` release: produces `version: "0.3.43"` / `date-released: "2026-09-14"`, and a diff of all other lines confirms **no collateral changes** — `cff-version: 1.2.0` is untouched because the anchor is `^version:`
- `make check` passes locally (lock file, all hooks, mypy 43 files, deptry)

> [!NOTE]
> The push to `main` requires `contents: write`, which the job declares. `main` is currently unprotected so this works as-is; if branch protection is added later, this job needs an exemption or a PAT.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated software citation metadata to reference the concept DOI.
  * Updated the listed release version to 0.3.42.
* **Chores**
  * Automated citation metadata updates after releases, including the released version and publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->