### PR TITLE
Smoke-check the agent SDK examples against current releases

### DIFF
--- a/.github/workflows/agent-sdk-smoke.yml
+++ b/.github/workflows/agent-sdk-smoke.yml
@@ -1,0 +1,100 @@
+name: agent-sdk-smoke
+
+# Checks the examples in examples/agent_sdks/ against the *current* release of
+# each framework, so upstream drift surfaces here instead of in a user's
+# traceback. Two breakages this repo already shipped would have been caught:
+# LangChain 1.0 removing AgentExecutor, and mcp 2.0 removing mcp.server.fastmcp.
+#
+# The weekly run is the point. Frameworks release on their own schedule, so an
+# examples file that passed on merge can be broken a fortnight later with no
+# commit here to trigger it.
+
+on:
+  schedule:
+    # Mondays, 06:00 UTC.
+    - cron: "0 6 * * 1"
+  pull_request:
+    paths:
+      - "examples/agent_sdks/**"
+      - "scripts/smoke_agent_sdks.py"
+      - ".github/workflows/agent-sdk-smoke.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    # One framework per job: several pin conflicting LangChain versions and
+    # cannot share an environment.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: openai_agents_tool
+            package: openai-agents
+          - module: claude_agent_sdk_tool
+            package: claude-agent-sdk
+          - module: pydantic_ai_tool
+            package: pydantic-ai
+          - module: smolagents_tool
+            package: smolagents
+          - module: google_adk_tool
+            package: google-adk
+          - module: crewai_tool
+            package: crewai
+          - module: strands_tool
+            package: strands-agents
+          - module: deepagents_tool
+            package: deepagents
+          - module: ag2_tool
+            package: ag2
+          - module: langchain_tool
+            package: langchain langchain-openai
+          - module: llamaindex_tool
+            package: llama-index llama-index-llms-openai
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install the framework and this library
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: |
+          python -m pip install --upgrade pip
+          # Unpinned on purpose: the job exists to detect new releases breaking
+          # these examples. A pin here would defeat it.
+          # shellcheck disable=SC2086
+          pip install "llm-sandbox[docker]" $PACKAGE
+
+      - name: Smoke-check the example
+        env:
+          MODULE: ${{ matrix.module }}
+        run: python scripts/smoke_agent_sdks.py "$MODULE"
+
+  # Docker is exercised once rather than in all eleven jobs: run_python is
+  # identical across the examples, and each container run pulls a ~1.6 GB image.
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install "llm-sandbox[docker]" openai-agents
+
+      - name: Execute code in a real container
+        run: python scripts/smoke_agent_sdks.py openai_agents_tool --docker

--- a/examples/agent_sdks/README.md
+++ b/examples/agent_sdks/README.md
@@ -24,8 +24,11 @@ dropped.
 | Strands Agents | [`strands_tool.py`](strands_tool.py) | strands-agents 1.50.2 |
 | AG2 | [`ag2_tool.py`](ag2_tool.py) | ag2 1.0.1 |
 
-Each example was import-checked against the version listed at the time of writing
-(there is no CI job doing this yet). Versions are stated
+Each example is checked by [`agent-sdk-smoke`](../../.github/workflows/agent-sdk-smoke.yml),
+which runs weekly against the *current* release of each framework — not the pinned
+one — so upstream drift surfaces here rather than in your traceback. It verifies
+the module imports, drives `SandboxSession` directly, applies the hardening, and
+exposes exactly one tool parameter (`code`). Versions are stated
 because these APIs move: LangChain 1.0 removed `AgentExecutor` and
 `langchain.hub`, LlamaIndex dropped `FunctionCallingAgentWorker`, and AG2 1.0
 replaced `ConversableAgent`/`register_function` outright. If an example fails

--- a/examples/agent_sdks/deepagents_tool.py
+++ b/examples/agent_sdks/deepagents_tool.py
@@ -10,6 +10,7 @@ pooling is built for -- see `examples/pool_basic_demo.py`.
 """
 
 import logging
+from typing import Any
 
 from deepagents import create_deep_agent
 from docker.errors import DockerException
@@ -73,11 +74,20 @@ def execute_python(code: str) -> str:
     return run_python(code)
 
 
-agent = create_deep_agent(
-    tools=[execute_python],
-    system_prompt="You solve problems by writing and running Python. Always print results.",
-)
+def build_agent(model: str = "claude-sonnet-4-5-20250929") -> Any:
+    """Construct the agent.
+
+    `model` is passed explicitly: leaving it None is deprecated in deepagents
+    and becomes an error in 1.0. Building lazily also keeps `import` working
+    without provider credentials.
+    """
+    return create_deep_agent(
+        model=model,
+        tools=[execute_python],
+        system_prompt="You solve problems by writing and running Python. Always print results.",
+    )
+
 
 if __name__ == "__main__":
-    result = agent.invoke({"messages": [{"role": "user", "content": "Sum the primes below 1000."}]})
+    result = build_agent().invoke({"messages": [{"role": "user", "content": "Sum the primes below 1000."}]})
     print(result["messages"][-1].content)

--- a/scripts/smoke_agent_sdks.py
+++ b/scripts/smoke_agent_sdks.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# ruff: noqa: T201, INP001
+"""Smoke-check one agent SDK example without calling a model.
+
+Importing an example proves its APIs still exist; it does not prove the example
+would run. The AG2 example shipped with `config=None`, which imports cleanly and
+only fails inside `run()` -- an import check could never have caught it.
+
+This goes one level deeper, for free:
+
+  * the module imports;
+  * it drives the sandbox itself (references `SandboxSession`) rather than
+    delegating to a helper;
+  * it applies container hardening;
+  * the tool the model sees takes exactly one parameter, `code`. This is the
+    check that catches a leaked `libraries` parameter, which would let a model
+    install arbitrary PyPI packages.
+
+With --docker it also executes a snippet in a real container, which exercises
+the hardened runtime config end to end.
+
+Each framework needs its own environment (several pin conflicting LangChain
+versions), so this checks one module per invocation:
+
+    python scripts/smoke_agent_sdks.py openai_agents_tool --docker
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import inspect
+import sys
+from pathlib import Path
+from typing import Any
+
+EXAMPLES_DIR = Path(__file__).resolve().parent.parent / "examples" / "agent_sdks"
+
+# How to reach the parameter schema the model is shown. Frameworks that expose
+# no introspectable schema fall back to the wrapper function's signature.
+SCHEMA_ACCESSORS: dict[str, Any] = {
+    "openai_agents_tool": lambda m: m.execute_python.params_json_schema["properties"],
+    "smolagents_tool": lambda m: m.execute_python.inputs,
+    "crewai_tool": lambda m: m.execute_python.args_schema.model_json_schema()["properties"],
+    "deepagents_tool": lambda m: m.execute_python.args_schema.model_json_schema()["properties"],
+    "langchain_tool": lambda m: m.execute_python.args_schema.model_json_schema()["properties"],
+    "llamaindex_tool": lambda m: m.sandbox_tool.metadata.get_parameters_dict()["properties"],
+    # These two declare their schema separately from the handler signature, so
+    # the signature fallback reads the wrong thing (`args`, or the decorator's
+    # own injected params) and reports a false failure.
+    "claude_agent_sdk_tool": lambda m: m.execute_python.input_schema,
+    "ag2_tool": lambda m: m.execute_python.schema.function.parameters["properties"],
+}
+
+REQUIRED_HARDENING = {"network_mode", "mem_limit", "pids_limit", "security_opt"}
+
+
+def _fallback_schema(module: Any) -> dict[str, Any]:
+    """Read parameter names off the tool wrapper when the SDK exposes no schema."""
+    fn = getattr(module, "execute_python", None)
+    if fn is None:
+        msg = "module defines no `execute_python` tool"
+        raise AssertionError(msg)
+    fn = getattr(fn, "__wrapped__", getattr(fn, "func", fn))
+    try:
+        params = inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        return {}
+    return {name: None for name in params if name not in {"self", "args", "kwargs"}}
+
+
+def check(name: str, *, with_docker: bool) -> list[str]:
+    """Run every check against one example module, returning failures."""
+    failures: list[str] = []
+    sys.path.insert(0, str(EXAMPLES_DIR))
+    module = importlib.import_module(name)
+
+    source = Path(module.__file__).read_text()
+
+    # The examples exist to teach this library; delegating to a helper hides it.
+    if "SandboxSession" not in source:
+        failures.append("does not reference SandboxSession directly")
+
+    runtime = getattr(module, "SANDBOX_RUNTIME", None)
+    if not isinstance(runtime, dict):
+        failures.append("missing SANDBOX_RUNTIME")
+    else:
+        missing = REQUIRED_HARDENING - set(runtime)
+        if missing:
+            failures.append(f"SANDBOX_RUNTIME missing {sorted(missing)}")
+        if runtime.get("network_mode") != "none":
+            failures.append(f"network_mode is {runtime.get('network_mode')!r}, expected 'none'")
+
+    accessor = SCHEMA_ACCESSORS.get(name)
+    try:
+        params = set(accessor(module)) if accessor else set(_fallback_schema(module))
+    except Exception as exc:  # noqa: BLE001 - any failure here is a real finding
+        failures.append(f"could not read tool schema: {type(exc).__name__}: {exc}")
+    else:
+        if params != {"code"}:
+            # `libraries` leaking through is the specific regression guarded here.
+            failures.append(f"tool exposes {sorted(params)}, expected ['code']")
+
+    if with_docker:
+        run_python = getattr(module, "run_python", None)
+        if run_python is None:
+            failures.append("no run_python to execute")
+        else:
+            out = run_python("print(6 * 7)")
+            if out.strip() != "42":
+                failures.append(f"run_python returned {out!r}, expected '42'")
+
+    return failures
+
+
+def main() -> int:
+    """Check one example and report pass or fail."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("module", help="example module name, e.g. openai_agents_tool")
+    parser.add_argument("--docker", action="store_true", help="also execute code in a real container")
+    args = parser.parse_args()
+
+    try:
+        failures = check(args.module, with_docker=args.docker)
+    except Exception as exc:  # noqa: BLE001 - import errors are the headline failure
+        print(f"FAIL {args.module}: {type(exc).__name__}: {exc}")
+        return 1
+
+    if failures:
+        print(f"FAIL {args.module}")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print(f"ok   {args.module}" + (" (with docker)" if args.docker else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Import checks prove an API still exists, not that the example would **run**. The AG2 example shipped with `config=None` — it imported cleanly and would only have failed inside `run()`. CodeRabbit caught that; my verification structurally could not.

## What it checks

`scripts/smoke_agent_sdks.py`, per example, without calling a model:

| Check | Catches |
|---|---|
| Module imports | Upstream API removal |
| References `SandboxSession` directly | An example that teaches the framework but not this library |
| `SANDBOX_RUNTIME` set, `network_mode == "none"` | Hardening silently dropped |
| Tool exposes exactly `{"code"}` | **A leaked `libraries` parameter** — the LlamaIndex example had exactly this, letting a model install arbitrary PyPI packages |

With `--docker` it also executes a snippet in a real container, exercising the hardened runtime end to end.

## It found things on its first run

**A real one:** the deepagents example passed no model —

```
LangChainDeprecationWarning: Passing `model=None` to `create_deep_agent` is
deprecated and will be removed in deepagents==1.0.0
```

Now passes one explicitly and builds lazily like its siblings.

**Two false positives, which were my checker's fault:** `claude-agent-sdk` and `ag2` declare their schema separately from the handler signature, so the signature fallback read `args` and `['context', 'event']` respectively. Both schemas were actually correct (`{'code'}`); both now have explicit accessors. Worth stating plainly — the tool was wrong, not the examples.

All eleven pass:

```
ok   openai_agents_tool          ok   crewai_tool
ok   claude_agent_sdk_tool       ok   strands_tool
ok   pydantic_ai_tool            ok   deepagents_tool
ok   smolagents_tool             ok   ag2_tool
ok   google_adk_tool             ok   langchain_tool
                                 ok   llamaindex_tool
ok   openai_agents_tool (with docker)
```

## The weekly run is the point

Frameworks release on their own schedule, so an example that passes at merge can break a fortnight later with **no commit here to trigger it**. Both breakages this repo already shipped — LangChain 1.0 removing `AgentExecutor`, `mcp` 2.0 removing `mcp.server.fastmcp` — would have surfaced this way instead of from a user.

Dependencies install **unpinned on purpose**: pinning would defeat the entire check.

## Shape

One job per framework — several pin conflicting LangChain versions and can't share an environment. Docker runs once rather than eleven times, since `run_python` is identical across the examples and each container run pulls a ~1.6 GB image. Verified the matrix covers all 11 example files with none missing.
