### PR TITLE
Point the registry entry at 0.3.43

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.vndee/llm-sandbox",
   "title": "LLM Sandbox",
   "description": "Securely run LLM-generated code in isolated containers across 7 languages and 3 container backends.",
-  "version": "0.3.42",
+  "version": "0.3.43",
   "repository": {
     "url": "https://github.com/vndee/llm-sandbox",
     "source": "github"
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "llm-sandbox",
-      "version": "0.3.42",
+      "version": "0.3.43",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
The published MCP registry manifest pins `0.3.42` — the release whose server fails to start because `mcp` 2.0.0 removed `mcp.server.fastmcp`. Anyone arriving through the registry is currently sent to the broken version.

## Changes

- `version` and `packages[0].version`: `0.3.42` → `0.3.43`
- Carries the description correction merged in #180: **Micromamba is a specialisation of the Docker backend**, not a fourth backend, so the entry now reads "3 container backends"

## Verified

Schema-valid against the live 2025-10-17 schema; description is 99 of the 100 permitted characters. The install path was checked end-to-end against **PyPI, not local source**:

```
$ uv pip install --refresh 'llm-sandbox[mcp-docker]'
llm-sandbox: 0.3.43
mcp:         1.29.0
$ python -c "from llm_sandbox.mcp_server.server import main"
MCP server imports OK
```

## After merge

`mcp-publisher publish` still has to run to push this to the registry — merging the file doesn't update the live entry.
