### PR TITLE
Open a PR from the citation job instead of pushing to main

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      pull-requests: write
     steps:
       # Unlike the pyproject.toml bump above, which only feeds the build via an
       # artifact, CITATION.cff has to be committed back: GitHub's "Cite this
@@ -55,18 +56,38 @@ jobs:
           sed -i "s/^date-released: \".*\"/date-released: \"${release_date}\"/" CITATION.cff
           grep -E '^(version|date-released):' CITATION.cff
 
-      - name: Commit and push if changed
+      # main is governed by a repository ruleset requiring pull requests, so this
+      # opens one rather than pushing directly. Direct pushes are rejected with
+      # GH013 even when the token holds contents: write.
+      - name: Open a pull request if changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
           if git diff --quiet -- CITATION.cff; then
-            echo "CITATION.cff already up to date; nothing to commit."
+            echo "CITATION.cff already up to date; nothing to do."
             exit 0
           fi
+
+          branch="citation/${RELEASE_VERSION}"
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git checkout -b "$branch"
           git add CITATION.cff
-          git commit -m "Update CITATION.cff for ${{ github.event.release.tag_name }}"
-          git push
+          git commit -m "Update CITATION.cff for ${RELEASE_VERSION}"
+          git push --force-with-lease origin "$branch"
+
+          # Reruns of the same release should update the existing PR, not fail.
+          if gh pr view "$branch" --json number >/dev/null 2>&1; then
+            echo "PR already open for $branch"
+          else
+            gh pr create \
+              --base "${{ github.event.repository.default_branch }}" \
+              --head "$branch" \
+              --title "Update CITATION.cff for ${RELEASE_VERSION}" \
+              --body "Automated: syncs \`version\` and \`date-released\` in \`CITATION.cff\` with the ${RELEASE_VERSION} release, so the \"Cite this repository\" widget and \`cffconvert\` report the current version."
+          fi
 
   publish:
     runs-on: ubuntu-latest

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -28,8 +28,8 @@ repository-code: "https://github.com/vndee/llm-sandbox"
 url: "https://vndee.github.io/llm-sandbox/"
 repository-artifact: "https://pypi.org/project/llm-sandbox/"
 license: MIT
-version: "0.3.42"
-date-released: "2026-08-02"
+version: "0.3.43"
+date-released: "2026-08-03"
 keywords:
   - "large language models"
   - "code interpreter"


### PR DESCRIPTION
The `update-citation` job added in #178 failed on its first real run, during the 0.3.43 release:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
! [remote rejected] main -> main (push declined due to repository rule violations)
```

## My mistake

When I added that job I wrote, in the PR description: *"`main` is currently unprotected so this works as-is."*

That was wrong. I checked `GET /repos/{owner}/{repo}/branches/main/protection`, got `404 Branch not protected`, and concluded there were no restrictions. But `main` is governed by a **repository ruleset**, which lives at a different endpoint and does not appear in the classic protection API:

```
$ gh api repos/vndee/llm-sandbox/rulesets
id=6047026 name=main enforcement=active target=branch
rules: deletion, non_fast_forward, pull_request, code_scanning
```

I checked the wrong endpoint and asserted a conclusion I hadn't actually verified.

## Blast radius

Contained. `publish` doesn't depend on `update-citation`, so **0.3.43 went to PyPI normally** — the mcp fix reached users on schedule. The only casualty was the citation bump, leaving `CITATION.cff` at 0.3.42.

## The fix

The job now pushes a `citation/<version>` branch and opens a PR, working within the ruleset rather than trying to punch through it. That seemed better than the alternatives — adding a bypass actor or a PAT — since the ruleset requiring PRs and code scanning on `main` is a deliberate choice worth respecting.

Reruns of the same release update the existing branch instead of failing on a duplicate PR. Needs `pull-requests: write` alongside `contents: write`.

Trade-off: one small PR per release to merge, instead of a silent auto-commit. If you'd rather it stay fully hands-off, the alternative is adding GitHub Actions as a bypass actor in the ruleset — a settings change only you can make, and I'd want you to choose that deliberately rather than have a workflow assume it.

## Also here

`CITATION.cff` caught up to 0.3.43 / 2026-08-03 — what the failed job would have done. Validated with `cffconvert`: *"Citation metadata are valid according to schema version 1.2.0."* `make check` passes.
