### PR TITLE
Correct the container hardening guidance and strengthen the examples

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -164,8 +164,13 @@ with SandboxSession(
 
         # Security options
         "privileged": False,
-        "read_only": True,
+        # NOTE: "read_only": True is not usable with SandboxSession. The session
+        # copies your code into the container, and Docker rejects that against a
+        # read-only rootfs ("container rootfs is marked read-only") -- a tmpfs on
+        # the workdir does not help.
         "cap_drop": ["ALL"],
+        # Keep DAC_OVERRIDE: without it the container cannot read the copied
+        # source file. Everything else stays dropped.
         "cap_add": ["DAC_OVERRIDE"],
         "security_opt": ["no-new-privileges"],
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -587,7 +587,10 @@ runtime_configs = {
     "privileged": False,
     "user": "1000:1000",           # Run as specific user/group
     "cap_drop": ["ALL"],           # Drop all capabilities
-    "cap_add": ["NET_ADMIN"],      # Add specific capabilities
+    # DAC_OVERRIDE must be added back whenever you drop ALL: without it the
+    # container cannot read the source file the session copies in, and every
+    # run fails with "[Errno 13] Permission denied".
+    "cap_add": ["DAC_OVERRIDE"],
     "security_opt": ["no-new-privileges:true"]
 }
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -456,7 +456,8 @@ class SecureAICodeExecutor:
                     "mem_limit": "256m",
                     "cpu_count": 1,
                     "network_mode": "none",
-                    "read_only": True
+                    "cap_drop": ["ALL"],
+                    "cap_add": ["DAC_OVERRIDE"],  # needed to read the copied code
                 }
             ) as session:
                 # Security check

--- a/docs/security.md
+++ b/docs/security.md
@@ -166,6 +166,53 @@ When you specify a restricted module like `"os"`, the language handler automatic
 
 **For Other Languages**: Each language handler implements its own import detection patterns appropriate for that language's syntax.
 
+## Container Hardening That Works
+
+Security policies are advisory (see above). The layer the runtime actually
+enforces is `runtime_configs`. This is the strongest set verified to work with
+`SandboxSession`:
+
+```python
+HARDENED = {
+    "network_mode": "none",                      # no egress
+    "mem_limit": "512m",
+    "pids_limit": 128,                           # bounds fork bombs
+    "cap_drop": ["ALL"],
+    "cap_add": ["DAC_OVERRIDE"],                 # see note below
+    "security_opt": ["no-new-privileges:true"],
+}
+
+with SandboxSession(lang="python", runtime_configs=HARDENED) as session:
+    result = session.run(code)
+```
+
+Verified inside the container: `CapEff` is `0000000000000002` (DAC_OVERRIDE
+only) and outbound connections fail.
+
+### Two caveats specific to this library
+
+**`cap_drop: ["ALL"]` needs `DAC_OVERRIDE` added back.** The session copies your
+code into the container before running it. Without `DAC_OVERRIDE` the container
+cannot read that file and every run fails with `[Errno 13] Permission denied`.
+Dropping everything else still removes `SYS_ADMIN`, `NET_RAW` and the rest.
+
+**`read_only: True` does not work.** Docker rejects the code copy against a
+read-only root filesystem:
+
+```
+docker.errors.APIError: 400 Client Error ...
+("container rootfs is marked read-only")
+```
+
+Mounting a tmpfs on the workdir does not help — the rejection is on the rootfs
+flag itself, not the destination directory. If you need an immutable filesystem,
+pair the library with a runtime that provides it rather than setting this flag.
+
+**`network_mode: "none"` disables `libraries=`.** Package installation needs the
+network. Pre-bake dependencies into a custom image instead — see
+[Custom Images](custom-images.md).
+
+
 ## Creating Security Policies
 
 ### Basic Usage

--- a/examples/agent_sdks/README.md
+++ b/examples/agent_sdks/README.md
@@ -57,13 +57,13 @@ per-call cost. See [`../pool_basic_demo.py`](../pool_basic_demo.py).
 **These examples run untrusted code — that is the whole point.** Anything the
 agent reads can steer what gets executed, so each file applies container
 controls that the runtime actually enforces: `network_mode="none"`,
-`mem_limit`, `pids_limit` and `no-new-privileges`. Verified: egress is blocked.
+`mem_limit`, `pids_limit`, `cap_drop=["ALL"]` and `no-new-privileges`.
+Verified inside the container: egress blocked, `CapEff` is `0000000000000002`.
 
-Two controls you will see recommended elsewhere, including in this project's own
-docs, **do not work** with llm-sandbox 0.3.43 and are deliberately omitted —
-`read_only=True` makes Docker reject the code copy (`container rootfs is marked
-read-only`), and `cap_drop=["ALL"]` drops `DAC_OVERRIDE` so the copied file
-cannot be read.
+`DAC_OVERRIDE` is added back deliberately — without it the container cannot read
+the source file llm-sandbox copies in. `read_only=True` is omitted because Docker
+rejects that copy outright against a read-only rootfs. See
+[the security guide](https://vndee.github.io/llm-sandbox/security/) for both.
 
 **Security policies are advisory.** `session.is_safe(code)` returns a verdict;
 it does not block execution, and `run()` executes code the policy flagged. If

--- a/examples/agent_sdks/ag2_tool.py
+++ b/examples/agent_sdks/ag2_tool.py
@@ -26,14 +26,18 @@ logger = logging.getLogger(__name__)
 # llm-sandbox's SecurityPolicy, which is advisory -- session.is_safe() returns a
 # verdict and session.run() executes regardless of it.
 #
-# read_only=True and cap_drop=["ALL"] are omitted on purpose: both break the
-# code-copy step (verified against llm-sandbox 0.3.43). read_only makes Docker
-# reject put_archive; cap_drop=ALL removes DAC_OVERRIDE so the copied file
-# cannot be read.
+# read_only=True is deliberately absent: Docker rejects the code copy with
+# "container rootfs is marked read-only", with or without a tmpfs on the
+# workdir. Verified against llm-sandbox 0.3.43.
 SANDBOX_RUNTIME = {
     "network_mode": "none",  # no egress: injected code cannot exfiltrate or fetch a second stage
     "mem_limit": "512m",
     "pids_limit": 128,  # bounds fork bombs
+    "cap_drop": ["ALL"],
+    # DAC_OVERRIDE has to go back or the container cannot read the source file
+    # llm-sandbox copies in. Everything else stays dropped: verified CapEff
+    # 0000000000000002 inside the container.
+    "cap_add": ["DAC_OVERRIDE"],
     "security_opt": ["no-new-privileges:true"],
 }
 

--- a/examples/agent_sdks/claude_agent_sdk_tool.py
+++ b/examples/agent_sdks/claude_agent_sdk_tool.py
@@ -24,14 +24,18 @@ logger = logging.getLogger(__name__)
 # llm-sandbox's SecurityPolicy, which is advisory -- session.is_safe() returns a
 # verdict and session.run() executes regardless of it.
 #
-# read_only=True and cap_drop=["ALL"] are omitted on purpose: both break the
-# code-copy step (verified against llm-sandbox 0.3.43). read_only makes Docker
-# reject put_archive; cap_drop=ALL removes DAC_OVERRIDE so the copied file
-# cannot be read.
+# read_only=True is deliberately absent: Docker rejects the code copy with
+# "container rootfs is marked read-only", with or without a tmpfs on the
+# workdir. Verified against llm-sandbox 0.3.43.
 SANDBOX_RUNTIME = {
     "network_mode": "none",  # no egress: injected code cannot exfiltrate or fetch a second stage
     "mem_limit": "512m",
     "pids_limit": 128,  # bounds fork bombs
+    "cap_drop": ["ALL"],
+    # DAC_OVERRIDE has to go back or the container cannot read the source file
+    # llm-sandbox copies in. Everything else stays dropped: verified CapEff
+    # 0000000000000002 inside the container.
+    "cap_add": ["DAC_OVERRIDE"],
     "security_opt": ["no-new-privileges:true"],
 }
 

--- a/examples/agent_sdks/crewai_tool.py
+++ b/examples/agent_sdks/crewai_tool.py
@@ -23,14 +23,18 @@ logger = logging.getLogger(__name__)
 # llm-sandbox's SecurityPolicy, which is advisory -- session.is_safe() returns a
 # verdict and session.run() executes regardless of it.
 #
-# read_only=True and cap_drop=["ALL"] are omitted on purpose: both break the
-# code-copy step (verified against llm-sandbox 0.3.43). read_only makes Docker
-# reject put_archive; cap_drop=ALL removes DAC_OVERRIDE so the copied file
-# cannot be read.
+# read_only=True is deliberately absent: Docker rejects the code copy with
+# "container rootfs is marked read-only", with or without a tmpfs on the
+# workdir. Verified against llm-sandbox 0.3.43.
 SANDBOX_RUNTIME = {
     "network_mode": "none",  # no egress: injected code cannot exfiltrate or fetch a second stage
     "mem_limit": "512m",
     "pids_limit": 128,  # bounds fork bombs
+    "cap_drop": ["ALL"],
+    # DAC_OVERRIDE has to go back or the container cannot read the source file
+    # llm-sandbox copies in. Everything else stays dropped: verified CapEff
+    # 0000000000000002 inside the container.
+    "cap_add": ["DAC_OVERRIDE"],
     "security_opt": ["no-new-privileges:true"],
 }
 

--- a/examples/agent_sdks/deepagents_tool.py
+++ b/examples/agent_sdks/deepagents_tool.py
@@ -26,14 +26,18 @@ logger = logging.getLogger(__name__)
 # llm-sandbox's SecurityPolicy, which is advisory -- session.is_safe() returns a
 # verdict and session.run() executes regardless of it.
 #
-# read_only=True and cap_drop=["ALL"] are omitted on purpose: both break the
-# code-copy step (verified against llm-sandbox 0.3.43). read_only makes Docker
-# reject put_archive; cap_drop=ALL removes DAC_OVERRIDE so the copied file
-# cannot be read.
+# read_only=True is deliberately absent: Docker rejects the code copy with
+# "container rootfs is marked read-only", with or without a tmpfs on the
+# workdir. Verified against llm-sandbox 0.3.43.
 SANDBOX_RUNTIME = {
     "network_mode": "none",  # no egress: injected code cannot exfiltrate or fetch a second stage
     "mem_limit": "512m",
     "pids_limit": 128,  # bounds fork bombs
+    "cap_drop": ["ALL"],
+    # DAC_OVERRIDE has to go back or the container cannot read the source file
+    # llm-sandbox copies in. Everything else stays dropped: verified CapEff
+    # 0000000000000002 inside the container.
+    "cap_add": ["DAC_OVERRIDE"],
     "security_opt": ["no-new-privileges:true"],
 }
 

--- a/examples/agent_sdks/google_adk_tool.py
+++ b/examples/agent_sdks/google_adk_tool.py
@@ -23,14 +23,18 @@ logger = logging.getLogger(__name__)
 # llm-sandbox's SecurityPolicy, which is advisory -- session.is_safe() returns a
 # verdict and session.run() executes regardless of it.
 #
-# read_only=True and cap_drop=["ALL"] are omitted on purpose: both break the
-# code-copy step (verified against llm-sandbox 0.3.43). read_only makes Docker
-# reject put_archive; cap_drop=ALL removes DAC_OVERRIDE so the copied file
-# cannot be read.
+# read_only=True is deliberately absent: Docker rejects the code copy with
+# "container rootfs is marked read-only", with or without a tmpfs on the
+# workdir. Verified against llm-sandbox 0.3.43.
 SANDBOX_RUNTIME = {
     "network_mode": "none",  # no egress: injected code cannot exfiltrate or fetch a second stage
     "mem_limit": "512m",
     "pids_limit": 128,  # bounds fork bombs
+    "cap_drop": ["ALL"],
+    # DAC_OVERRIDE has to go back or the container cannot read the source file
+    # llm-sandbox copies in. Everything else stays dropped: verified CapEff
+    # 0000000000000002 inside the container.
+    "cap_add": ["DAC_OVERRIDE"],
     "security_opt": ["no-new-privileges:true"],
 }
 

--- a/examples/agent_sdks/langchain_tool.py
+++ b/examples/agent_sdks/langchain_tool.py
@@ -26,14 +26,18 @@ logger = logging.getLogger(__name__)
 # llm-sandbox's SecurityPolicy, which is advisory -- session.is_safe() returns a
 # verdict and session.run() executes regardless of it.
 #
-# read_only=True and cap_drop=["ALL"] are omitted on purpose: both break the
-# code-copy step (verified against llm-sandbox 0.3.43). read_only makes Docker
-# reject put_archive; cap_drop=ALL removes DAC_OVERRIDE so the copied file
-# cannot be read.
+# read_only=True is deliberately absent: Docker rejects the code copy with
+# "container rootfs is marked read-only", with or without a tmpfs on the
+# workdir. Verified against llm-sandbox 0.3.43.
 SANDBOX_RUNTIME = {
     "network_mode": "none",  # no egress: injected code cannot exfiltrate or fetch a second stage
     "mem_limit": "512m",
     "pids_limit": 128,  # bounds fork bombs
+    "cap_drop": ["ALL"],
+    # DAC_OVERRIDE has to go back or the container cannot read the source file
+    # llm-sandbox copies in. Everything else stays dropped: verified CapEff
+    # 0000000000000002 inside the container.
+    "cap_add": ["DAC_OVERRIDE"],
     "security_opt": ["no-new-privileges:true"],
 }
 

--- a/examples/agent_sdks/llamaindex_tool.py
+++ b/examples/agent_sdks/llamaindex_tool.py
@@ -26,14 +26,18 @@ logger = logging.getLogger(__name__)
 # llm-sandbox's SecurityPolicy, which is advisory -- session.is_safe() returns a
 # verdict and session.run() executes regardless of it.
 #
-# read_only=True and cap_drop=["ALL"] are omitted on purpose: both break the
-# code-copy step (verified against llm-sandbox 0.3.43). read_only makes Docker
-# reject put_archive; cap_drop=ALL removes DAC_OVERRIDE so the copied file
-# cannot be read.
+# read_only=True is deliberately absent: Docker rejects the code copy with
+# "container rootfs is marked read-only", with or without a tmpfs on the
+# workdir. Verified against llm-sandbox 0.3.43.
 SANDBOX_RUNTIME = {
     "network_mode": "none",  # no egress: injected code cannot exfiltrate or fetch a second stage
     "mem_limit": "512m",
     "pids_limit": 128,  # bounds fork bombs
+    "cap_drop": ["ALL"],
+    # DAC_OVERRIDE has to go back or the container cannot read the source file
+    # llm-sandbox copies in. Everything else stays dropped: verified CapEff
+    # 0000000000000002 inside the container.
+    "cap_add": ["DAC_OVERRIDE"],
     "security_opt": ["no-new-privileges:true"],
 }
 

--- a/examples/agent_sdks/openai_agents_tool.py
+++ b/examples/agent_sdks/openai_agents_tool.py
@@ -24,14 +24,18 @@ logger = logging.getLogger(__name__)
 # llm-sandbox's SecurityPolicy, which is advisory -- session.is_safe() returns a
 # verdict and session.run() executes regardless of it.
 #
-# read_only=True and cap_drop=["ALL"] are omitted on purpose: both break the
-# code-copy step (verified against llm-sandbox 0.3.43). read_only makes Docker
-# reject put_archive; cap_drop=ALL removes DAC_OVERRIDE so the copied file
-# cannot be read.
+# read_only=True is deliberately absent: Docker rejects the code copy with
+# "container rootfs is marked read-only", with or without a tmpfs on the
+# workdir. Verified against llm-sandbox 0.3.43.
 SANDBOX_RUNTIME = {
     "network_mode": "none",  # no egress: injected code cannot exfiltrate or fetch a second stage
     "mem_limit": "512m",
     "pids_limit": 128,  # bounds fork bombs
+    "cap_drop": ["ALL"],
+    # DAC_OVERRIDE has to go back or the container cannot read the source file
+    # llm-sandbox copies in. Everything else stays dropped: verified CapEff
+    # 0000000000000002 inside the container.
+    "cap_add": ["DAC_OVERRIDE"],
     "security_opt": ["no-new-privileges:true"],
 }
 

--- a/examples/agent_sdks/pydantic_ai_tool.py
+++ b/examples/agent_sdks/pydantic_ai_tool.py
@@ -28,14 +28,18 @@ logger = logging.getLogger(__name__)
 # llm-sandbox's SecurityPolicy, which is advisory -- session.is_safe() returns a
 # verdict and session.run() executes regardless of it.
 #
-# read_only=True and cap_drop=["ALL"] are omitted on purpose: both break the
-# code-copy step (verified against llm-sandbox 0.3.43). read_only makes Docker
-# reject put_archive; cap_drop=ALL removes DAC_OVERRIDE so the copied file
-# cannot be read.
+# read_only=True is deliberately absent: Docker rejects the code copy with
+# "container rootfs is marked read-only", with or without a tmpfs on the
+# workdir. Verified against llm-sandbox 0.3.43.
 SANDBOX_RUNTIME = {
     "network_mode": "none",  # no egress: injected code cannot exfiltrate or fetch a second stage
     "mem_limit": "512m",
     "pids_limit": 128,  # bounds fork bombs
+    "cap_drop": ["ALL"],
+    # DAC_OVERRIDE has to go back or the container cannot read the source file
+    # llm-sandbox copies in. Everything else stays dropped: verified CapEff
+    # 0000000000000002 inside the container.
+    "cap_add": ["DAC_OVERRIDE"],
     "security_opt": ["no-new-privileges:true"],
 }
 

--- a/examples/agent_sdks/smolagents_tool.py
+++ b/examples/agent_sdks/smolagents_tool.py
@@ -31,14 +31,18 @@ logger = logging.getLogger(__name__)
 # llm-sandbox's SecurityPolicy, which is advisory -- session.is_safe() returns a
 # verdict and session.run() executes regardless of it.
 #
-# read_only=True and cap_drop=["ALL"] are omitted on purpose: both break the
-# code-copy step (verified against llm-sandbox 0.3.43). read_only makes Docker
-# reject put_archive; cap_drop=ALL removes DAC_OVERRIDE so the copied file
-# cannot be read.
+# read_only=True is deliberately absent: Docker rejects the code copy with
+# "container rootfs is marked read-only", with or without a tmpfs on the
+# workdir. Verified against llm-sandbox 0.3.43.
 SANDBOX_RUNTIME = {
     "network_mode": "none",  # no egress: injected code cannot exfiltrate or fetch a second stage
     "mem_limit": "512m",
     "pids_limit": 128,  # bounds fork bombs
+    "cap_drop": ["ALL"],
+    # DAC_OVERRIDE has to go back or the container cannot read the source file
+    # llm-sandbox copies in. Everything else stays dropped: verified CapEff
+    # 0000000000000002 inside the container.
+    "cap_add": ["DAC_OVERRIDE"],
     "security_opt": ["no-new-privileges:true"],
 }
 

--- a/examples/agent_sdks/strands_tool.py
+++ b/examples/agent_sdks/strands_tool.py
@@ -22,14 +22,18 @@ logger = logging.getLogger(__name__)
 # llm-sandbox's SecurityPolicy, which is advisory -- session.is_safe() returns a
 # verdict and session.run() executes regardless of it.
 #
-# read_only=True and cap_drop=["ALL"] are omitted on purpose: both break the
-# code-copy step (verified against llm-sandbox 0.3.43). read_only makes Docker
-# reject put_archive; cap_drop=ALL removes DAC_OVERRIDE so the copied file
-# cannot be read.
+# read_only=True is deliberately absent: Docker rejects the code copy with
+# "container rootfs is marked read-only", with or without a tmpfs on the
+# workdir. Verified against llm-sandbox 0.3.43.
 SANDBOX_RUNTIME = {
     "network_mode": "none",  # no egress: injected code cannot exfiltrate or fetch a second stage
     "mem_limit": "512m",
     "pids_limit": 128,  # bounds fork bombs
+    "cap_drop": ["ALL"],
+    # DAC_OVERRIDE has to go back or the container cannot read the source file
+    # llm-sandbox copies in. Everything else stays dropped: verified CapEff
+    # 0000000000000002 inside the container.
+    "cap_add": ["DAC_OVERRIDE"],
     "security_opt": ["no-new-privileges:true"],
 }
 

--- a/scripts/smoke_agent_sdks.py
+++ b/scripts/smoke_agent_sdks.py
@@ -52,7 +52,7 @@ SCHEMA_ACCESSORS: dict[str, Any] = {
     "ag2_tool": lambda m: m.execute_python.schema.function.parameters["properties"],
 }
 
-REQUIRED_HARDENING = {"network_mode", "mem_limit", "pids_limit", "security_opt"}
+REQUIRED_HARDENING = {"network_mode", "mem_limit", "pids_limit", "cap_drop", "security_opt"}
 
 
 def _fallback_schema(module: Any) -> dict[str, Any]:


### PR DESCRIPTION
Three docs pages recommended `runtime_configs` that don't work with `SandboxSession`. I tested each rather than assuming:

```
read_only=True                   -> RAISES 400 "container rootfs is marked read-only"
read_only=True + tmpfs workdir   -> RAISES the same
cap_drop=["ALL"]                 -> exit 2, "[Errno 13] Permission denied"
cap_drop=["ALL"] + DAC_OVERRIDE  -> works
```

## This corrects something I said earlier

I previously reported `cap_drop: ["ALL"]` as unusable. It isn't — it just needs `DAC_OVERRIDE` added back, because the session copies your code into the container and can't read it otherwise. Testing the controls **in isolation** rather than as a block is what surfaced that.

So the examples now drop every capability except one, which is stronger than what they shipped with. Verified inside the container:

```
CapEff: 0000000000000002   (DAC_OVERRIDE only)
egress: blocked
```

`read_only` genuinely doesn't work. Docker rejects the copy against the rootfs flag, and a tmpfs on the workdir doesn't change it.

## Docs corrected

| File | Was | Now |
|---|---|---|
| `docs/backends.md` | offered `"read_only": True` | removed, with the error it raises |
| `docs/examples.md` | runnable snippet with `"read_only": True` | `cap_drop` + `cap_add` instead |
| `docs/configuration.md` | `cap_drop: ["ALL"]` + `cap_add: ["NET_ADMIN"]` — would fail every run | documents `DAC_OVERRIDE` as the one to keep |

`docs/security.md` gains a **Container Hardening That Works** section: the verified config, both caveats, and the note that `network_mode="none"` disables `libraries=`.

> [!NOTE]
> The `read_only=True` at `backends.md:105` is a bind `Mount` flag, not a container flag. That one is fine and I left it alone.

## Guarded going forward

The smoke test now requires `cap_drop` in `SANDBOX_RUNTIME`, so an example that loses it fails CI. All eleven pass, including the Docker-backed run.
