### PR TITLE
Add backend plugin system with entry-point discovery

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,3 +1,20 @@
+# Bandit configuration.
+#
+# llm_sandbox/testing is a pytest suite that ships inside the package, so plugin authors can
+# `from llm_sandbox.testing import BackendComplianceTests` and run it against their own
+# backend. Assertions are its entire purpose, so B101 (assert_used) fires on every check it
+# makes. tests/ is excluded for the same reason.
+#
+# pyproject.toml carries the twin exemption for ruff:
+#   [tool.ruff.lint.per-file-ignores]
+#   "llm_sandbox/testing/*" = ["S101", ...]
+#
+# This exempts those paths, not the rule: B101 stays active everywhere else.
+#
+# Two gotchas, both verified rather than assumed:
+#   - The INI key is `exclude`, mapping to --exclude. `exclude_dirs` is the TOML/YAML
+#     spelling and is silently ignored here.
+#   - The values are globs matched against discovered file paths, so the trailing /* is
+#     required; a bare directory name matches nothing and fails silently.
 [bandit]
-exclude = tests
-skips = B108
+exclude = llm_sandbox/testing/*,tests/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This document provides context and guidance for AI assistants working with the L
 
 **LLM Sandbox** is a lightweight and portable sandbox environment designed to run Large Language Model (LLM) generated code in a safe and isolated mode. It provides secure execution environments for AI-generated code while offering flexibility in container backends and comprehensive language support.
 
-**Version:** 0.3.13
+**Version:** 0.4.0
 **License:** MIT
 **Python Support:** 3.10+
 **Documentation:** https://vndee.github.io/llm-sandbox/

--- a/README.md
+++ b/README.md
@@ -942,10 +942,38 @@ graph LR
 - **[Configuration](https://vndee.github.io/llm-sandbox/configuration/)** - Detailed configuration options
 - **[Security](https://vndee.github.io/llm-sandbox/security/)** - Security policies and best practices
 - **[Backends](https://vndee.github.io/llm-sandbox/backends/)** - Container backend details
+- **[Backend Plugins](https://vndee.github.io/llm-sandbox/plugins/)** - Community backends, and how to write one
 - **[Languages](https://vndee.github.io/llm-sandbox/languages/)** - Supported programming languages
 - **[Integrations](https://vndee.github.io/llm-sandbox/integrations/)** - LLM framework integrations
 - **[API Reference](https://vndee.github.io/llm-sandbox/api-reference/)** - Complete API documentation
 - **[Examples](https://vndee.github.io/llm-sandbox/examples/)** - Real-world usage examples
+
+## 🔌 Backend plugins
+
+Docker, Podman, Kubernetes, and Micromamba ship with LLM Sandbox. Other backends can be
+published as separate packages that register themselves through a public entry point:
+
+```bash
+pip install llm-sandbox-<service>
+```
+
+```python
+with SandboxSession(backend="<service>", lang="python") as session:
+    result = session.run("print('hello')")
+```
+
+```python
+import llm_sandbox
+
+llm_sandbox.list_backends()  # built-ins plus every installed plugin
+```
+
+Installing a backend plugin means running third-party code that executes code on your
+behalf — you are trusting that package's authors, not this project.
+
+- **[Community plugins](https://vndee.github.io/llm-sandbox/plugins/)** - what is available
+- **[Writing a plugin](https://vndee.github.io/llm-sandbox/plugins/authoring/)** - the full guide
+- **[INTEGRATIONS.md](INTEGRATIONS.md)** - what belongs in core versus a plugin
 
 ## 🤝 Contributing
 

--- a/docs/design/plugin-system.md
+++ b/docs/design/plugin-system.md
@@ -1,0 +1,755 @@
+# Backend plugin system — design note
+
+**Status:** proposed, awaiting review
+**Scope:** the mechanism `INTEGRATIONS.md` already promises — third-party backends
+shipped as separate distributions, discovered through an entry point, selected with
+`SandboxSession(backend="<service>")`.
+
+`INTEGRATIONS.md` is on `main` and commits publicly to this. The mechanism does not
+exist. This note proposes it. Once a third party publishes against the entry-point
+contract we cannot change it without breaking them, so this note is written as if
+every decision below is permanent.
+
+---
+
+## 1. What is actually there today
+
+Read before proposing, because several assumptions in the surrounding discussion are
+wrong.
+
+### 1.1 `SandboxSession` is a function
+
+```python
+# llm_sandbox/session.py:751
+SandboxSession = create_session
+```
+
+It is an alias for a factory function, not a class. `SandboxSession(backend=...)` is
+`create_session(backend=...)`. Nothing can subclass it, and `isinstance(x, SandboxSession)`
+is a `TypeError`. Plugin documentation must never imply otherwise.
+
+### 1.2 `backend=` already accepts plain strings
+
+`SandboxBackend` is a `str` subclass (`const.py:13`, `StrEnum`). `create_session`
+dispatches with `match`/`case`, which compares by `==`, and `_check_dependency` uses
+set membership, which compares by hash and `==`. Both succeed for a bare `str`:
+
+```python
+SandboxSession(backend="docker")  # works today, on main
+```
+
+This is load-bearing. Whatever we build must not regress it.
+
+`SandboxBackend._missing_` also does case-insensitive lookup, so `SandboxBackend("Docker")`
+resolves. It raises `ValueError` — not a `SandboxError` — for anything unknown. Any new
+code path that calls `SandboxBackend(value)` on a user-supplied string would surface a bare
+`ValueError` for plugin names. It must not.
+
+### 1.3 There are four built-in backends, not three
+
+```python
+# const.py:61
+DOCKER = "docker"
+KUBERNETES = "kubernetes"
+PODMAN = "podman"
+MICROMAMBA = "micromamba"
+```
+
+`micromamba` is a `SandboxDockerSession` subclass that wraps commands in `micromamba run`.
+It is a real, selectable backend value. Every error message and every listing helper has to
+account for it. (See §8 — the example error message in the task brief omits it.)
+
+### 1.4 Backend resolution is duplicated across three sites, inconsistently
+
+| Site | Supports |
+|---|---|
+| `session.py:248` `create_session` | docker, kubernetes, podman, micromamba |
+| `interactive.py:85` `_create_backend_session` | docker, podman, kubernetes |
+| `pool/factory.py:97` `create_pool_manager` | docker, kubernetes, podman |
+
+Three `match` statements, three different backend sets. `session.py` additionally owns
+`_check_dependency`, which the other two lack. A registry has to unify these without
+changing any of their current behaviour — including the omissions, which are observable
+(asking for a micromamba pool raises `UnsupportedBackendError` today, and must continue to).
+
+### 1.5 The real backend contract is `BaseSession`, and all of it is private
+
+`BaseSession` (`core/session_base.py:41`) is an ABC with four abstract methods, and it
+inherits four more from the mixins in `core/mixins.py`:
+
+| Method | Declared in |
+|---|---|
+| `_handle_timeout` | `session_base.py:544` |
+| `_connect_to_existing_container` | `session_base.py:552` |
+| `open` | `session_base.py:564` |
+| `close` | `session_base.py:573` |
+| `_ensure_directory_exists` | `mixins.py:259` |
+| `_ensure_ownership` | `mixins.py:264` |
+| `_process_non_stream_output` | `mixins.py:337` |
+| `_process_stream_output` | `mixins.py:342` |
+
+Six of the eight are underscore-prefixed. A third party cannot implement a backend today
+without implementing private API — exactly what a plugin system is supposed to prevent.
+This is the single largest obstacle and §4 addresses it.
+
+### 1.6 Artifact support depends on an undeclared method
+
+`ArtifactSandboxSession.run` calls
+`language_handler.run_with_artifacts(container=self._session, ...)`, and the handler calls
+`container.get_archive(path)` (`language_handlers/base.py:189`). `get_archive` is defined on
+`SandboxDockerSession` (`docker.py:458`) and `SandboxKubernetesSession` (`kubernetes.py:651`)
+and inherited by Podman. It is declared on **no** ABC. It is a required method that exists
+only by convention.
+
+There are also two unrelated protocols both called "container":
+
+- `ContainerAPI` (`core/mixins.py:21`) — a `runtime_checkable` Protocol for the low-level
+  runtime driver (create / start / stop / exec / copy in / copy out).
+- `ContainerProtocol` (`language_handlers/base.py:17`) — a `TYPE_CHECKING`-only Protocol
+  describing what a *session* must offer the language handler (`execute_command`,
+  `get_archive`, `run`).
+
+They do not match, and `ArtifactSandboxSession` passes a session where the parameter is
+named `container`. Any interface we publish has to be unambiguous about which is which.
+
+### 1.7 Constraints from the existing test suite
+
+Two tests constrain the implementation directly:
+
+- `tests/test_const.py:84` — `assert len(list(SandboxBackend)) == 4`. Dynamically extending
+  the enum breaks this, and would be wrong anyway (see §5.3).
+- `tests/test_exceptions.py:193` — `assert str(error) == "Unsupported backend: invalid_backend"`.
+  The `UnsupportedBackendError` message is pinned exactly. We cannot enrich it in place.
+
+Five call sites use `pytest.raises(UnsupportedBackendError)` (`test_session.py:97`,
+`test_backend.py:75`, `test_pool_factory.py:148`, `test_interactive_session.py:57` and `:404`).
+Any new error must be a **subclass** so those keep passing — and so downstream
+`except UnsupportedBackendError` keeps working.
+
+### 1.8 Packaging and CI
+
+- `requires-python = ">=3.10,<4.0"`. Verified on the repo's own 3.10.16 venv:
+  `entry_points(group=...)` returns `EntryPoints`, `.select()` and `.names` exist, and
+  `ep.dist.name` / `ep.dist.version` are populated. The API is safe at the floor.
+  `ep.dist` is still read defensively (`getattr(ep, "dist", None)`) because it is `None`
+  for hand-constructed entry points.
+- The only runtime dependency is `pydantic`. `importlib.metadata` and `difflib` are stdlib,
+  so the registry adds nothing.
+- CI matrix is 3.10–3.13. `make check` runs pre-commit, `mypy`, and `deptry`.
+  `ruff` is `select = ["ALL"]`, line length 120. Docs build with `mkdocs build -s` (strict)
+  and `pymdownx.snippets: check_paths: true`.
+
+---
+
+## 2. The entry point
+
+### 2.1 Group name
+
+```
+llm_sandbox.backends
+```
+
+Matches the import path of the module that defines the contract (§4), which is the
+convention users expect (`pytest11` notwithstanding). Underscore, not hyphen, so it matches
+the Python package name rather than the distribution name.
+
+### 2.2 What a plugin declares
+
+```toml
+# llm-sandbox-tenki/pyproject.toml
+[project]
+name = "llm-sandbox-tenki"
+dependencies = ["llm-sandbox>=0.4,<1.0"]
+
+[project.entry-points."llm_sandbox.backends"]
+tenki = "llm_sandbox_tenki:TenkiBackend"
+```
+
+The entry-point **name** (`tenki`) is what users pass to `backend=`. The entry-point
+**value** resolves to the registered object.
+
+### 2.3 Shape of the registered object
+
+The entry point must resolve to a **subclass of `SandboxBackendPlugin`** — a class, never
+an instance. Core never instantiates it; every method is a `classmethod`. It is a
+descriptor and a factory, not the session itself.
+
+```python
+from llm_sandbox.backends import BackendCapability, SandboxBackendPlugin
+
+class TenkiBackend(SandboxBackendPlugin):
+    PLUGIN_API_VERSION = 1
+    name = "tenki"
+    capabilities = frozenset({BackendCapability.ARTIFACTS})
+
+    @classmethod
+    def create_session(cls, **kwargs):
+        from llm_sandbox_tenki.session import TenkiSession
+        return TenkiSession(**kwargs)
+```
+
+**Why a descriptor and not the session class itself.** This is the decision that determines
+what we are frozen into. Registering the session class directly would be simpler to write,
+but it would freeze the whole of `BaseSession` — including the six private methods in §1.5
+and the container-with-a-shell assumption in §7.1 — as permanent public contract. The
+descriptor freezes six names, and every one of them is a name we chose deliberately. What a
+plugin does *behind* `create_session` stays the plugin's business, and `BaseSession` stays
+refactorable.
+
+**Why not a `ContainerAPI` implementation.** It is the smallest possible contract and would
+give plugins the most reuse, but it forces every hosted execution service to emulate
+container semantics — create a container, start it, exec into it, tar files in and out —
+whether or not it has any of those concepts. It closes the door on the exact category of
+backend the plugin path exists to serve.
+
+**Rejected leniency.** Accepting either a class or an instance was considered and dropped.
+Two accepted shapes means two shapes to support forever and two ways for a plugin author
+to be subtly wrong. The registry validates strictly and says what it expected.
+
+### 2.4 The plugin interface
+
+```python
+class SandboxBackendPlugin(ABC):
+    """Descriptor a third-party distribution registers to provide a backend."""
+
+    PLUGIN_API_VERSION: ClassVar[int]
+    name: ClassVar[str]
+    capabilities: ClassVar[frozenset[BackendCapability]] = frozenset()
+
+    @classmethod
+    @abstractmethod
+    def create_session(cls, **kwargs: Any) -> BaseSession: ...
+
+    @classmethod
+    def create_pool_manager(cls, **kwargs: Any) -> ContainerPoolManager: ...
+
+    @classmethod
+    def create_interactive_session(cls, **kwargs: Any) -> BaseSession: ...
+```
+
+Six frozen names. Every one justified:
+
+| Name | Required | Why a plugin cannot work without it |
+|---|---|---|
+| `PLUGIN_API_VERSION` | yes | The only thing that lets a future core tell "built for the interface you have" from "built for an interface you no longer have". Without it a v1 plugin on a v2 core fails as an `AttributeError` somewhere inside a session, which is unactionable. §6. |
+| `name` | yes | The canonical backend name. The entry-point name is the *lookup* key, but it is chosen by whoever wrote the `pyproject.toml`, which may not be the plugin author (forks, vendoring). Carrying it on the object lets the registry detect and report a mismatch instead of silently honouring whichever came first. |
+| `capabilities` | no (defaults empty) | `ArtifactSandboxSession`, `InteractiveSandboxSession`, and the pool factory each need to know, *before* constructing anything, whether this backend can do the thing. Discovering it by calling and catching produces half-built sessions and containers that leak. |
+| `create_session` | yes | The entire point. Everything `SandboxSession(backend=...)` does routes here. |
+| `create_pool_manager` | no (raises by default) | Pooling is a distinct object with its own lifecycle (`ContainerPoolManager` has four abstract methods of its own) and genuinely backend-specific semantics — a hosted service may pool server-side, or not at all. Optional, with a default that raises a clear capability error. |
+| `create_interactive_session` | no (raises by default) | Same reasoning, and see §7.6: interactive sessions currently reach into backend session internals, so this is the least portable capability of the three. Optional, default raises. |
+
+Deliberately **not** on the interface:
+
+- **A `describe()`/metadata hook.** Distribution name and version come free from
+  `ep.dist`. Anything more is documentation, and documentation belongs in the plugin's README.
+- **A streaming capability flag.** `run()` takes `on_stdout`/`on_stderr` in its signature
+  regardless. A backend that cannot stream invokes each callback once with the complete
+  output at completion. Requiring the *signature* rather than real-time delivery keeps the
+  contract smaller and keeps caller code uniform.
+- **A library-installation capability flag.** Core already has
+  `LibraryInstallationNotSupportedError` and already raises it for languages that cannot
+  install (`session_base.py:271`). A backend that cannot install libraries raises the same
+  existing exception. No new concept.
+- **A `close`/teardown hook on the plugin class.** The plugin class is a namespace, not a
+  resource. Lifecycle belongs to the objects it returns.
+
+### 2.5 Capabilities
+
+```python
+class BackendCapability(StrEnum):
+    ARTIFACTS = "artifacts"                      # get_archive() + plot extraction
+    INTERACTIVE = "interactive"                  # InteractiveSandboxSession support
+    POOLING = "pooling"                          # create_pool_manager() support
+    EXISTING_CONTAINER = "existing_container"    # container_id= attach support
+```
+
+Four. New capabilities may be added within a major API version (§6) — a plugin that does
+not declare a capability it has never heard of is unaffected.
+
+### 2.6 Name normalisation
+
+```python
+def normalize_backend_name(name: str) -> str:
+    return name.strip().lower().replace("-", "_")
+```
+
+`"My-Service"`, `"my_service"`, and `"MY_SERVICE"` all resolve to `my_service`. Applied to
+the requested name, the entry-point name, and the plugin's declared `name` alike, so
+collisions are detected on the normalised form.
+
+### 2.7 Collision resolution
+
+| Situation | Resolution |
+|---|---|
+| Plugin name normalises onto a built-in (`docker`, `kubernetes`, `podman`, `micromamba`) | **Built-in wins.** Emit `BackendShadowWarning` naming the offending distribution and version. The built-in resolves as though the plugin were not installed. |
+| Two plugins claim the same normalised name | **Error naming both distributions** — but only when *that name* is requested. |
+| Plugin's declared `name` disagrees with its entry-point name | Registered under the entry-point name (that is what users type), with a warning naming both. |
+
+The "only when requested" rule matters. Raising at discovery time would let one bad pair of
+plugins break `list_backends()` and every other backend's resolution — the exact failure
+mode the brief forbids. Instead the conflict is *recorded* at discovery and raised at
+lookup, so `list_backends()` reports the conflicted name with `status="conflict"` and
+everything else keeps working.
+
+Built-in-wins is not negotiable: `SandboxSession(backend="docker")` must mean Docker on
+every machine, and an installed package must never be able to change that.
+
+---
+
+## 3. Lazy loading and the registry
+
+`llm_sandbox/registry.py`. Two distinct phases, and the distinction is a security property,
+not an optimisation:
+
+**Discovery** reads distribution metadata via
+`importlib.metadata.entry_points(group="llm_sandbox.backends")`. It imports nothing and
+executes no third-party code. It yields names, distributions, and versions.
+
+**Loading** calls `ep.load()`, which imports the plugin's module. This happens only when
+that specific backend is requested by name.
+
+Discovery runs on the first backend resolution of the process — **including when a built-in
+will win** — and is cached from then on. An earlier draft short-circuited built-ins before
+discovery to save the metadata scan; building it showed that suppresses the shadow warning
+for exactly the user who most needs it, since a package registering itself as `docker` is a
+supply-chain attack shape. One cached metadata scan is the right price for that signal.
+
+Consequences:
+
+- `import llm_sandbox` never imports a plugin, and never even scans metadata. Discovery is
+  triggered by the first resolution, not by import. `tests/test_lazy_imports.py` already
+  asserts the analogous property for optional backend dependencies and must keep passing.
+- `list_backends()` never imports a plugin either — it reports name, distribution, and
+  version from metadata alone. `list_backends(load=True)` opts into importing, to populate
+  `capabilities`, and tolerates per-plugin failures by recording `status="error"` rather
+  than propagating.
+- Installing a plugin means its build already ran on your machine. Lazy loading limits
+  *import*-time execution to explicit opt-in; it is not a sandbox. §9 says so plainly and
+  the authoring guide will repeat it.
+
+Caching is a module-level dict guarded by a `threading.Lock` — pool code creates sessions
+from worker threads. `clear_cache()` is public for tests and for processes that install
+plugins at runtime.
+
+### 3.1 Failure isolation
+
+Any failure loading one entry point raises `BackendLoadError` **for that request only** and
+never propagates into discovery of other backends:
+
+- entry point raises on import
+- resolved object is not a `SandboxBackendPlugin` subclass
+- `PLUGIN_API_VERSION` missing or unsupported
+- `create_session` not implemented
+
+Each produces a message naming the distribution, the entry point, and what was expected.
+
+### 3.2 Error message for an unknown backend
+
+This message is the entire onboarding experience for most plugin users, so it is specified
+here rather than left to the implementation.
+
+Nothing installed provides the name, and nothing is close:
+
+```
+Unknown backend 'tenki'.
+Built-in backends: docker, kubernetes, micromamba, podman.
+No installed package provides 'tenki'. Third-party backends ship as separate
+packages — try: pip install llm-sandbox-tenki
+See https://github.com/vndee/llm-sandbox/blob/main/INTEGRATIONS.md
+```
+
+A plugin *is* installed and the name is a near miss (`difflib.get_close_matches`, stdlib):
+
+```
+Unknown backend 'tenkki'.
+Built-in backends: docker, kubernetes, micromamba, podman.
+Installed plugin backends: tenki (llm-sandbox-tenki 0.1.0).
+Did you mean 'tenki'?
+See https://github.com/vndee/llm-sandbox/blob/main/INTEGRATIONS.md
+```
+
+The second form is the common case in practice — someone has the plugin and typo'd — and it
+is worth the extra branch. The `pip install llm-sandbox-<name>` suggestion follows the
+naming convention `INTEGRATIONS.md` already states; it is a suggestion, and the message
+says "try", because the convention is not enforced.
+
+### 3.3 Exception hierarchy
+
+All new exceptions subclass `UnsupportedBackendError` so that the five existing
+`pytest.raises(UnsupportedBackendError)` sites and any downstream `except` keep working:
+
+```
+SandboxError
+└── UnsupportedBackendError          (unchanged: message pinned by tests/test_exceptions.py:193)
+    ├── BackendNotFoundError          no backend by that name
+    ├── BackendLoadError              entry point failed to load or is malformed
+    ├── BackendNameConflictError      two distributions claim the name
+    └── BackendCapabilityError        backend exists but lacks the requested capability
+```
+
+`UnsupportedBackendError` itself is left completely untouched — same constructor, same
+message. The subclasses bypass its message formatting and set their own.
+
+### 3.4 Public helper
+
+```python
+llm_sandbox.list_backends(load: bool = False) -> list[BackendInfo]
+```
+
+`BackendInfo` is a frozen dataclass: `name`, `is_builtin`, `distribution`, `version`,
+`entry_point`, `capabilities` (`None` unless loaded), `status`
+(`"ok" | "shadowed" | "conflict" | "error"`), `error`.
+
+---
+
+## 4. The public backend base
+
+Registering a descriptor answers *how core finds the plugin*. It does not answer *how a
+plugin writes a session*. For that we publish `SandboxBackendBase`.
+
+`llm_sandbox/backends/` is a new public package containing `SandboxBackendPlugin`,
+`BackendCapability`, `SandboxBackendBase`, `BackendInfo`, and `PLUGIN_API_VERSION`.
+
+`SandboxBackendBase` subclasses `BaseSession` and re-declares the six *private* abstract
+methods under public names, adapting to the private ones with `final` bridges:
+
+```python
+class SandboxBackendBase(BaseSession, ABC):
+    @abstractmethod
+    def handle_timeout(self) -> None: ...
+
+    @typing.final
+    def _handle_timeout(self) -> None:      # satisfies BaseSession
+        self.handle_timeout()
+```
+
+...and the same for `connect_to_existing_container`, `ensure_directory_exists`,
+`ensure_ownership`, `process_non_stream_output`, `process_stream_output`. `open` and `close`
+are already public and pass through unchanged.
+
+It additionally declares `get_archive` — abstract when `BackendCapability.ARTIFACTS` is
+declared, otherwise raising `BackendCapabilityError` — which closes the §1.6 gap for
+plugins without changing anything for the built-ins.
+
+**Why this and not renaming the methods on `BaseSession`.** Renaming is cleaner long-term
+and would leave one obvious way to write a backend. It also touches a class that
+`SandboxDockerSession`, `SandboxPodmanSession`, `SandboxKubernetesSession`,
+`MicromambaSession`, and `InteractiveSandboxSession` all inherit from, plus any downstream
+code we cannot see. The blast radius is unknown and the payoff is aesthetic. Deferred; it
+can happen later behind deprecation shims without disturbing the plugin contract, which is
+precisely the property the descriptor in §2.3 buys us.
+
+**Cost, stated honestly.** In-tree backends keep using `BaseSession` and private names;
+out-of-tree backends use `SandboxBackendBase` and public names. Two idioms for the same
+job. The alternative was freezing six underscore-prefixed names as permanent public API.
+
+### 4.1 The required set
+
+Confirmed for v1. A compliant backend implements:
+
+| Required | Contract |
+|---|---|
+| `open()` / `close()` | Idempotent. `close()` must release every resource, and must be safe to call after a failed `open()`. |
+| `run(code, libraries=None, timeout=None, on_stdout=None, on_stderr=None)` | Returns `ConsoleOutput`. `exit_code` is 0 on success. Raises `SandboxTimeoutError` on timeout. |
+| `execute_command(command, workdir=None, on_stdout=None, on_stderr=None)` | Returns `ConsoleOutput`. Raises `CommandEmptyError` on empty input, `NotOpenSessionError` if not open. |
+| `copy_to_runtime(src, dest)` / `copy_from_runtime(src, dest)` | Raises `FileNotFoundError` for a missing source; must reject path traversal in `dest`. |
+
+Optional, capability-declared: artifacts (`get_archive`), interactive, pooling,
+existing-container attach.
+
+The line sits here because `copy_to_runtime`/`copy_from_runtime` are already public,
+already documented session methods, and artifact extraction is built on file transfer. A
+narrower required set would make the public session API partial in a way users cannot
+predict from the backend name.
+
+### 4.2 What plugins import, and from where
+
+Everything a realistic plugin needs, at a stable path:
+
+| Need | Path | Status |
+|---|---|---|
+| `SandboxBackendPlugin`, `BackendCapability`, `SandboxBackendBase`, `PLUGIN_API_VERSION`, `BackendInfo`, `normalize_backend_name` | `llm_sandbox.backends` | new |
+| `BaseSession`, `ContainerAPI` | `llm_sandbox.backends` | re-exported from `core` |
+| `list_backends`, backend exceptions and warnings | `llm_sandbox` | new |
+| `BackendComplianceTests` | `llm_sandbox.testing` | new, needs the `testing` extra |
+| `ConsoleOutput`, `ExecutionResult`, `PlotOutput`, `FileType`, `StreamCallback` | `llm_sandbox` | already exported |
+| `SessionConfig`, `SecurityPolicy`, `SupportedLanguage`, `SandboxBackend` | `llm_sandbox` | already exported |
+| `ContainerPoolManager`, `PoolConfig` | `llm_sandbox.pool` | already exported |
+| Exceptions | `llm_sandbox.exceptions` | see below |
+
+Audit result: five exceptions a plugin must be able to raise are **not** in
+`llm_sandbox.__all__` — `SandboxTimeoutError`, `NotOpenSessionError`, `CommandFailedError`,
+`MissingDependencyError`, `LibraryInstallationNotSupportedError`. `llm_sandbox.exceptions`
+is already a public, non-underscore module referenced by the docs, so it is declared public
+in full, and these five are additionally added to the top-level `__all__`. Purely additive.
+
+`ContainerAPI` (`core/mixins.py`) **is** promoted, re-exported from `llm_sandbox.backends`.
+This reverses an earlier decision in this note. Writing the reference plugin showed the
+choice was not "publish `ContainerAPI` or don't" but "publish it or freeze its six-method
+shape anyway, undocumented": `FileOperationsMixin` and `CommandExecutionMixin` both read
+`self.container_api`, so any backend that wants the inherited file transfer and command
+execution must supply an object with exactly that shape. A structural protocol the plugin
+can satisfy without importing anything is still a frozen contract. Better to name it.
+
+Nothing else under `llm_sandbox.core` is promoted.
+
+---
+
+## 5. Backend-specific vs session-level, and what has to move
+
+### 5.1 Where the boundary actually falls
+
+| Behaviour | Layer | Notes |
+|---|---|---|
+| Security scanning (`is_safe`, pattern checks) | session | `BaseSession`, fully backend-agnostic. Free for plugins. |
+| Language handler selection, execution commands | session | Fully backend-agnostic. Free. |
+| Timeout *policy* (session lifetime, `_execute_with_timeout`) | session | `TimeoutMixin`. Free. |
+| Timeout *enforcement* (killing the workload) | backend | `_handle_timeout`. Required. |
+| Temp-file write → copy in → run commands | session | `BaseSession.run`. Assumes a filesystem — see §7.1. |
+| Library installation | session, via handler | Uses `execute_commands`, so it works for any backend with a shell. |
+| Container/pod lifecycle | backend | `open`/`close`. Required. |
+| Command execution and output decoding | backend | `execute_command` + the two `_process_*_output` hooks. |
+| File transfer | backend | `copy_to_container`/`copy_from_container`. |
+| Artifact extraction | split | Handler drives it; backend supplies `get_archive`. §1.6. |
+| Pooling | backend | Separate class hierarchy, four abstract methods. |
+| Interactive | backend, deeply | §7.6. |
+
+### 5.2 Refactor required
+
+One refactor, and it is mechanical: the three dispatch sites in §1.4 route through the
+registry instead of their own `match` statements. Built-ins become internal
+`SandboxBackendPlugin` subclasses in `llm_sandbox/backends/builtin.py`, each importing its
+module lazily inside `create_session` so the §3 lazy-import property is preserved for
+built-ins too.
+
+Behaviour is preserved exactly, including the current inconsistencies:
+
+- micromamba's provider declares neither `INTERACTIVE` nor `POOLING`, so
+  `InteractiveSandboxSession(backend="micromamba")` and
+  `create_pool_manager(backend="micromamba")` keep raising an `UnsupportedBackendError`
+  subclass, as they do today.
+- Kubernetes' provider keeps filtering `runtime_configs` out of interactive kwargs
+  (`interactive.py:99`).
+
+Two constraints from the existing tests pin how the refactor may be written:
+
+- **`_check_dependency` stays in `llm_sandbox/session.py`,** and `session.py` keeps importing
+  `find_spec` at module level. Six tests patch `llm_sandbox.session.find_spec`
+  (`test_session.py:19,27,35,43,56,69,82`) and moving the function would break all of them.
+  `create_session` calls it for built-ins before delegating, preserving current ordering
+  (after the `pool=` short-circuit, before construction).
+- **Built-in providers must import the session class inside the method, not at module
+  scope.** Tests patch the source-module attribute
+  (`@patch("llm_sandbox.docker.SandboxDockerSession")`, `test_session.py:44,57,70,83`), which
+  only works with late binding — the same pattern `create_session` uses today. This is also
+  what keeps `tests/test_lazy_imports.py` green.
+- `_create_backend_session` in `interactive.py` must be **kept as a function**, not deleted:
+  `test_interactive_session.py:404` calls it directly.
+
+### 5.3 Breaking-change risks
+
+**None identified as unavoidable.** Assessed:
+
+| Risk | Assessment |
+|---|---|
+| `UnsupportedBackendError` message changes | **Avoided.** Untouched; new subclasses carry the rich messages. `tests/test_exceptions.py:193` stays green. |
+| Extending `SandboxBackend` dynamically | **Rejected.** Breaks `tests/test_const.py:84` (`len == 4`), and is wrong regardless: the enum means "backends core ships and tests in CI", which is exactly the line `INTEGRATIONS.md` draws. Plugins are strings; built-ins are enum members that are also strings. They coexist because the enum already *is* `str`. |
+| Widening `backend: SandboxBackend` to `SandboxBackend \| str` | Parameter-type widening. Every existing call stays valid; no runtime change (bare strings already worked, §1.2). |
+| Registry adds import cost to `import llm_sandbox` | Discovery is lazy, triggered on first resolution, not at import. |
+| Built-in resolution changes shape | Same classes, same kwargs, same lazy imports. The `match` is replaced by a dict lookup. |
+| A plugin shadowing a built-in | Prevented by design (§2.7). |
+
+The one thing to watch during implementation: `_check_dependency` currently runs *before*
+session construction and after the pool short-circuit. That ordering must be preserved —
+`create_session(pool=...)` never checks dependencies today.
+
+---
+
+## 6. Versioning
+
+```python
+PLUGIN_API_VERSION = 1                       # what core implements
+SUPPORTED_PLUGIN_API_VERSIONS = frozenset({1})  # what core accepts
+```
+
+Independent of the package version. A plugin declares the version it targets; core checks
+membership in `SUPPORTED_PLUGIN_API_VERSIONS` at load. The set (rather than a single int)
+exists so a future core can accept `{1, 2}` through a transition instead of forcing a flag
+day.
+
+Mismatch produces a message naming the distribution, the version it declared, and what this
+core accepts — never an `AttributeError` from inside a session.
+
+**Guaranteed within a major plugin API version:**
+
+- No new *required* member on `SandboxBackendPlugin`.
+- No incompatible signature change to a required method.
+- No change to the meaning or type of a required return value.
+- The entry-point group name does not change.
+- The import paths in §4.2 keep working.
+- New capabilities may be added; not declaring one is always safe.
+- New *optional* hooks may be added, always with a working default.
+
+**Bumps the major version:**
+
+- Removing or renaming a required member.
+- Changing a required signature or return type incompatibly.
+- Changing the entry-point group.
+- Changing collision or normalisation rules such that an existing plugin resolves differently.
+
+**Not covered by the guarantee:** anything under `llm_sandbox.core`, `llm_sandbox.pool`
+internals, the language handler classes, and the private methods on `BaseSession`. A plugin
+that reaches into those is on its own, which is the whole reason §4 exists.
+
+---
+
+## 7. What makes this harder than it looks
+
+### 7.1 `BaseSession.run()` assumes a POSIX container with a shell
+
+`run()` writes the code to a host temp file, copies it into `workdir`, asks the language
+handler for shell command strings, and executes them (`session_base.py:485-530`). It assumes
+a writable filesystem, file transfer, and a shell.
+
+A hosted execution API with an `POST /execute {code}` endpoint has none of these. Such a
+backend either emulates them, or overrides `run()` and loses `install()`, artifact
+extraction, and interactive support along with it. The plugin descriptor in §2.3 makes this
+survivable — the plugin can return whatever session it likes — but it does not make it
+*easy*, and the authoring guide has to say so. This is the single biggest reason the
+descriptor shape was chosen over registering a `ContainerAPI`.
+
+### 7.2 `get_archive` is a phantom requirement
+
+§1.6. Artifacts need it; no ABC declares it. `SandboxBackendBase` fixes it for plugins;
+the built-ins keep it as an undeclared convention, which is worth cleaning up separately.
+
+### 7.3 Two protocols named "container"
+
+§1.6. `ContainerAPI` describes a runtime driver, `ContainerProtocol` describes a session as
+seen by a language handler, they do not match, and `ArtifactSandboxSession` passes a session
+into a parameter named `container`. Documentation has to disambiguate carefully or plugin
+authors will implement the wrong one.
+
+### 7.4 Three dispatch sites disagree about which backends exist
+
+§1.4. The registry unifies them, which means it also *surfaces* the disagreement. The
+inconsistencies are preserved deliberately (§5.2) — fixing them would be a behaviour change
+outside this scope, and is worth a separate issue.
+
+### 7.5 `SandboxSession` is not a class
+
+§1.1. It cannot be subclassed or `isinstance`-checked. Documentation and type hints have to
+be careful; the natural thing to write in a plugin README is wrong.
+
+### 7.6 Interactive sessions reach into backend internals
+
+`InteractiveSandboxSession` reads `_backend_session._session_start_time`, `.container`,
+`.container_api`, and `.python_executable_path`, then bootstraps by writing a runner script
+into the container and polling files on its filesystem (`interactive.py:186-215`). A plugin
+can only support this by subclassing `SandboxBackendBase` and behaving like a container.
+Recommendation: v1 documents `INTERACTIVE` as supported only for container-shaped backends,
+and does not pretend otherwise.
+
+### 7.7 `SessionConfig.lang` is typed as `SupportedLanguage`
+
+A plugin cannot introduce a language. Out of scope, but plugin authors will ask.
+
+### 7.8 Entry-point caching
+
+`importlib.metadata` caches. A plugin `pip install`ed into a running process will not appear
+until `clear_cache()`. Tests that install fixtures at runtime must call it.
+
+### 7.9 Repo tooling will resist the reference plugin
+
+`ruff` runs `select = ["ALL"]` across the repo, `deptry` runs in `make check`, and
+`mkdocs build -s` is strict with `snippets.check_paths: true`. The reference plugin in
+`examples/plugins/` depends on `llm-sandbox` and pytest, which `deptry` will flag exactly as
+it already flags `examples/agent_sdks` (already handled with `extend_exclude`). Plan for
+tooling configuration as part of Phase 4, not as an afterthought.
+
+### 7.10 The compliance kit needs pytest, which core does not depend on
+
+`from llm_sandbox.testing import BackendComplianceTests` requires pytest at import. Proposal:
+`llm_sandbox/testing/` imports pytest at module level and a new `testing` extra
+(`pip install llm-sandbox[testing]`) declares it. No new *required* runtime dependency —
+the constraint is respected — but the module is not importable without the extra, and the
+error when it is missing should say so.
+
+### 7.11 Nav placement of this note
+
+`docs/design/` is not in `mkdocs.yml` nav and `mkdocs build -s` is strict. Verified by
+running it: mkdocs logs unlisted pages at INFO, not WARNING, and the build exits 0. Left out
+of nav deliberately — it is a design record, not user documentation. (The run also emits a
+`git-revision-date-localized` warning about revision timestamps because the file is not yet
+committed; it comes from the plugin's own logger, not mkdocs, so `-s` does not fail on it.)
+
+---
+
+## 8. Where `INTEGRATIONS.md` and the implementation will differ
+
+Per instruction, `INTEGRATIONS.md` is not edited. Discrepancies found:
+
+1. **Accurate.** "A backend plugin is a standalone package that depends on `llm-sandbox`
+   and registers itself through the backend entry-point interface" — this is exactly what
+   §2 builds.
+2. **Accurate.** `SandboxSession(backend="<service>")` works, and already works for strings
+   today (§1.2).
+3. **Accurate but currently false, by design.** "the entry-point interface is public" is
+   the premise of this work; it becomes true when this lands.
+4. **Incomplete, not wrong.** No mention of `PLUGIN_API_VERSION`, capability declaration, or
+   the compliance kit. The authoring guide covers them; `INTEGRATIONS.md` reads as a policy
+   document and does not need to.
+5. **Worth noting.** It names Docker, Podman, and Kubernetes as what ships in core and does
+   not mention micromamba (§1.3). Not a plugin-system inaccuracy, but the "which backends
+   are built in" question now has a user-visible answer via `list_backends()` and the error
+   messages, and those will say four. Flagging rather than editing.
+
+---
+
+## 9. Security
+
+Stated here so it is stated once, plainly, and repeated verbatim in the authoring guide and
+the plugin index:
+
+Installing a backend plugin means running third-party code in your environment. A backend,
+by definition, is the component that executes untrusted code — it is the most
+security-sensitive part of this system. Choosing a community backend means trusting that
+package's authors. It does not mean trusting this project: listing in the plugin index
+records that a plugin exists and is community-maintained, and implies no review, no
+endorsement, and no guarantee.
+
+Lazy loading (§3) means core does not import a plugin until you ask for that backend by
+name. That limits *import*-time execution. It is not a sandbox, and by the time you can ask
+for the backend, the package's install hooks have already run.
+
+---
+
+## 10. Questions raised at review, and how they were resolved
+
+1. **Module name.** Kept `llm_sandbox.backends`, matching the entry point group name.
+2. **`list_backends()` at top level.** Kept, as specified. It is the only function other than
+   `create_session` at the top level.
+3. **The pre-existing defects in §7.2 and §7.4.** Filed, not fixed. This change stays purely
+   additive: `SandboxBackendBase` declares `get_archive` for plugins, and the built-ins keep
+   their undeclared convention; the micromamba gaps in the interactive and pool dispatch
+   paths are preserved exactly rather than quietly closed.
+4. **`SUPPORTED_PLUGIN_API_VERSIONS` as a set.** Kept. It costs nothing now and is what lets
+   a future major give plugin authors a transition window instead of a flag day.
+
+## 11. What changed while building it
+
+Two decisions in this note were wrong and were reversed during implementation. Both are
+corrected in place above; they are collected here so the record is honest.
+
+- **`ContainerAPI` is now public** (§4.2). The note originally refused to promote it. Writing
+  the reference plugin showed the real choice was between publishing it and freezing its
+  shape anyway, undocumented, since the inherited file-transfer and command-execution
+  machinery both read `self.container_api`.
+- **Discovery is no longer skipped for built-ins** (§3). The note originally short-circuited
+  built-in lookups before any entry point scan. A test proved that suppresses the shadow
+  warning for the one user who most needs it — someone whose `docker` backend a package is
+  trying to hijack.
+
+A third correction came from the test suite rather than the design: `_check_dependency` cannot
+move out of `llm_sandbox/session.py`, because six tests patch `llm_sandbox.session.find_spec`.
+See §5.2.

--- a/docs/design/plugin-system.md
+++ b/docs/design/plugin-system.md
@@ -145,7 +145,7 @@ Any new error must be a **subclass** so those keep passing — and so downstream
 
 ### 2.1 Group name
 
-```
+```text
 llm_sandbox.backends
 ```
 
@@ -350,7 +350,7 @@ here rather than left to the implementation.
 
 Nothing installed provides the name, and nothing is close:
 
-```
+```text
 Unknown backend 'tenki'.
 Built-in backends: docker, kubernetes, micromamba, podman.
 No installed package provides 'tenki'. Third-party backends ship as separate
@@ -360,7 +360,7 @@ See https://github.com/vndee/llm-sandbox/blob/main/INTEGRATIONS.md
 
 A plugin *is* installed and the name is a near miss (`difflib.get_close_matches`, stdlib):
 
-```
+```text
 Unknown backend 'tenkki'.
 Built-in backends: docker, kubernetes, micromamba, podman.
 Installed plugin backends: tenki (llm-sandbox-tenki 0.1.0).
@@ -782,3 +782,6 @@ See §5.2.
   Both isolation points now catch `BaseException`, re-raising `KeyboardInterrupt`.
 - **`_get_records()` could return `None`** when `clear_cache()` landed between the
   assignment and the return.
+
+All of the above are fixed on this branch, each with a regression test. The plugin API
+surface itself did not change as a result -- every correction was behind it.

--- a/docs/design/plugin-system.md
+++ b/docs/design/plugin-system.md
@@ -753,3 +753,32 @@ corrected in place above; they are collected here so the record is honest.
 A third correction came from the test suite rather than the design: `_check_dependency` cannot
 move out of `llm_sandbox/session.py`, because six tests patch `llm_sandbox.session.find_spec`.
 See §5.2.
+
+### Found in code review, after the first implementation landed
+
+- **There were four dispatch sites, not three** (§1.4). `PooledSandboxSession` inferred the
+  backend by substring-matching the pool manager's *class name*, then dispatched through its
+  own hardcoded `match`. That made `POOLING` undeliverable for any plugin, and silently
+  misrouted a third-party manager whose class name happened to contain `Docker`.
+  `ContainerPoolManager` now carries a `backend_name`, and the dispatch goes through the
+  registry like the other three.
+- **`SandboxBackendBase` rejected `None` for non-nullable config fields.** Core forwards
+  `runtime_configs=None` and `workdir="/sandbox"` unconditionally from
+  `ArtifactSandboxSession`; the built-ins each normalise by hand, and the new base class did
+  not. The result was a pydantic `ValidationError` — not even a `SandboxError` — from the one
+  consumer of the `ARTIFACTS` capability. `_build_config` now drops `None` for fields that
+  do not accept it.
+- **Capabilities were documented as enforced but only two of four were.** `ARTIFACTS` and
+  `EXISTING_CONTAINER` are now checked before construction, as §2.4 always claimed.
+- **Degenerate backend names failed open.** An entry point may legally be named `""`, and
+  `str(None)` is `"none"` — so a plugin could answer to `backend=""` or `backend=None`, which
+  is what a caller passes when a config value is unset. Names are now NFKC-folded and
+  validated against `^[a-z0-9][a-z0-9_]*$` on both the registration and lookup sides.
+- **Warning delivery could abort discovery.** `warnings.warn` inside `_discover` meant that
+  under `-W error`, a single shadowing plugin broke *every* backend and re-scanned metadata
+  on every call. Discovery is now pure; warnings are logged unconditionally and delivered
+  best-effort after the cache is committed.
+- **`SystemExit` from a plugin escaped failure isolation**, taking the host process down.
+  Both isolation points now catch `BaseException`, re-raising `KeyboardInterrupt`.
+- **`_get_records()` could return `None`** when `clear_cache()` landed between the
+  assignment and the return.

--- a/docs/plugins/authoring.md
+++ b/docs/plugins/authoring.md
@@ -163,7 +163,10 @@ here lets core warn about a mismatch instead of silently honouring one of them.
 
 **`capabilities`** — optional, defaults to empty. Declare only what you actually implement.
 Core checks the declaration *before* constructing anything, so an unsupported capability
-fails cleanly instead of leaving a half-built session or a leaked container behind.
+fails cleanly instead of leaving a half-built session or a leaked container behind. All four
+are enforced: `ArtifactSandboxSession` requires `ARTIFACTS`, `container_id=` requires
+`EXISTING_CONTAINER`, `create_pool_manager()` requires `POOLING`, and
+`InteractiveSandboxSession` requires `INTERACTIVE`.
 
 | Capability | Unlocks | You must implement |
 |---|---|---|
@@ -192,12 +195,14 @@ lifecycle plus six hooks.
 from typing import Any
 
 from llm_sandbox.backends import SandboxBackendBase
-from llm_sandbox.data import StreamCallback
+from llm_sandbox import StreamCallback
 from llm_sandbox.exceptions import ContainerError
 
 
 class MyServiceSession(SandboxBackendBase):
     """A session backed by a MyService sandbox."""
+
+    backend_name = "myservice"  # so errors name the backend, not this class
 
     def __init__(self, api_key: str | None = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -304,6 +309,28 @@ regardless of which backend they picked:
 
     `on_stdout` and `on_stderr` must be accepted and must fire. A backend that cannot stream
     may collect the complete output and invoke each callback once at the end.
+
+!!! warning "`workdir` defaults to a path inside a container"
+
+    Core's default `workdir` is `/sandbox`, and `ArtifactSandboxSession` passes it
+    *explicitly* rather than leaving it unset — so "the caller did not choose one" is not
+    something you can detect by absence alone.
+
+    If your backend executes anywhere other than a container filesystem, map it:
+
+    ```python
+    CONTAINER_DEFAULT_WORKDIR = "/sandbox"
+
+    def __init__(self, **kwargs):
+        requested = kwargs.get("workdir")
+        self._owns_workdir = requested in (None, CONTAINER_DEFAULT_WORKDIR)
+        if self._owns_workdir:
+            kwargs["workdir"] = tempfile.mkdtemp()
+        super().__init__(**kwargs)
+    ```
+
+    And only delete a directory you created. Deleting one the caller named is not
+    recoverable.
 
 !!! warning "The inherited `run()` assumes a filesystem and a shell"
 
@@ -480,7 +507,8 @@ window rather than a flag day.
 | Import from | Names |
 |---|---|
 | `llm_sandbox.backends` | `SandboxBackendPlugin`, `SandboxBackendBase`, `BackendCapability`, `BackendInfo`, `BaseSession`, `ContainerAPI`, `PLUGIN_API_VERSION`, `SUPPORTED_PLUGIN_API_VERSIONS`, `ENTRY_POINT_GROUP`, `normalize_backend_name` |
-| `llm_sandbox` | `SandboxSession`, `create_session`, `ArtifactSandboxSession`, `InteractiveSandboxSession`, `list_backends`, `SessionConfig`, `ConsoleOutput`, `ExecutionResult`, `PlotOutput`, `FileType`, `StreamCallback`, `SupportedLanguage`, `SandboxBackend`, `DefaultImage`, `SecurityPolicy`, `SecurityPattern`, `SecurityIssueSeverity`, `KernelType` |
+| `llm_sandbox` | `SandboxSession`, `create_session`, `ArtifactSandboxSession`, `InteractiveSandboxSession`, `list_backends`, `SessionConfig`, `ConsoleOutput`, `ExecutionResult`, `PlotOutput`, `FileType`, `StreamCallback`, `SupportedLanguage`, `SandboxBackend`, `DefaultImage`, `SecurityPolicy`, `SecurityPattern`, `SecurityIssueSeverity`, `KernelType`, `BackendShadowWarning`, `BackendNameMismatchWarning` |
+| `llm_sandbox.registry` | `get_backend`, `list_backends`, `clear_cache`, `BackendShadowWarning`, `BackendNameMismatchWarning` |
 | `llm_sandbox.exceptions` | every exception in the module |
 | `llm_sandbox.pool` | `ContainerPoolManager`, `PoolConfig`, `ExhaustionStrategy`, `PooledContainer`, `ContainerState`, and the pool exceptions |
 | `llm_sandbox.testing` | `BackendComplianceTests`, `BackendInterfaceComplianceTests` |
@@ -489,8 +517,12 @@ window rather than a flag day.
 
 - Anything under `llm_sandbox.core`. `BaseSession` and `ContainerAPI` are re-exported from
   `llm_sandbox.backends` precisely so you never have to.
-- `llm_sandbox.registry` internals. `get_backend` and `clear_cache` are stable; anything
-  underscore-prefixed is not.
+- `BaseSession` **as a base class**. It is exported so you can annotate against it, and
+  `create_session` is typed as returning it. Do not subclass it directly: its abstract
+  method set may grow within a plugin API major version, and `SandboxBackendBase` exists
+  to absorb that for you. Subclass `SandboxBackendBase`.
+- Underscore-prefixed names in `llm_sandbox.registry`. The four listed above are stable;
+  nothing else in that module is.
 - The language handler classes in `llm_sandbox.language_handlers`.
 - The underscore-prefixed methods on `BaseSession`. `SandboxBackendBase` gives you public
   names for all of them; the bridges are `@final`, so override the public name.

--- a/docs/plugins/authoring.md
+++ b/docs/plugins/authoring.md
@@ -57,7 +57,7 @@ A complete, runnable version of everything below lives in
 
 ## 1. Set up the project
 
-```
+```text
 llm-sandbox-myservice/
 ├── pyproject.toml
 ├── README.md
@@ -153,8 +153,8 @@ instantiates it — every method is a classmethod.
 ### What each declaration is for
 
 **`PLUGIN_API_VERSION`** — required. Which version of this interface you built against.
-Without it, a plugin built for an interface core no longer has fails as an `AttributeError`
-somewhere deep inside a session, which tells the user nothing. See
+Without it, a plugin built against an interface core no longer provides fails with an
+`AttributeError` somewhere deep inside a session, which tells the user nothing. See
 [Version compatibility](#version-compatibility).
 
 **`name`** — required. Your canonical backend name. The entry-point key is what users type,
@@ -172,12 +172,18 @@ are enforced: `ArtifactSandboxSession` requires `ARTIFACTS`, `container_id=` req
 |---|---|---|
 | `ARTIFACTS` | `ArtifactSandboxSession`, plot capture | `get_archive()` on the session |
 | `EXISTING_CONTAINER` | `container_id=` | `connect_to_existing_container()` |
-| `POOLING` | `create_pool_manager()` | `create_pool_manager()` on the descriptor |
+| `POOLING` | `create_pool_manager()` | `create_pool_manager()` on the descriptor, **and** `EXISTING_CONTAINER` |
 | `INTERACTIVE` | `InteractiveSandboxSession` | `create_interactive_session()` on the descriptor |
 
 Declaring a capability you do not have is worse than not declaring it. Leave
 `create_pool_manager` and `create_interactive_session` alone if you do not support them —
 the inherited defaults raise a clear `BackendCapabilityError`.
+
+!!! note "`POOLING` implies `EXISTING_CONTAINER`"
+
+    A pooled session attaches to a container the pool already created, so a backend that
+    declares `POOLING` must also declare `EXISTING_CONTAINER` and implement
+    `connect_to_existing_container()`. Core checks this before building a pooled session.
 
 !!! note "`INTERACTIVE` is the hard one"
 
@@ -189,7 +195,7 @@ the inherited defaults raise a clear `BackendCapabilityError`.
 
 Subclass `SandboxBackendBase` and you inherit `run()`, `install()`, security policy
 enforcement, session timeouts, file transfer, and the context manager protocol. You implement
-lifecycle plus six hooks.
+lifecycle plus five hooks.
 
 ```python title="src/llm_sandbox_myservice/session.py"
 from typing import Any
@@ -247,7 +253,11 @@ class MyServiceSession(SandboxBackendBase):
             self.client.cancel(self.container)
 
     def ensure_directory_exists(self, path: str) -> None:
-        self.container_api.execute_command(self.container, f"mkdir -p {path}")
+        exit_code, output = self.container_api.execute_command(self.container, f"mkdir -p {path}")
+        if exit_code != 0:
+            # Do not swallow this: the copy that follows will fail confusingly instead.
+            _, stderr = self.process_non_stream_output(output)
+            raise ContainerError(f"Could not create {path}: {stderr}")
 
     def ensure_ownership(self, paths: list[str]) -> None:
         """No-op when the sandbox always runs as the owning user."""

--- a/docs/plugins/authoring.md
+++ b/docs/plugins/authoring.md
@@ -1,0 +1,603 @@
+# Writing a backend plugin
+
+LLM Sandbox ships with Docker, Podman, Kubernetes, and Micromamba backends. A **backend
+plugin** adds another one from a separate package, without a fork and without a pull request
+to this project.
+
+```bash
+pip install llm-sandbox-<service>
+```
+
+```python
+from llm_sandbox import SandboxSession
+
+with SandboxSession(backend="<service>", lang="python") as session:
+    print(session.run("print('hello')").stdout)
+```
+
+You do not need approval to publish one. LLM Sandbox is MIT-licensed and the entry-point
+interface documented here is public. [INTEGRATIONS.md][integrations] explains which backends
+belong in core and which belong in a plugin; this page explains how to build one.
+
+[integrations]: https://github.com/vndee/llm-sandbox/blob/main/INTEGRATIONS.md
+
+!!! danger "Installing a plugin means running someone else's code"
+
+    A backend is the component that executes untrusted code. It is the most
+    security-sensitive part of this system.
+
+    Installing a backend plugin means trusting that package's authors — with your
+    credentials, your infrastructure, and the code you send to be executed. It does not mean
+    trusting the LLM Sandbox maintainers. A listing in the [community plugin index](index.md)
+    records that a plugin exists and is community-maintained. It implies no review, no
+    endorsement, and no guarantee.
+
+    LLM Sandbox does not import a plugin until you ask for its backend by name, which limits
+    what runs at import time. That is not a sandbox: by the time a package is installed, its
+    build already ran on your machine. Evaluate a community backend the way you would
+    evaluate any dependency that handles your secrets.
+
+## The shape of a plugin
+
+Three pieces, in increasing size:
+
+| Layer | What it is | Why |
+|---|---|---|
+| **Descriptor** | A `SandboxBackendPlugin` subclass | What the entry point points at. Declares who you are and hands back sessions. |
+| **Session** | A `SandboxBackendBase` subclass | What users hold. Inherits `run()`, `install()`, security scanning, timeouts. |
+| **Runtime driver** | A `ContainerAPI` implementation | Creates somewhere to run code, runs it, moves files in and out. |
+
+The descriptor is deliberately tiny. It is the only part frozen as public contract, which is
+what lets LLM Sandbox refactor its internals without breaking you.
+
+A complete, runnable version of everything below lives in
+[`examples/plugins/llm-sandbox-example/`][example]. Copy it rather than retyping this page.
+
+[example]: https://github.com/vndee/llm-sandbox/tree/main/examples/plugins/llm-sandbox-example
+
+## 1. Set up the project
+
+```
+llm-sandbox-myservice/
+├── pyproject.toml
+├── README.md
+├── src/
+│   └── llm_sandbox_myservice/
+│       ├── __init__.py
+│       ├── backend.py       # the descriptor
+│       ├── session.py       # the session
+│       └── runtime.py       # the runtime driver
+└── tests/
+    ├── test_compliance.py
+    └── test_backend.py
+```
+
+```toml title="pyproject.toml"
+[project]
+name = "llm-sandbox-myservice"
+version = "0.1.0"
+description = "MyService backend for llm-sandbox"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+
+# Depend on llm-sandbox. Never vendor or fork it.
+dependencies = [
+    "llm-sandbox>=0.4.0,<1.0.0",
+    "myservice-sdk>=2.0",
+]
+
+[project.optional-dependencies]
+test = ["llm-sandbox[testing]>=0.4.0,<1.0.0", "pytest>=7.2.0"]
+
+# This is the entire registration mechanism.
+[project.entry-points."llm_sandbox.backends"]
+myservice = "llm_sandbox_myservice:MyServiceBackend"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/llm_sandbox_myservice"]
+```
+
+The entry point **key** (`myservice`) is what users pass to `backend=`. The **value**
+resolves to your descriptor class. There is no registration call and nothing to import at
+start-up — LLM Sandbox reads packaging metadata and imports your module only when someone
+asks for your backend.
+
+Names are normalised before lookup: case is ignored and hyphens and underscores are
+equivalent, so `myservice`, `MyService`, `my-service`, and `my_service` all reach the same
+backend.
+
+## 2. Write the descriptor
+
+```python title="src/llm_sandbox_myservice/backend.py"
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from llm_sandbox.backends import BackendCapability, SandboxBackendPlugin
+
+if TYPE_CHECKING:
+    from llm_sandbox.backends import BaseSession
+
+
+class MyServiceBackend(SandboxBackendPlugin):
+    """Executes code on MyService."""
+
+    PLUGIN_API_VERSION: ClassVar[int] = 1
+    name: ClassVar[str] = "myservice"
+    capabilities: ClassVar[frozenset[BackendCapability]] = frozenset({
+        BackendCapability.ARTIFACTS,
+        BackendCapability.EXISTING_CONTAINER,
+    })
+
+    @classmethod
+    def create_session(cls, *args: Any, **kwargs: Any) -> "BaseSession":
+        # Import inside the method: resolving the entry point stays cheap, and an import
+        # error surfaces as a clear BackendLoadError naming your distribution.
+        from llm_sandbox_myservice.session import MyServiceSession
+
+        return MyServiceSession(**kwargs)
+```
+
+```python title="src/llm_sandbox_myservice/__init__.py"
+from llm_sandbox_myservice.backend import MyServiceBackend
+
+__all__ = ["MyServiceBackend"]
+```
+
+The entry point must resolve to the **class**, not an instance. LLM Sandbox never
+instantiates it — every method is a classmethod.
+
+### What each declaration is for
+
+**`PLUGIN_API_VERSION`** — required. Which version of this interface you built against.
+Without it, a plugin built for an interface core no longer has fails as an `AttributeError`
+somewhere deep inside a session, which tells the user nothing. See
+[Version compatibility](#version-compatibility).
+
+**`name`** — required. Your canonical backend name. The entry-point key is what users type,
+but it is chosen by whoever wrote the `pyproject.toml`, which is not always you. Declaring it
+here lets core warn about a mismatch instead of silently honouring one of them.
+
+**`capabilities`** — optional, defaults to empty. Declare only what you actually implement.
+Core checks the declaration *before* constructing anything, so an unsupported capability
+fails cleanly instead of leaving a half-built session or a leaked container behind.
+
+| Capability | Unlocks | You must implement |
+|---|---|---|
+| `ARTIFACTS` | `ArtifactSandboxSession`, plot capture | `get_archive()` on the session |
+| `EXISTING_CONTAINER` | `container_id=` | `connect_to_existing_container()` |
+| `POOLING` | `create_pool_manager()` | `create_pool_manager()` on the descriptor |
+| `INTERACTIVE` | `InteractiveSandboxSession` | `create_interactive_session()` on the descriptor |
+
+Declaring a capability you do not have is worse than not declaring it. Leave
+`create_pool_manager` and `create_interactive_session` alone if you do not support them —
+the inherited defaults raise a clear `BackendCapabilityError`.
+
+!!! note "`INTERACTIVE` is the hard one"
+
+    Interactive sessions write a runner script into the sandbox filesystem and poll it, and
+    reach into the backing session's container handle. In practice only container-shaped
+    backends can support it. Shipping without it is normal.
+
+## 3. Write the session
+
+Subclass `SandboxBackendBase` and you inherit `run()`, `install()`, security policy
+enforcement, session timeouts, file transfer, and the context manager protocol. You implement
+lifecycle plus six hooks.
+
+```python title="src/llm_sandbox_myservice/session.py"
+from typing import Any
+
+from llm_sandbox.backends import SandboxBackendBase
+from llm_sandbox.data import StreamCallback
+from llm_sandbox.exceptions import ContainerError
+
+
+class MyServiceSession(SandboxBackendBase):
+    """A session backed by a MyService sandbox."""
+
+    def __init__(self, api_key: str | None = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
+        from myservice_sdk import Client
+
+        self.client = Client(api_key=api_key)
+        self.container_api = MyServiceRuntime(self.client)
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def open(self) -> None:
+        super().open()  # starts the session timer, marks the session open
+
+        if self.using_existing_container and self.config.container_id:
+            self.connect_to_existing_container(self.config.container_id)
+        else:
+            self.container = self.container_api.create_container({
+                "image": self.config.image or "myservice/python:3.11",
+                "workdir": self.config.workdir,
+            })
+            self.container_api.start_container(self.container)
+
+        self.environment_setup()
+
+    def close(self) -> None:
+        super().close()  # stops the timer, marks the session closed
+
+        if self.container is not None and not self.using_existing_container:
+            try:
+                self.container_api.stop_container(self.container)
+            except Exception as exc:
+                raise ContainerError(str(exc)) from exc
+            finally:
+                self.container = None
+
+    # -- required hooks ----------------------------------------------------
+
+    def handle_timeout(self) -> None:
+        """Cancel in-flight work. This is what makes a timeout real."""
+        if self.container is not None:
+            self.client.cancel(self.container)
+
+    def ensure_directory_exists(self, path: str) -> None:
+        self.container_api.execute_command(self.container, f"mkdir -p {path}")
+
+    def ensure_ownership(self, paths: list[str]) -> None:
+        """No-op when the sandbox always runs as the owning user."""
+
+    def process_non_stream_output(self, output: Any) -> tuple[str, str]:
+        stdout, stderr = output
+        errors = self.config.encoding_errors
+        return (
+            stdout.decode("utf-8", errors=errors) if stdout else "",
+            stderr.decode("utf-8", errors=errors) if stderr else "",
+        )
+
+    def process_stream_output(
+        self,
+        output: Any,
+        on_stdout: StreamCallback | None = None,
+        on_stderr: StreamCallback | None = None,
+    ) -> tuple[str, str]:
+        stdout, stderr = "", ""
+        for channel, chunk in output:
+            text = chunk.decode("utf-8", errors=self.config.encoding_errors)
+            if channel == "stdout":
+                stdout += text
+                if on_stdout:
+                    on_stdout(text)
+            else:
+                stderr += text
+                if on_stderr:
+                    on_stderr(text)
+        return stdout, stderr
+
+    # -- optional, because ARTIFACTS is declared ---------------------------
+
+    def get_archive(self, path: str) -> tuple[bytes, dict]:
+        return self.container_api.copy_from_container(self.container, path)
+
+    # -- optional, because EXISTING_CONTAINER is declared ------------------
+
+    def connect_to_existing_container(self, container_id: str) -> None:
+        self.container = self.client.attach(container_id)
+```
+
+### The required interface
+
+Every compliant backend supports these. They are what the public session API promises users
+regardless of which backend they picked:
+
+| Method | Contract |
+|---|---|
+| `open()` / `close()` | `close()` releases every resource and is safe to call twice, and after a failed `open()`. |
+| `run(code, libraries=None, timeout=None, on_stdout=None, on_stderr=None)` | Returns `ConsoleOutput`. Propagates the real exit code. Raises `SandboxTimeoutError` on timeout. |
+| `execute_command(command, workdir=None, ...)` | Returns `ConsoleOutput`. Raises `CommandEmptyError` on empty input, `NotOpenSessionError` if not open. |
+| `copy_to_runtime(src, dest)` / `copy_from_runtime(src, dest)` | Raises `FileNotFoundError` for a missing source; rejects path traversal in `dest`. |
+
+`run`, `execute_command`, `copy_to_runtime`, and `copy_from_runtime` are all inherited from
+`SandboxBackendBase` — you get them by implementing the runtime driver in the next step.
+
+!!! warning "Streaming callbacks are required; real-time delivery is not"
+
+    `on_stdout` and `on_stderr` must be accepted and must fire. A backend that cannot stream
+    may collect the complete output and invoke each callback once at the end.
+
+!!! warning "The inherited `run()` assumes a filesystem and a shell"
+
+    `SandboxBackendBase.run()` writes the code to a temporary file, copies it into the
+    workdir, and executes shell commands from the language handler.
+
+    If your service is a `POST /execute {code}` endpoint with no filesystem, you must either
+    emulate one in your runtime driver, or override `run()` outright — which also gives up
+    `install()` and artifact extraction. Emulating is usually less work than it sounds and
+    keeps every other feature working.
+
+## 4. Write the runtime driver
+
+`ContainerAPI` is a structural protocol — six methods. You do not need to inherit from it;
+matching the shape is enough.
+
+```python title="src/llm_sandbox_myservice/runtime.py"
+import io
+import tarfile
+from typing import Any
+
+
+class MyServiceRuntime:
+    """Moves work to MyService and results back."""
+
+    def __init__(self, client: Any) -> None:
+        self.client = client
+
+    def create_container(self, config: Any) -> Any:
+        return self.client.create_sandbox(image=config["image"], workdir=config["workdir"])
+
+    def start_container(self, container: Any) -> None:
+        self.client.start(container)
+
+    def stop_container(self, container: Any) -> None:
+        self.client.destroy(container)
+
+    def execute_command(self, container: Any, command: str, **kwargs: Any) -> tuple[int, Any]:
+        result = self.client.exec(container, command, cwd=kwargs.get("workdir"))
+        return result.exit_code, (result.stdout_bytes, result.stderr_bytes)
+
+    def copy_to_container(self, container: Any, src: str, dest: str, **kwargs: Any) -> None:
+        with open(src, "rb") as handle:
+            self.client.upload(container, dest, handle.read())
+
+    def copy_from_container(self, container: Any, src: str, **kwargs: Any) -> tuple[bytes, dict]:
+        payload = self.client.download(container, src)
+        if payload is None:
+            return b"", {"size": 0}  # size 0 is how callers detect "not found"
+
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w") as tar:
+            info = tarfile.TarInfo(name=src.rsplit("/", 1)[-1])
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+
+        data = buffer.getvalue()
+        return data, {"size": len(data)}
+```
+
+Two contracts worth stating explicitly:
+
+- `execute_command` returns `(exit_code, output)`, where `output` is whatever your
+  `process_non_stream_output` / `process_stream_output` hooks know how to decode.
+- `copy_from_container` returns **uncompressed tar bytes** plus a stat mapping. A `size` of
+  `0` is how callers detect a missing path — do not raise for that case.
+
+## 5. Run the compliance kit
+
+The compliance kit is how you check your backend satisfies the interface without anyone
+having to review your code.
+
+```bash
+pip install -e ".[test]"
+```
+
+```python title="tests/test_compliance.py"
+from llm_sandbox.testing import BackendComplianceTests
+
+
+class TestMyServiceCompliance(BackendComplianceTests):
+    backend = "myservice"
+    session_kwargs = {"lang": "python", "api_key": "test-key"}
+```
+
+```bash
+pytest
+```
+
+That is the whole file. pytest collects every inherited check:
+
+- **Interface completeness** — registration, plugin API version, name agreement, capability
+  declarations, and that undeclared optional factories raise.
+- **Lifecycle** — the context manager runs code; `run()` before `open()` raises; `close()` is
+  idempotent; closing an unopened session is safe; **and an exception inside the `with` body
+  still closes the session.** That last one is the check most worth having: a backend that
+  leaks a container when the body raises passes every happy-path test and quietly costs its
+  users money.
+- **Result types** — `run()` returns a `ConsoleOutput` with correctly typed fields, and a
+  failing program's exit code survives instead of being normalised to 0 or 1.
+- **File transfer** — a file round-trips unchanged; a missing source raises `FileNotFoundError`.
+- **Timeouts** — long-running code raises `SandboxTimeoutError`, and teardown after a timeout
+  does not raise on top of it.
+- **Declared capabilities** — if you declare `ARTIFACTS`, `get_archive()` really returns tar
+  bytes for a file that exists.
+
+Customise the code snippets if your backend's default language is not Python:
+
+```python
+class TestMyServiceCompliance(BackendComplianceTests):
+    backend = "myservice"
+    hello_code = "console.log('llm-sandbox-compliance')"
+    hello_expected = "llm-sandbox-compliance"
+    failing_code = "process.exit(3)"
+    slow_code = "setTimeout(() => {}, 30000)"
+    timeout_seconds = 1.0
+```
+
+If your CI cannot reach the real service, run the static half there and the full suite in a
+job that has credentials:
+
+```python
+from llm_sandbox.testing import BackendInterfaceComplianceTests
+
+
+class TestMyServiceInterface(BackendInterfaceComplianceTests):
+    backend = "myservice"
+```
+
+Then add your own tests for the things only you can check — that your service is actually
+being called, that your options are honoured, that your errors map onto LLM Sandbox's.
+
+## Version compatibility
+
+LLM Sandbox exposes a plugin API version independent of its package version:
+
+```python
+from llm_sandbox.backends import PLUGIN_API_VERSION, SUPPORTED_PLUGIN_API_VERSIONS
+
+PLUGIN_API_VERSION           # 1  -- what this release implements
+SUPPORTED_PLUGIN_API_VERSIONS  # frozenset({1}) -- what this release accepts
+```
+
+Declare the version you built against. On load, a mismatch produces an error naming your
+distribution, the version you declared, and what that release accepts — instead of an
+obscure failure later.
+
+**Within a plugin API major version, LLM Sandbox guarantees:**
+
+- No new *required* member on `SandboxBackendPlugin`.
+- No incompatible signature change to a required method.
+- No change to the meaning or type of a required return value.
+- The entry-point group name does not change.
+- Every name in [Public API surface](#public-api-surface) keeps working from its documented
+  import path.
+- New capabilities may be added. Not declaring one is always safe.
+- New *optional* hooks may be added, always with a working default.
+
+**These bump the major version:**
+
+- Removing or renaming a required member.
+- Changing a required signature or return type incompatibly.
+- Changing the entry-point group.
+- Changing name-normalisation or collision rules such that an existing plugin resolves
+  differently.
+
+A future release can accept more than one version at once, so a bump comes with a transition
+window rather than a flag day.
+
+## Public API surface
+
+**Covered by the compatibility guarantee.** Import only from these paths:
+
+| Import from | Names |
+|---|---|
+| `llm_sandbox.backends` | `SandboxBackendPlugin`, `SandboxBackendBase`, `BackendCapability`, `BackendInfo`, `BaseSession`, `ContainerAPI`, `PLUGIN_API_VERSION`, `SUPPORTED_PLUGIN_API_VERSIONS`, `ENTRY_POINT_GROUP`, `normalize_backend_name` |
+| `llm_sandbox` | `SandboxSession`, `create_session`, `ArtifactSandboxSession`, `InteractiveSandboxSession`, `list_backends`, `SessionConfig`, `ConsoleOutput`, `ExecutionResult`, `PlotOutput`, `FileType`, `StreamCallback`, `SupportedLanguage`, `SandboxBackend`, `DefaultImage`, `SecurityPolicy`, `SecurityPattern`, `SecurityIssueSeverity`, `KernelType` |
+| `llm_sandbox.exceptions` | every exception in the module |
+| `llm_sandbox.pool` | `ContainerPoolManager`, `PoolConfig`, `ExhaustionStrategy`, `PooledContainer`, `ContainerState`, and the pool exceptions |
+| `llm_sandbox.testing` | `BackendComplianceTests`, `BackendInterfaceComplianceTests` |
+
+**Not covered. Do not import these** — they will change without a major version bump:
+
+- Anything under `llm_sandbox.core`. `BaseSession` and `ContainerAPI` are re-exported from
+  `llm_sandbox.backends` precisely so you never have to.
+- `llm_sandbox.registry` internals. `get_backend` and `clear_cache` are stable; anything
+  underscore-prefixed is not.
+- The language handler classes in `llm_sandbox.language_handlers`.
+- The underscore-prefixed methods on `BaseSession`. `SandboxBackendBase` gives you public
+  names for all of them; the bridges are `@final`, so override the public name.
+- The concrete built-in session classes (`SandboxDockerSession` and friends). Subclassing
+  them couples you to internals.
+
+Exceptions you are expected to raise, all importable from `llm_sandbox` or
+`llm_sandbox.exceptions`:
+
+| Exception | Raise it when |
+|---|---|
+| `ContainerError` | The runtime failed to create, start, attach to, or destroy a sandbox |
+| `NotOpenSessionError` | An operation needs an open session and there is not one |
+| `SandboxTimeoutError` | Execution exceeded its timeout |
+| `CommandFailedError` | A command that had to succeed did not |
+| `MissingDependencyError` | Your SDK is not installed |
+| `LibraryInstallationNotSupportedError` | Your backend cannot install libraries |
+| `SecurityViolationError` | A security policy was violated |
+| `ImagePullError` / `ImageNotFoundError` | An image could not be fetched or found |
+| `BackendCapabilityError` | Something asked for a capability you do not declare |
+
+## Conventions
+
+**Package naming.** `llm-sandbox-<service>`, with the import name
+`llm_sandbox_<service>`. Please do not publish an `llm-sandbox-*` package that is a fork or a
+vendored copy rather than a dependent — it confuses users about what they are installing.
+
+**Entry-point naming.** The entry-point key should be the service name, lowercase, and should
+match your `name` attribute. Prefer the shortest unambiguous form: `myservice`, not
+`llm-sandbox-myservice`. Users type it on every call.
+
+**Depend on `llm-sandbox`; do not vendor it.** Vendoring means your users get two copies of
+the session machinery and no upstream fixes.
+
+**Declare a compatible version range.** Lower bound is the release that introduced the plugin
+API you target; upper bound is the next major:
+
+```toml
+dependencies = ["llm-sandbox>=0.4.0,<1.0.0"]
+```
+
+Do not pin exactly (`==0.4.1`) — it makes your plugin uninstallable alongside anything else.
+Do not leave it open-ended (`llm-sandbox`) — a future major will break you silently.
+
+**Semver your own package.** Bump the major when you change your own options or behaviour in
+a way that breaks users. Your release cadence is yours; that is the point of the plugin path.
+
+**What belongs where:**
+
+| Core handles | You handle |
+|---|---|
+| Security policy scanning | Talking to your service |
+| Language handler selection, execution commands | Authentication and credentials |
+| Session and execution timeout policy | Cancelling work when a timeout fires |
+| The `run()` pipeline, `install()` | Runtime lifecycle |
+| File transfer safety (traversal, symlinks) | Moving the bytes |
+| Artifact detection and extraction logic | `get_archive()` |
+
+Do not reimplement the left column. If something there does not fit your backend,
+[open an issue](https://github.com/vndee/llm-sandbox/issues) — that is a gap in this
+interface and worth fixing for everyone.
+
+## Publish
+
+```bash
+python -m build
+twine upload dist/*
+```
+
+Then [open an issue](https://github.com/vndee/llm-sandbox/issues) to be added to the
+[community plugin index](index.md). Include the package name, the service, the maintainer,
+and the repository. There is no application, no review, and no fee.
+
+If you are an employee of, contractor for, or otherwise compensated by the service your
+plugin integrates, please say so — most vendor integrations are written by the vendor, and
+that is expected.
+
+## Troubleshooting
+
+**`Unknown backend 'myservice'`** — the distribution is not installed, or the entry point is
+not declared. Check `llm_sandbox.list_backends()` and the
+`[project.entry-points."llm_sandbox.backends"]` table. Editable installs sometimes need a
+reinstall after adding an entry point.
+
+**`... does not declare PLUGIN_API_VERSION`** — add `PLUGIN_API_VERSION = 1` to the descriptor.
+
+**`... targets plugin API version N`** — your plugin and the installed LLM Sandbox disagree.
+Check your version range.
+
+**`... must resolve to a subclass of SandboxBackendPlugin`** — the entry point points at an
+instance, a function, or the session class. Point it at the descriptor class.
+
+**`... is incomplete: it does not implement create_session`** — the descriptor is still
+abstract.
+
+**`Backend name 'x' is claimed by more than one installed distribution`** — two packages
+registered the same name. Uninstall one. Other backends keep working.
+
+**A `BackendShadowWarning` naming your distribution** — you registered a name a built-in
+already owns. Built-ins always win; rename your entry point.
+
+**Your plugin is not being imported** — that is by design. Discovery reads metadata only;
+your module is imported when someone requests your backend.
+
+## See also
+
+- [Community plugin index](index.md)
+- [INTEGRATIONS.md][integrations] — what belongs in core, what belongs in a plugin
+- [Reference plugin][example] — everything on this page, runnable
+- [Container Backends](../backends.md) — how the built-in backends work

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -26,7 +26,8 @@ with SandboxSession(backend="<service>", lang="python") as session:
     trusting its authors, not us.
 
     Evaluate one the way you would evaluate any dependency that handles your secrets: read
-    the source, check who maintains it, and look at what it does with your data.
+    the source, check who maintains it and how actively, confirm it passes the compliance
+    kit, and look at what it sends off your machine.
 
     The built-in Docker, Podman, Kubernetes, and Micromamba backends are maintained and
     CI-tested in this repository. If your code must not leave your infrastructure, use those.

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -1,0 +1,81 @@
+# Community plugin index
+
+Backends that LLM Sandbox does not ship, published as separate packages by their maintainers.
+
+```bash
+pip install llm-sandbox-<service>
+```
+
+```python
+from llm_sandbox import SandboxSession
+
+with SandboxSession(backend="<service>", lang="python") as session:
+    print(session.run("print('hello')").stdout)
+```
+
+!!! danger "These are not our packages"
+
+    A backend is the component that executes untrusted code — the most security-sensitive
+    part of this system. Installing one of these means running third-party code in your
+    environment and handing that package's authors your credentials, your infrastructure, and
+    the code you send to be executed.
+
+    **Listing here records that a plugin exists and is community-maintained. It is not a
+    review, an endorsement, or a guarantee.** We do not audit these packages, we cannot test
+    them in CI, and we cannot debug them. When you choose a community backend you are
+    trusting its authors, not us.
+
+    Evaluate one the way you would evaluate any dependency that handles your secrets: read
+    the source, check who maintains it, and look at what it does with your data.
+
+    The built-in Docker, Podman, Kubernetes, and Micromamba backends are maintained and
+    CI-tested in this repository. If your code must not leave your infrastructure, use those.
+
+## Plugins
+
+| Name | Service | Maintainer | Repository |
+|---|---|---|---|
+| `llm-sandbox-example` | — (local subprocess reference implementation) | LLM Sandbox | [examples/plugins/llm-sandbox-example][example] |
+
+[example]: https://github.com/vndee/llm-sandbox/tree/main/examples/plugins/llm-sandbox-example
+
+!!! warning "`llm-sandbox-example` is not a sandbox"
+
+    The reference plugin runs code directly on the host machine with no isolation at all. It
+    is published as source to copy, not to depend on, and is not on PyPI. Use it to learn the
+    interface; never point it at untrusted code.
+
+## Getting listed
+
+[Open an issue](https://github.com/vndee/llm-sandbox/issues) with:
+
+- the package name (convention: `llm-sandbox-<service>`)
+- the service it executes code on
+- the maintainer
+- the repository URL
+- confirmation that it passes [the compliance kit](authoring.md#5-run-the-compliance-kit)
+
+You do not need approval to publish a plugin — LLM Sandbox is MIT-licensed and the
+entry-point interface is public. This index exists so people can find your plugin, not to
+gate it.
+
+If you are an employee of, contractor for, or otherwise compensated by the service your
+plugin integrates, please say so in the issue. Most vendor integrations are written by the
+vendor, and that is expected.
+
+## What belongs in a plugin rather than core
+
+Commercial and hosted execution services. If running code requires an account, an API key, or
+a call to infrastructure you operate, it belongs in a plugin — not as a judgement on the
+service, but because this project cannot test it in CI without your credentials, cannot debug
+it when it breaks, and cannot promise users it still works after a release.
+
+Open-source runtimes that execute entirely on the end user's own machine are wanted in core.
+
+[INTEGRATIONS.md](https://github.com/vndee/llm-sandbox/blob/main/INTEGRATIONS.md) has the
+full policy and the reasoning behind it.
+
+## See also
+
+- [Writing a backend plugin](authoring.md)
+- [Container Backends](../backends.md) — the built-in backends

--- a/examples/plugins/llm-sandbox-example/README.md
+++ b/examples/plugins/llm-sandbox-example/README.md
@@ -1,0 +1,106 @@
+# llm-sandbox-example
+
+A complete, working [llm-sandbox](https://github.com/vndee/llm-sandbox) backend plugin,
+kept as small as a correct one can be. Copy it as the starting point for a real backend.
+
+> [!WARNING]
+> **This backend provides no isolation.** It runs code directly on your machine, as you,
+> with your filesystem and your network. It exists to demonstrate the plugin interface end
+> to end with something you can actually run. Never point it at untrusted code — that is
+> what the Docker, Podman, and Kubernetes backends are for.
+
+## Try it
+
+```bash
+pip install -e ".[test]"
+```
+
+```python
+from llm_sandbox import SandboxSession
+
+with SandboxSession(backend="example", lang="python") as session:
+    print(session.run("print(6 * 7)").stdout)  # 42
+```
+
+```python
+import llm_sandbox
+
+for backend in llm_sandbox.list_backends():
+    origin = "built-in" if backend.is_builtin else f"{backend.distribution} {backend.version}"
+    print(f"{backend.name:<14} {origin}")
+```
+
+## What is in here
+
+| File | What it does |
+|---|---|
+| `pyproject.toml` | Declares the entry point. This is the entire registration mechanism. |
+| `src/llm_sandbox_example/backend.py` | The `SandboxBackendPlugin` descriptor the entry point resolves to. |
+| `src/llm_sandbox_example/session.py` | The session, a `SandboxBackendBase` subclass. |
+| `src/llm_sandbox_example/runtime.py` | The `ContainerAPI` that actually moves and runs things. |
+| `tests/test_compliance.py` | The whole compliance kit, in five lines. |
+| `tests/test_backend.py` | Tests only you can write, about your backend's own behaviour. |
+
+## How registration works
+
+One table in `pyproject.toml`:
+
+```toml
+[project.entry-points."llm_sandbox.backends"]
+example = "llm_sandbox_example:ExampleBackend"
+```
+
+The key is the name users pass to `SandboxSession(backend=...)`. The value resolves to a
+`SandboxBackendPlugin` subclass. That is all — there is no registration call, no plugin
+manager, and nothing to import at start-up. llm-sandbox reads the metadata and imports your
+module only when someone asks for your backend by name.
+
+Names are normalised: `example`, `Example`, and `EXAMPLE` all resolve here, and hyphens and
+underscores are interchangeable.
+
+## The three layers
+
+**The descriptor** (`backend.py`) declares who you are and hands back sessions. It is
+deliberately tiny; keeping it that way is what lets llm-sandbox refactor its internals
+without breaking you.
+
+**The session** (`session.py`) is what users hold. Subclassing `SandboxBackendBase` means
+inheriting `run()`, `install()`, security policy enforcement, timeouts, file transfer, and
+the context manager protocol — you implement lifecycle plus six hooks.
+
+**The runtime driver** (`runtime.py`) implements `ContainerAPI`: six methods that create a
+place to run things, run them, and move files in and out. Implement this and the two layers
+above it mostly write themselves. A real backend talks to a container runtime or a vendor
+API here; this one shells out to subprocesses.
+
+## Running the compliance kit
+
+```bash
+pytest
+```
+
+`tests/test_compliance.py` is five lines and gets you the full suite: interface
+completeness, lifecycle (including cleanup when the `with` body raises), result-type
+conformance, file round-tripping, and timeout cancellation.
+
+If you cannot run live sessions in CI — no credentials, no daemon — subclass
+`BackendInterfaceComplianceTests` instead for the static half, and run the full suite in a
+job that does have access.
+
+## Turning this into a real backend
+
+1. Rename the package and the distribution. The convention is `llm-sandbox-<service>`.
+2. Change `name` in `backend.py` and the entry point key in `pyproject.toml` to match.
+3. Replace `runtime.py` with calls to your service.
+4. Declare only the `capabilities` you actually implement. Declaring one you do not have is
+   worse than not declaring it: users get a half-built session instead of a clear error.
+5. Keep `PLUGIN_API_VERSION` accurate, and pin `llm-sandbox` to a compatible range.
+6. Delete this warning box and write an honest one about your own isolation guarantees.
+
+Full guide: [Writing a backend plugin](https://vndee.github.io/llm-sandbox/plugins/authoring/).
+Policy on what belongs in core versus a plugin:
+[INTEGRATIONS.md](https://github.com/vndee/llm-sandbox/blob/main/INTEGRATIONS.md).
+
+## License
+
+MIT, same as llm-sandbox.

--- a/examples/plugins/llm-sandbox-example/README.md
+++ b/examples/plugins/llm-sandbox-example/README.md
@@ -66,7 +66,7 @@ without breaking you.
 
 **The session** (`session.py`) is what users hold. Subclassing `SandboxBackendBase` means
 inheriting `run()`, `install()`, security policy enforcement, timeouts, file transfer, and
-the context manager protocol — you implement lifecycle plus six hooks.
+the context manager protocol — you implement lifecycle plus five hooks.
 
 **The runtime driver** (`runtime.py`) implements `ContainerAPI`: six methods that create a
 place to run things, run them, and move files in and out. Implement this and the two layers
@@ -93,7 +93,8 @@ job that does have access.
 2. Change `name` in `backend.py` and the entry point key in `pyproject.toml` to match.
 3. Replace `runtime.py` with calls to your service.
 4. Declare only the `capabilities` you actually implement. Declaring one you do not have is
-   worse than not declaring it: users get a half-built session instead of a clear error.
+   worse than not declaring it: core takes the declaration at its word and lets the call
+   through, so the failure surfaces later and further from the cause.
 5. Keep `PLUGIN_API_VERSION` accurate, and pin `llm-sandbox` to a compatible range.
 6. Delete this warning box and write an honest one about your own isolation guarantees.
 

--- a/examples/plugins/llm-sandbox-example/pyproject.toml
+++ b/examples/plugins/llm-sandbox-example/pyproject.toml
@@ -5,6 +5,9 @@ description = "Reference backend plugin for llm-sandbox. Demonstrates the interf
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
+# This package runs code on the host with no isolation. It exists to be read and copied,
+# never installed from an index -- the classifier makes an accidental upload fail.
+classifiers = ["Private :: Do Not Upload"]
 
 # Depend on llm-sandbox; never vendor or fork it. Pin to a plugin-API-compatible range:
 # the lower bound is the release that introduced the plugin API you target, and the upper

--- a/examples/plugins/llm-sandbox-example/pyproject.toml
+++ b/examples/plugins/llm-sandbox-example/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "llm-sandbox-example"
+version = "0.1.0"
+description = "Reference backend plugin for llm-sandbox. Demonstrates the interface; provides no isolation."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+
+# Depend on llm-sandbox; never vendor or fork it. Pin to a plugin-API-compatible range:
+# the lower bound is the release that introduced the plugin API you target, and the upper
+# bound is the next major, where the interface may change.
+dependencies = ["llm-sandbox>=0.4.0,<1.0.0"]
+
+[project.optional-dependencies]
+# `llm_sandbox.testing` needs pytest, which llm-sandbox does not require at runtime.
+test = ["llm-sandbox[testing]>=0.4.0,<1.0.0", "pytest>=7.2.0"]
+
+# This is the whole registration mechanism. The key is the name users pass to
+# `SandboxSession(backend=...)`; the value resolves to the SandboxBackendPlugin subclass.
+[project.entry-points."llm_sandbox.backends"]
+example = "llm_sandbox_example:ExampleBackend"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/llm_sandbox_example"]

--- a/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/__init__.py
+++ b/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/__init__.py
@@ -1,0 +1,14 @@
+"""Reference backend plugin for llm-sandbox.
+
+Copy this package as the starting point for a real backend. See the README for what to
+change.
+
+Warning:
+    This backend executes code directly on the host machine and provides no isolation
+    whatsoever. It exists to demonstrate the plugin interface end to end.
+
+"""
+
+from llm_sandbox_example.backend import ExampleBackend
+
+__all__ = ["ExampleBackend"]

--- a/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/backend.py
+++ b/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/backend.py
@@ -1,0 +1,56 @@
+"""The plugin descriptor: the object the entry point points at.
+
+Warning:
+    This backend runs code **directly on the host machine**, with your user, your
+    filesystem, and your network. It is a reference implementation of the plugin interface,
+    not a sandbox. Do not run untrusted code with it. Use the Docker, Podman, or Kubernetes
+    backends for that.
+
+"""
+
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from llm_sandbox.backends import BackendCapability, SandboxBackendPlugin
+
+if TYPE_CHECKING:
+    from llm_sandbox.backends import BaseSession
+
+
+class ExampleBackend(SandboxBackendPlugin):
+    """A minimal, complete backend plugin.
+
+    Everything a plugin must declare is here and nothing else is required:
+
+    - `PLUGIN_API_VERSION` -- which plugin interface this was built against
+    - `name` -- the canonical backend name
+    - `capabilities` -- the optional behaviour this backend actually implements
+    - `create_session` -- the factory everything routes through
+
+    `create_pool_manager` and `create_interactive_session` are not overridden, because this
+    backend declares neither capability. Their inherited defaults raise a clear error.
+    """
+
+    PLUGIN_API_VERSION: ClassVar[int] = 1
+    name: ClassVar[str] = "example"
+    capabilities: ClassVar[frozenset[BackendCapability]] = frozenset({BackendCapability.ARTIFACTS})
+
+    @classmethod
+    def create_session(cls, *args: Any, **kwargs: Any) -> "BaseSession":  # noqa: ARG003
+        """Create a local subprocess sandbox session.
+
+        The session class is imported here rather than at module scope so that resolving the
+        entry point stays cheap, and so an import error in the session module surfaces as a
+        clear `llm_sandbox.BackendLoadError` naming this distribution.
+
+        Args:
+            *args: Ignored. Accepted because core forwards positional arguments for
+                backwards compatibility with the built-in backends.
+            **kwargs: Session arguments, forwarded verbatim.
+
+        Returns:
+            BaseSession: The session.
+
+        """
+        from llm_sandbox_example.session import LocalSandboxSession
+
+        return LocalSandboxSession(**kwargs)

--- a/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/runtime.py
+++ b/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/runtime.py
@@ -29,6 +29,24 @@ _PYTHON_PREFIX = "python "
 _KILL_GRACE_SECONDS = 5.0
 
 
+def _kill_group(process: subprocess.Popen[bytes]) -> None:
+    """Kill a process and everything it spawned, then reap it.
+
+    Killing only the shell leaves grandchildren alive holding the inherited pipe, which
+    hangs communicate() forever -- a timeout that does not actually cancel anything.
+
+    Args:
+        process (subprocess.Popen[bytes]): The process to kill. Already-exited is fine.
+
+    """
+    if process.poll() is not None:
+        return
+    with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+        os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        process.wait(timeout=_KILL_GRACE_SECONDS)
+
+
 class LocalContainerAPI:
     """Run commands and move files in a local directory, via subprocesses.
 
@@ -114,6 +132,11 @@ class LocalContainerAPI:
             self._processes.add(process)
         try:
             stdout, stderr = process.communicate()
+        except BaseException:
+            # Killed rather than left running: an interrupted communicate() would otherwise
+            # orphan the whole group, and nothing else will come back for it.
+            _kill_group(process)
+            raise
         finally:
             with self._lock:
                 self._processes.discard(process)
@@ -173,12 +196,6 @@ class LocalContainerAPI:
             processes = list(self._processes)
 
         for process in processes:
-            if process.poll() is not None:
-                continue
-            # Kill the group, not just the shell -- see start_new_session above.
-            with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
-                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
-            with contextlib.suppress(subprocess.TimeoutExpired):
-                process.wait(timeout=_KILL_GRACE_SECONDS)
+            _kill_group(process)
             with self._lock:
                 self._processes.discard(process)

--- a/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/runtime.py
+++ b/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/runtime.py
@@ -8,8 +8,11 @@ security scanning, timeouts, and file transfer.
 A real backend would talk to a container runtime or a remote API here. This one shells out.
 """
 
+import contextlib
 import io
+import os
 import shutil
+import signal
 import subprocess
 import sys
 import tarfile
@@ -21,6 +24,9 @@ from typing import Any
 # not on PATH, so the local runtime resolves it to the interpreter running llm-sandbox --
 # the kind of environment translation a real backend does too.
 _PYTHON_PREFIX = "python "
+
+#: How long to wait for a killed process group to be reaped before giving up.
+_KILL_GRACE_SECONDS = 5.0
 
 
 class LocalContainerAPI:
@@ -99,6 +105,10 @@ class LocalContainerAPI:
             cwd=workdir,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            # Its own process group, so a timeout can kill the whole tree. Killing only the
+            # shell leaves grandchildren alive holding the inherited pipe, which hangs
+            # communicate() forever -- a timeout that does not actually cancel anything.
+            start_new_session=True,
         )
         with self._lock:
             self._processes.add(process)
@@ -161,6 +171,14 @@ class LocalContainerAPI:
         """
         with self._lock:
             processes = list(self._processes)
+
         for process in processes:
-            if process.poll() is None:
-                process.kill()
+            if process.poll() is not None:
+                continue
+            # Kill the group, not just the shell -- see start_new_session above.
+            with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                process.wait(timeout=_KILL_GRACE_SECONDS)
+            with self._lock:
+                self._processes.discard(process)

--- a/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/runtime.py
+++ b/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/runtime.py
@@ -1,0 +1,166 @@
+"""The runtime driver: a `ContainerAPI` backed by local subprocesses.
+
+`ContainerAPI` is a structural protocol -- six methods that move a workload in, run it, and
+move results out. Implementing it is the shortest path to a working backend, because
+`llm_sandbox.backends.SandboxBackendBase` builds everything else on top: `run()`, `install()`,
+security scanning, timeouts, and file transfer.
+
+A real backend would talk to a container runtime or a remote API here. This one shells out.
+"""
+
+import io
+import shutil
+import subprocess
+import sys
+import tarfile
+import threading
+from pathlib import Path
+from typing import Any
+
+# Commands come from the language handler as `python <file>`. On many systems `python` is
+# not on PATH, so the local runtime resolves it to the interpreter running llm-sandbox --
+# the kind of environment translation a real backend does too.
+_PYTHON_PREFIX = "python "
+
+
+class LocalContainerAPI:
+    """Run commands and move files in a local directory, via subprocesses.
+
+    Satisfies `llm_sandbox.backends.ContainerAPI` structurally; there is no need to inherit
+    from it. The "container" passed to each method is the sandbox directory path.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the runtime driver."""
+        self._processes: set[subprocess.Popen[bytes]] = set()
+        self._lock = threading.Lock()
+
+    def create_container(self, config: Any) -> Any:
+        """Create the sandbox directory.
+
+        Args:
+            config (Any): Mapping with a ``workdir`` key.
+
+        Returns:
+            Any: The sandbox directory path, used as the container handle.
+
+        """
+        workdir = Path(config["workdir"])
+        workdir.mkdir(parents=True, exist_ok=True)
+        return str(workdir)
+
+    def start_container(self, container: Any) -> None:
+        """Start the sandbox. Nothing to do for a directory.
+
+        Args:
+            container (Any): The sandbox directory path.
+
+        """
+        Path(container).mkdir(parents=True, exist_ok=True)
+
+    def stop_container(self, container: Any) -> None:  # noqa: ARG002
+        """Stop the sandbox by killing any command still running.
+
+        Deliberately does **not** delete the directory. The session decides that, because
+        only it knows whether the workdir was created for this session or handed in by the
+        caller -- and deleting a caller's directory is not recoverable.
+
+        Args:
+            container (Any): The sandbox directory path. Unused.
+
+        """
+        self.terminate_running()
+
+    def execute_command(self, container: Any, command: str, **kwargs: Any) -> tuple[int, Any]:
+        """Run a shell command in the sandbox directory.
+
+        Args:
+            container (Any): The sandbox directory path.
+            command (str): The command line to run.
+            **kwargs: Accepts ``workdir``; ``stream`` is ignored because this runtime
+                collects output and replays it (see `LocalSandboxSession.process_stream_output`).
+
+        Returns:
+            tuple[int, Any]: Exit code, and a ``(stdout_bytes, stderr_bytes)`` pair.
+
+        """
+        workdir = kwargs.get("workdir") or container
+        Path(workdir).mkdir(parents=True, exist_ok=True)
+
+        if command.startswith(_PYTHON_PREFIX):
+            interpreter = shutil.which("python") or sys.executable
+            command = f"{interpreter} {command[len(_PYTHON_PREFIX) :]}"
+
+        # S602: running a shell command is the entire job of this backend. See the warning
+        # in the module docstring of backend.py -- this example is not an isolation boundary.
+        process = subprocess.Popen(  # noqa: S602
+            command,
+            shell=True,
+            cwd=workdir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        with self._lock:
+            self._processes.add(process)
+        try:
+            stdout, stderr = process.communicate()
+        finally:
+            with self._lock:
+                self._processes.discard(process)
+
+        return process.returncode or 0, (stdout, stderr)
+
+    def copy_to_container(self, container: Any, src: str, dest: str, **_kwargs: Any) -> None:  # noqa: ARG002
+        """Copy a file or directory into the sandbox.
+
+        Args:
+            container (Any): The sandbox directory path.
+            src (str): Host path to copy from.
+            dest (str): Sandbox path to copy to.
+            **_kwargs: Unused.
+
+        """
+        source = Path(src)
+        destination = Path(dest)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+
+        if source.is_dir():
+            shutil.copytree(source, destination, dirs_exist_ok=True)
+        else:
+            shutil.copy2(source, destination)
+
+    def copy_from_container(self, container: Any, src: str, **_kwargs: Any) -> tuple[bytes, dict]:  # noqa: ARG002
+        """Read a path out of the sandbox as an uncompressed tar archive.
+
+        Args:
+            container (Any): The sandbox directory path.
+            src (str): Sandbox path to read.
+            **_kwargs: Unused.
+
+        Returns:
+            tuple[bytes, dict]: Tar bytes and a stat mapping. A ``size`` of 0 means the path
+                does not exist, which is how callers detect a missing file.
+
+        """
+        source = Path(src)
+        if not source.exists():
+            return b"", {"size": 0}
+
+        buffer = io.BytesIO()
+        with tarfile.open(fileobj=buffer, mode="w") as tar:
+            tar.add(source, arcname=source.name)
+
+        payload = buffer.getvalue()
+        return payload, {"name": source.name, "size": len(payload)}
+
+    def terminate_running(self) -> None:
+        """Kill every command still running.
+
+        This is what makes timeouts real: core cannot kill the Python thread waiting on the
+        command, so the backend has to kill the work itself.
+        """
+        with self._lock:
+            processes = list(self._processes)
+        for process in processes:
+            if process.poll() is None:
+                process.kill()

--- a/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/session.py
+++ b/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/session.py
@@ -50,13 +50,20 @@ class LocalSandboxSession(SandboxBackendBase):
             kwargs["workdir"] = tempfile.mkdtemp(prefix="llm-sandbox-example-")
         kwargs.setdefault("skip_environment_setup", True)
 
-        super().__init__(**kwargs)
+        try:
+            super().__init__(**kwargs)
 
-        # Imported lazily so the module stays importable without a runtime present -- the
-        # same discipline a real backend needs for its vendor SDK.
-        from llm_sandbox_example.runtime import LocalContainerAPI
+            # Imported lazily so the module stays importable without a runtime present --
+            # the same discipline a real backend needs for its vendor SDK.
+            from llm_sandbox_example.runtime import LocalContainerAPI
 
-        self.container_api = LocalContainerAPI()
+            self.container_api = LocalContainerAPI()
+        except BaseException:
+            # close() never runs for a session that failed to construct, so anything
+            # allocated before the failure has to be released here.
+            if self._owns_workdir:
+                shutil.rmtree(kwargs["workdir"], ignore_errors=True)
+            raise
 
     # ------------------------------------------------------------------ #
     # Lifecycle

--- a/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/session.py
+++ b/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/session.py
@@ -1,0 +1,165 @@
+"""The session: what `create_session` hands back.
+
+Subclassing `llm_sandbox.backends.SandboxBackendBase` means implementing only the six
+required hooks plus lifecycle. Everything else -- ``run()``, ``install()``, security policy
+enforcement, timeouts, file transfer, the context manager protocol -- is inherited.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from llm_sandbox.backends import SandboxBackendBase
+from llm_sandbox.data import StreamCallback
+
+
+class LocalSandboxSession(SandboxBackendBase):
+    """A session that runs code in a temporary directory on the local machine.
+
+    Warning:
+        This provides **no isolation**. Code runs as you, with your filesystem and your
+        network. It exists to demonstrate the plugin interface. Never use it for untrusted
+        code -- that is what the Docker, Podman, and Kubernetes backends are for.
+
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize the session.
+
+        Args:
+            **kwargs: Session arguments. ``workdir`` defaults to a fresh temporary directory,
+                since the usual ``/sandbox`` default is not writable on a normal machine.
+                ``skip_environment_setup`` defaults to True because there is no container to
+                prepare; pass False to build a virtualenv and enable ``install()``.
+
+        """
+        self._owns_workdir = "workdir" not in kwargs
+        if self._owns_workdir:
+            kwargs["workdir"] = tempfile.mkdtemp(prefix="llm-sandbox-example-")
+        kwargs.setdefault("skip_environment_setup", True)
+
+        super().__init__(**kwargs)
+
+        # Imported lazily so the module stays importable without a runtime present -- the
+        # same discipline a real backend needs for its vendor SDK.
+        from llm_sandbox_example.runtime import LocalContainerAPI
+
+        self.container_api = LocalContainerAPI()
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+
+    def open(self) -> None:
+        """Create the sandbox directory and prepare the environment."""
+        super().open()
+
+        self.container = self.container_api.create_container({"workdir": self.config.workdir})
+        self.container_api.start_container(self.container)
+
+        self.environment_setup()
+
+    def close(self) -> None:
+        """Kill any running command and remove the sandbox directory.
+
+        Called on every exit path, including when the ``with`` body raises. Releasing
+        resources here is the single most important thing a backend gets right.
+        """
+        super().close()
+
+        if self.container is not None:
+            self.container_api.stop_container(self.container)
+            self.container = None
+
+        if self._owns_workdir:
+            shutil.rmtree(self.config.workdir, ignore_errors=True)
+
+    # ------------------------------------------------------------------ #
+    # Required hooks
+    # ------------------------------------------------------------------ #
+
+    def handle_timeout(self) -> None:
+        """Kill in-flight commands so a timeout actually cancels the work."""
+        self.container_api.terminate_running()
+
+    def ensure_directory_exists(self, path: str) -> None:
+        """Create a directory inside the sandbox.
+
+        Args:
+            path (str): Absolute path of the directory to create.
+
+        """
+        Path(path).mkdir(parents=True, exist_ok=True)
+
+    def ensure_ownership(self, paths: list[str]) -> None:
+        """No-op: everything already runs as the invoking user.
+
+        Args:
+            paths (list[str]): Ignored.
+
+        """
+
+    def process_non_stream_output(self, output: Any) -> tuple[str, str]:
+        """Decode the ``(stdout, stderr)`` byte pair the runtime returns.
+
+        Args:
+            output (Any): A ``(stdout_bytes, stderr_bytes)`` pair.
+
+        Returns:
+            tuple[str, str]: Decoded ``(stdout, stderr)``.
+
+        """
+        if not isinstance(output, tuple) or len(output) != 2:  # noqa: PLR2004
+            return "", ""
+
+        stdout, stderr = output
+        errors = self.config.encoding_errors
+        return (
+            stdout.decode("utf-8", errors=errors) if stdout else "",
+            stderr.decode("utf-8", errors=errors) if stderr else "",
+        )
+
+    def process_stream_output(
+        self,
+        output: Any,
+        on_stdout: StreamCallback | None = None,
+        on_stderr: StreamCallback | None = None,
+    ) -> tuple[str, str]:
+        """Replay collected output through the callbacks.
+
+        This runtime waits for the command to finish, so there is nothing to stream. The
+        contract requires the signature and requires the callbacks to fire -- it does not
+        require chunks to arrive in real time.
+
+        Args:
+            output (Any): A ``(stdout_bytes, stderr_bytes)`` pair.
+            on_stdout (StreamCallback | None): Called once with the complete stdout.
+            on_stderr (StreamCallback | None): Called once with the complete stderr.
+
+        Returns:
+            tuple[str, str]: The accumulated ``(stdout, stderr)``.
+
+        """
+        stdout, stderr = self.process_non_stream_output(output)
+        if on_stdout and stdout:
+            on_stdout(stdout)
+        if on_stderr and stderr:
+            on_stderr(stderr)
+        return stdout, stderr
+
+    # ------------------------------------------------------------------ #
+    # Optional: declared as BackendCapability.ARTIFACTS
+    # ------------------------------------------------------------------ #
+
+    def get_archive(self, path: str) -> tuple[bytes, dict]:
+        """Read a path out of the sandbox as a tar archive.
+
+        Args:
+            path (str): Absolute path inside the sandbox.
+
+        Returns:
+            tuple[bytes, dict]: Tar bytes and a stat mapping with a ``size`` key.
+
+        """
+        return self.container_api.copy_from_container(self.container, path)

--- a/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/session.py
+++ b/examples/plugins/llm-sandbox-example/src/llm_sandbox_example/session.py
@@ -8,10 +8,13 @@ enforcement, timeouts, file transfer, the context manager protocol -- is inherit
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from llm_sandbox.backends import SandboxBackendBase
 from llm_sandbox.data import StreamCallback
+
+#: Core's default workdir. An absolute path inside a container, not on the host.
+CONTAINER_DEFAULT_WORKDIR = "/sandbox"
 
 
 class LocalSandboxSession(SandboxBackendBase):
@@ -24,17 +27,25 @@ class LocalSandboxSession(SandboxBackendBase):
 
     """
 
+    backend_name: ClassVar[str] = "example"
+
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the session.
 
         Args:
-            **kwargs: Session arguments. ``workdir`` defaults to a fresh temporary directory,
-                since the usual ``/sandbox`` default is not writable on a normal machine.
-                ``skip_environment_setup`` defaults to True because there is no container to
-                prepare; pass False to build a virtualenv and enable ``install()``.
+            **kwargs: Session arguments. ``workdir`` is replaced with a fresh temporary
+                directory unless the caller named one of their own, since core's default is a
+                path inside a container. ``skip_environment_setup`` defaults to True because
+                there is no container to prepare; pass False to build a virtualenv and enable
+                ``install()``.
 
         """
-        self._owns_workdir = "workdir" not in kwargs
+        # Core's workdir default is "/sandbox" -- an absolute path inside a container, which
+        # is not writable on a normal machine. `ArtifactSandboxSession` also passes it
+        # explicitly rather than leaving it unset, so "absent" is not enough to detect it.
+        # Any backend that executes somewhere other than a container has to map this.
+        requested_workdir = kwargs.get("workdir")
+        self._owns_workdir = requested_workdir in (None, CONTAINER_DEFAULT_WORKDIR)
         if self._owns_workdir:
             kwargs["workdir"] = tempfile.mkdtemp(prefix="llm-sandbox-example-")
         kwargs.setdefault("skip_environment_setup", True)
@@ -66,14 +77,19 @@ class LocalSandboxSession(SandboxBackendBase):
         Called on every exit path, including when the ``with`` body raises. Releasing
         resources here is the single most important thing a backend gets right.
         """
-        super().close()
-
-        if self.container is not None:
-            self.container_api.stop_container(self.container)
-            self.container = None
-
-        if self._owns_workdir:
-            shutil.rmtree(self.config.workdir, ignore_errors=True)
+        try:
+            super().close()
+        finally:
+            # Whatever the base teardown does, the runtime must be stopped and a directory
+            # we created must be removed. A backend that leaks on the error path is the
+            # failure mode that quietly costs its users money.
+            try:
+                if self.container is not None:
+                    self.container_api.stop_container(self.container)
+                    self.container = None
+            finally:
+                if self._owns_workdir:
+                    shutil.rmtree(self.config.workdir, ignore_errors=True)
 
     # ------------------------------------------------------------------ #
     # Required hooks
@@ -110,9 +126,6 @@ class LocalSandboxSession(SandboxBackendBase):
             tuple[str, str]: Decoded ``(stdout, stderr)``.
 
         """
-        if not isinstance(output, tuple) or len(output) != 2:  # noqa: PLR2004
-            return "", ""
-
         stdout, stderr = output
         errors = self.config.encoding_errors
         return (

--- a/examples/plugins/llm-sandbox-example/tests/test_backend.py
+++ b/examples/plugins/llm-sandbox-example/tests/test_backend.py
@@ -1,0 +1,86 @@
+"""Tests specific to this backend, beyond what the compliance kit covers.
+
+The compliance kit checks that you satisfy the interface. These check that your backend does
+its own job correctly -- which only you can write.
+"""
+
+from pathlib import Path
+
+import pytest
+from llm_sandbox_example import ExampleBackend
+
+from llm_sandbox import SandboxSession, list_backends
+from llm_sandbox.backends import BackendCapability
+from llm_sandbox.exceptions import BackendCapabilityError
+from llm_sandbox.registry import get_backend
+
+
+class TestRegistration:
+    """The plugin is wired up correctly as an installed distribution."""
+
+    def test_listed_as_an_installed_backend(self) -> None:
+        """Listed as an installed backend."""
+        info = next(item for item in list_backends() if item.name == "example")
+
+        assert info.is_builtin is False
+        assert info.distribution == "llm-sandbox-example"
+
+    def test_resolves_to_this_class(self) -> None:
+        """Resolves to this class."""
+        assert get_backend("example") is ExampleBackend
+
+    def test_declares_only_what_it_implements(self) -> None:
+        """Declares only what it implements."""
+        assert ExampleBackend.capabilities == frozenset({BackendCapability.ARTIFACTS})
+
+        with pytest.raises(BackendCapabilityError):
+            ExampleBackend.create_pool_manager()
+
+
+class TestSessionBehaviour:
+    """Behaviour particular to running code in a local directory."""
+
+    def test_runs_code_and_captures_stdout(self) -> None:
+        """Runs code and captures stdout."""
+        with SandboxSession(backend="example", lang="python") as session:
+            result = session.run("print(6 * 7)")
+
+        assert result.exit_code == 0
+        assert result.stdout.strip() == "42"
+
+    def test_stderr_is_captured_separately(self) -> None:
+        """Stderr is captured separately."""
+        with SandboxSession(backend="example", lang="python") as session:
+            result = session.run("import sys; sys.stderr.write('to-stderr')")
+
+        assert "to-stderr" in result.stderr
+        assert "to-stderr" not in result.stdout
+
+    def test_streaming_callbacks_fire(self) -> None:
+        """Streaming callbacks fire."""
+        chunks: list[str] = []
+
+        with SandboxSession(backend="example", lang="python") as session:
+            session.run("print('streamed')", on_stdout=chunks.append)
+
+        assert any("streamed" in chunk for chunk in chunks)
+
+    def test_temporary_workdir_is_removed_on_close(self) -> None:
+        """The backend owns the directory it created, so it must clean it up."""
+        session = SandboxSession(backend="example", lang="python")
+        workdir = Path(session.config.workdir)
+
+        with session:
+            assert workdir.exists()
+
+        assert not workdir.exists(), "Session leaked its temporary working directory"
+
+    def test_caller_supplied_workdir_is_left_alone(self, tmp_path: Path) -> None:
+        """Caller supplied workdir is left alone."""
+        workdir = tmp_path / "mine"
+        workdir.mkdir()
+
+        with SandboxSession(backend="example", lang="python", workdir=str(workdir)) as session:
+            session.run("print('hello')")
+
+        assert workdir.exists(), "Backend deleted a directory it did not create"

--- a/examples/plugins/llm-sandbox-example/tests/test_compliance.py
+++ b/examples/plugins/llm-sandbox-example/tests/test_compliance.py
@@ -1,0 +1,19 @@
+"""Run the llm-sandbox compliance kit against this backend.
+
+This is the whole file. Subclass the suite, name your backend, and pytest collects every
+inherited check. Copy it into your own plugin and change `backend` and `session_kwargs`.
+
+Run it with:
+
+    pip install -e ".[test]"
+    pytest
+"""
+
+from llm_sandbox.testing import BackendComplianceTests
+
+
+class TestExampleBackendCompliance(BackendComplianceTests):
+    """Full conformance suite: interface, lifecycle, result types, files, timeouts."""
+
+    backend = "example"
+    session_kwargs = {"lang": "python"}  # noqa: RUF012

--- a/llm_sandbox/__init__.py
+++ b/llm_sandbox/__init__.py
@@ -3,13 +3,37 @@
 from .const import DefaultImage, SandboxBackend, SupportedLanguage
 from .core.config import SessionConfig
 from .data import ConsoleOutput, ExecutionResult, FileType, PlotOutput, StreamCallback
-from .exceptions import ContainerError, ResourceError, SandboxError, SecurityError, ValidationError
+from .exceptions import (
+    BackendCapabilityError,
+    BackendLoadError,
+    BackendNameConflictError,
+    BackendNotFoundError,
+    CommandFailedError,
+    ContainerError,
+    LibraryInstallationNotSupportedError,
+    MissingDependencyError,
+    NotOpenSessionError,
+    ResourceError,
+    SandboxError,
+    SandboxTimeoutError,
+    SecurityError,
+    UnsupportedBackendError,
+    ValidationError,
+)
 from .interactive import KernelType
+from .registry import BackendNameMismatchWarning, BackendShadowWarning, list_backends
 from .security import SecurityIssueSeverity, SecurityPattern, SecurityPolicy
 from .session import ArtifactSandboxSession, InteractiveSandboxSession, SandboxSession, create_session
 
 __all__ = [
     "ArtifactSandboxSession",
+    "BackendCapabilityError",
+    "BackendLoadError",
+    "BackendNameConflictError",
+    "BackendNameMismatchWarning",
+    "BackendNotFoundError",
+    "BackendShadowWarning",
+    "CommandFailedError",
     "ConsoleOutput",
     "ContainerError",
     "DefaultImage",
@@ -17,11 +41,15 @@ __all__ = [
     "FileType",
     "InteractiveSandboxSession",
     "KernelType",
+    "LibraryInstallationNotSupportedError",
+    "MissingDependencyError",
+    "NotOpenSessionError",
     "PlotOutput",
     "ResourceError",
     "SandboxBackend",
     "SandboxError",
     "SandboxSession",
+    "SandboxTimeoutError",
     "SecurityError",
     "SecurityIssueSeverity",
     "SecurityPattern",
@@ -29,6 +57,8 @@ __all__ = [
     "SessionConfig",
     "StreamCallback",
     "SupportedLanguage",
+    "UnsupportedBackendError",
     "ValidationError",
     "create_session",
+    "list_backends",
 ]

--- a/llm_sandbox/backends/__init__.py
+++ b/llm_sandbox/backends/__init__.py
@@ -1,0 +1,56 @@
+"""Public API for writing a third-party backend.
+
+Everything a backend plugin needs is importable from here or from the top-level
+``llm_sandbox`` package. Plugins must not import from ``llm_sandbox.core`` or any other
+private module: only the names listed in ``docs/plugins/authoring.md`` are covered by the
+compatibility guarantee, and internals will be refactored without notice.
+
+```python
+from llm_sandbox.backends import (
+    BackendCapability,
+    SandboxBackendBase,
+    SandboxBackendPlugin,
+)
+
+
+class MyServiceBackend(SandboxBackendPlugin):
+    PLUGIN_API_VERSION = 1
+    name = "myservice"
+    capabilities = frozenset({BackendCapability.ARTIFACTS})
+
+    @classmethod
+    def create_session(cls, *args, **kwargs):
+        from llm_sandbox_myservice.session import MyServiceSession
+
+        return MyServiceSession(**kwargs)
+```
+
+See ``docs/plugins/authoring.md`` for the full guide and
+``llm_sandbox.testing.BackendComplianceTests`` for the conformance suite.
+"""
+
+from llm_sandbox.backends.base import SandboxBackendBase
+from llm_sandbox.backends.plugin import (
+    ENTRY_POINT_GROUP,
+    PLUGIN_API_VERSION,
+    SUPPORTED_PLUGIN_API_VERSIONS,
+    BackendCapability,
+    BackendInfo,
+    SandboxBackendPlugin,
+    normalize_backend_name,
+)
+from llm_sandbox.core.mixins import ContainerAPI
+from llm_sandbox.core.session_base import BaseSession
+
+__all__ = [
+    "ENTRY_POINT_GROUP",
+    "PLUGIN_API_VERSION",
+    "SUPPORTED_PLUGIN_API_VERSIONS",
+    "BackendCapability",
+    "BackendInfo",
+    "BaseSession",
+    "ContainerAPI",
+    "SandboxBackendBase",
+    "SandboxBackendPlugin",
+    "normalize_backend_name",
+]

--- a/llm_sandbox/backends/base.py
+++ b/llm_sandbox/backends/base.py
@@ -117,9 +117,7 @@ class SandboxBackendBase(BaseSession, ABC):
         remaining = dict(kwargs)
         config_kwargs = {key: remaining.pop(key) for key in list(remaining) if key in SessionConfig.model_fields}
         config_kwargs = {
-            key: value
-            for key, value in config_kwargs.items()
-            if value is not None or key in _NULLABLE_CONFIG_FIELDS
+            key: value for key, value in config_kwargs.items() if value is not None or key in _NULLABLE_CONFIG_FIELDS
         }
         return SessionConfig(**config_kwargs), remaining
 

--- a/llm_sandbox/backends/base.py
+++ b/llm_sandbox/backends/base.py
@@ -9,12 +9,32 @@ The bridges are ``@final``: override the public name, never the underscore one.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, final
+from typing import Any, ClassVar, final, get_args
 
+from llm_sandbox.backends.plugin import BackendCapability
 from llm_sandbox.core.config import SessionConfig
 from llm_sandbox.core.session_base import BaseSession
 from llm_sandbox.data import StreamCallback
 from llm_sandbox.exceptions import BackendCapabilityError
+
+
+def _nullable_config_fields() -> frozenset[str]:
+    """Names of `SessionConfig` fields that accept ``None``.
+
+    Returns:
+        frozenset[str]: The nullable field names.
+
+    """
+    # get_args handles both `typing.Optional[X]` and the `X | None` form, which is a
+    # types.UnionType rather than a typing.Union on Python 3.10.
+    return frozenset(
+        name
+        for name, field in SessionConfig.model_fields.items()
+        if field.annotation is None or type(None) in get_args(field.annotation)
+    )
+
+
+_NULLABLE_CONFIG_FIELDS = _nullable_config_fields()
 
 
 class SandboxBackendBase(BaseSession, ABC):
@@ -46,6 +66,14 @@ class SandboxBackendBase(BaseSession, ABC):
 
     """
 
+    backend_name: ClassVar[str] = ""
+    """The backend name this session belongs to.
+
+    Set it to match your plugin's `SandboxBackendPlugin.name` so that diagnostics and
+    `llm_sandbox.exceptions.UnsupportedBackendError.backend` name the backend rather than
+    the session class. Defaults to empty, in which case the class name is used.
+    """
+
     def __init__(self, config: SessionConfig | None = None, **kwargs: Any) -> None:
         """Initialize the backend session.
 
@@ -71,6 +99,13 @@ class SandboxBackendBase(BaseSession, ABC):
     def _build_config(kwargs: dict[str, Any]) -> tuple[SessionConfig, dict[str, Any]]:
         """Split session configuration values out of a keyword argument mapping.
 
+        Core forwards ``None`` for several settings whose caller-side default is ``None``
+        but whose `SessionConfig` field is not nullable -- ``runtime_configs`` and
+        ``workdir`` both arrive that way from `llm_sandbox.ArtifactSandboxSession` and
+        `llm_sandbox.InteractiveSandboxSession`. The built-in backends each normalise these
+        by hand before constructing their config; doing it here means a plugin does not have
+        to know which settings need it.
+
         Args:
             kwargs (dict[str, Any]): The keyword arguments handed to the session.
 
@@ -80,8 +115,11 @@ class SandboxBackendBase(BaseSession, ABC):
 
         """
         remaining = dict(kwargs)
+        config_kwargs = {key: remaining.pop(key) for key in list(remaining) if key in SessionConfig.model_fields}
         config_kwargs = {
-            key: remaining.pop(key) for key in list(remaining) if key in SessionConfig.model_fields
+            key: value
+            for key, value in config_kwargs.items()
+            if value is not None or key in _NULLABLE_CONFIG_FIELDS
         }
         return SessionConfig(**config_kwargs), remaining
 
@@ -179,7 +217,10 @@ class SandboxBackendBase(BaseSession, ABC):
             BackendCapabilityError: If this backend cannot attach to existing runtimes.
 
         """
-        raise BackendCapabilityError(type(self).__name__, "existing_container")
+        raise BackendCapabilityError(
+            self.backend_name or type(self).__name__,
+            capability=BackendCapability.EXISTING_CONTAINER.value,
+        )
 
     def get_archive(self, path: str) -> tuple[bytes, dict]:  # noqa: ARG002
         """Read a path out of the sandbox as an uncompressed tar archive.
@@ -199,7 +240,10 @@ class SandboxBackendBase(BaseSession, ABC):
             BackendCapabilityError: If this backend does not support artifact extraction.
 
         """
-        raise BackendCapabilityError(type(self).__name__, "artifacts")
+        raise BackendCapabilityError(
+            self.backend_name or type(self).__name__,
+            capability=BackendCapability.ARTIFACTS.value,
+        )
 
     # ------------------------------------------------------------------ #
     # Bridges onto BaseSession's private contract. Do not override.

--- a/llm_sandbox/backends/base.py
+++ b/llm_sandbox/backends/base.py
@@ -1,0 +1,241 @@
+"""Public base class for third-party backend sessions.
+
+`llm_sandbox.core.session_base.BaseSession` is the real backend contract, but six of its
+eight abstract methods are underscore-prefixed, and a plugin cannot be asked to implement
+private API. This module re-declares those six under public names and bridges them, so a
+plugin implements only names that are covered by the compatibility guarantee.
+
+The bridges are ``@final``: override the public name, never the underscore one.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, final
+
+from llm_sandbox.core.config import SessionConfig
+from llm_sandbox.core.session_base import BaseSession
+from llm_sandbox.data import StreamCallback
+from llm_sandbox.exceptions import BackendCapabilityError
+
+
+class SandboxBackendBase(BaseSession, ABC):
+    """Base class for a backend session provided by a plugin.
+
+    Subclasses get everything backend-agnostic for free -- security scanning, language
+    handler selection, library installation, session timeouts, the context manager protocol,
+    and the ``run()`` pipeline -- and implement only what is genuinely backend-specific.
+
+    Required overrides:
+
+    - `open` / `close` -- lifecycle
+    - `handle_timeout` -- cancel in-flight work when execution times out
+    - `ensure_directory_exists` / `ensure_ownership` -- filesystem preparation
+    - `process_non_stream_output` / `process_stream_output` -- decode runtime output
+
+    Optional, gated on a declared `llm_sandbox.backends.BackendCapability`:
+
+    - `get_archive` -- required for ``ARTIFACTS``
+    - `connect_to_existing_container` -- required for ``EXISTING_CONTAINER``
+
+    Note:
+        The inherited ``run()`` writes code to a temporary file, copies it into the sandbox
+        workdir, and executes shell commands from the language handler. It assumes a POSIX
+        filesystem and a shell. A backend without those must either supply a
+        `llm_sandbox.core.mixins.ContainerAPI` that emulates them, or override ``run()``
+        outright -- which also gives up ``install()`` and artifact extraction. See
+        ``docs/plugins/authoring.md``.
+
+    """
+
+    def __init__(self, config: SessionConfig | None = None, **kwargs: Any) -> None:
+        """Initialize the backend session.
+
+        Args:
+            config (SessionConfig | None): A pre-built session configuration. When omitted,
+                one is built from any recognised keyword arguments (``lang``, ``image``,
+                ``workdir``, ``verbose``, ``security_policy``, timeouts, and so on), which
+                is usually what a `create_session` implementation wants.
+            **kwargs: Session configuration values and backend-specific arguments.
+                Unrecognised keys are passed through to `BaseSession` untouched.
+
+        """
+        if config is None:
+            config, kwargs = self._build_config(kwargs)
+
+        # CommandExecutionMixin reads self.stream; set it before super().__init__ so a
+        # subclass can still override it afterwards.
+        self.stream: bool = bool(kwargs.pop("stream", False))
+
+        super().__init__(config=config, **kwargs)
+
+    @staticmethod
+    def _build_config(kwargs: dict[str, Any]) -> tuple[SessionConfig, dict[str, Any]]:
+        """Split session configuration values out of a keyword argument mapping.
+
+        Args:
+            kwargs (dict[str, Any]): The keyword arguments handed to the session.
+
+        Returns:
+            tuple[SessionConfig, dict[str, Any]]: The configuration, and the keyword
+                arguments that were not consumed by it.
+
+        """
+        remaining = dict(kwargs)
+        config_kwargs = {
+            key: remaining.pop(key) for key in list(remaining) if key in SessionConfig.model_fields
+        }
+        return SessionConfig(**config_kwargs), remaining
+
+    # ------------------------------------------------------------------ #
+    # Required: implement these
+    # ------------------------------------------------------------------ #
+
+    @abstractmethod
+    def handle_timeout(self) -> None:
+        """Cancel in-flight work after an execution timeout.
+
+        Called from a background thread once `run` exceeds its timeout. Python cannot kill
+        the thread running the code, so this is the only mechanism that actually stops
+        work -- kill the container, cancel the remote job, close the connection.
+
+        Must not raise; failures here are logged and swallowed by the caller.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def ensure_directory_exists(self, path: str) -> None:
+        """Create a directory inside the sandbox, including parents.
+
+        Called before copying a file in, so the destination's parent exists.
+
+        Args:
+            path (str): Absolute path of the directory to create.
+
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def ensure_ownership(self, paths: list[str]) -> None:
+        """Make the given paths writable by the user the sandbox executes as.
+
+        Backends that always execute as the owning user may implement this as a no-op.
+
+        Args:
+            paths (list[str]): Absolute paths inside the sandbox.
+
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def process_non_stream_output(self, output: Any) -> tuple[str, str]:
+        """Decode a completed command's output into stdout and stderr.
+
+        Args:
+            output (Any): Whatever this backend's command execution returned.
+
+        Returns:
+            tuple[str, str]: Decoded ``(stdout, stderr)``.
+
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def process_stream_output(
+        self,
+        output: Any,
+        on_stdout: StreamCallback | None = None,
+        on_stderr: StreamCallback | None = None,
+    ) -> tuple[str, str]:
+        """Consume a streaming command's output, invoking callbacks as chunks arrive.
+
+        A backend that cannot stream may collect the full output and invoke each callback
+        once at completion; the signature is required, real-time delivery is not.
+
+        Args:
+            output (Any): The stream object this backend's command execution returned.
+            on_stdout (StreamCallback | None): Called with each decoded stdout chunk.
+            on_stderr (StreamCallback | None): Called with each decoded stderr chunk.
+
+        Returns:
+            tuple[str, str]: The fully accumulated ``(stdout, stderr)``.
+
+        """
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------ #
+    # Optional: gated on a declared capability
+    # ------------------------------------------------------------------ #
+
+    def connect_to_existing_container(self, container_id: str) -> None:  # noqa: ARG002
+        """Attach to an already-running container, pod, or remote session.
+
+        Override this and declare `BackendCapability.EXISTING_CONTAINER` to support
+        ``container_id=``. When attached, core skips environment setup and leaves the
+        runtime running on close.
+
+        Args:
+            container_id (str): Identifier of the runtime to attach to.
+
+        Raises:
+            BackendCapabilityError: If this backend cannot attach to existing runtimes.
+
+        """
+        raise BackendCapabilityError(type(self).__name__, "existing_container")
+
+    def get_archive(self, path: str) -> tuple[bytes, dict]:  # noqa: ARG002
+        """Read a path out of the sandbox as an uncompressed tar archive.
+
+        Override this and declare `BackendCapability.ARTIFACTS` to support
+        `llm_sandbox.ArtifactSandboxSession`. The language handler calls it to collect
+        generated plots.
+
+        Args:
+            path (str): Absolute path inside the sandbox.
+
+        Returns:
+            tuple[bytes, dict]: The tar bytes, and a stat mapping with at least a ``size``
+                key. A ``size`` of 0 signals "not found" to the caller.
+
+        Raises:
+            BackendCapabilityError: If this backend does not support artifact extraction.
+
+        """
+        raise BackendCapabilityError(type(self).__name__, "artifacts")
+
+    # ------------------------------------------------------------------ #
+    # Bridges onto BaseSession's private contract. Do not override.
+    # ------------------------------------------------------------------ #
+
+    @final
+    def _handle_timeout(self) -> None:
+        """Bridge to `handle_timeout`."""
+        self.handle_timeout()
+
+    @final
+    def _connect_to_existing_container(self, container_id: str) -> None:
+        """Bridge to `connect_to_existing_container`."""
+        self.connect_to_existing_container(container_id)
+
+    @final
+    def _ensure_directory_exists(self, path: str) -> None:
+        """Bridge to `ensure_directory_exists`."""
+        self.ensure_directory_exists(path)
+
+    @final
+    def _ensure_ownership(self, paths: list[str]) -> None:
+        """Bridge to `ensure_ownership`."""
+        self.ensure_ownership(paths)
+
+    @final
+    def _process_non_stream_output(self, output: Any) -> tuple[str, str]:
+        """Bridge to `process_non_stream_output`."""
+        return self.process_non_stream_output(output)
+
+    @final
+    def _process_stream_output(
+        self,
+        output: Any,
+        on_stdout: StreamCallback | None = None,
+        on_stderr: StreamCallback | None = None,
+    ) -> tuple[str, str]:
+        """Bridge to `process_stream_output`."""
+        return self.process_stream_output(output, on_stdout=on_stdout, on_stderr=on_stderr)

--- a/llm_sandbox/backends/builtin.py
+++ b/llm_sandbox/backends/builtin.py
@@ -1,0 +1,156 @@
+"""Built-in backend providers.
+
+The backends llm-sandbox ships and tests in CI, expressed through the same
+`SandboxBackendPlugin` interface third-party backends use, so the registry has one code
+path instead of a special case.
+
+Two details are load-bearing and must not be "tidied":
+
+1. Session classes are imported **inside** each method, never at module scope. That keeps
+   `import llm_sandbox` free of optional backend dependencies (see
+   ``tests/test_lazy_imports.py``) and keeps ``@patch("llm_sandbox.docker.SandboxDockerSession")``
+   working, which several tests rely on.
+2. The capability declarations reproduce today's behaviour exactly, including its gaps --
+   micromamba genuinely has no interactive or pooling support, and asking for either has
+   always raised. See ``docs/design/plugin-system.md`` section 5.2.
+"""
+
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from llm_sandbox.backends.plugin import PLUGIN_API_VERSION, BackendCapability, SandboxBackendPlugin
+
+if TYPE_CHECKING:
+    from llm_sandbox.core.session_base import BaseSession
+    from llm_sandbox.pool.base import ContainerPoolManager
+
+_CONTAINER_CAPABILITIES = frozenset({
+    BackendCapability.ARTIFACTS,
+    BackendCapability.INTERACTIVE,
+    BackendCapability.POOLING,
+    BackendCapability.EXISTING_CONTAINER,
+})
+
+
+class BuiltinBackend(SandboxBackendPlugin):
+    """Marker base for backends that ship with llm-sandbox itself."""
+
+    PLUGIN_API_VERSION: ClassVar[int] = PLUGIN_API_VERSION
+
+
+class DockerBackend(BuiltinBackend):
+    """The Docker backend. The default, and the most widely exercised."""
+
+    name: ClassVar[str] = "docker"
+    capabilities: ClassVar[frozenset[BackendCapability]] = _CONTAINER_CAPABILITIES
+
+    @classmethod
+    def create_session(cls, *args: Any, **kwargs: Any) -> "BaseSession":
+        """Create a Docker sandbox session."""
+        from llm_sandbox.docker import SandboxDockerSession
+
+        return SandboxDockerSession(*args, **kwargs)
+
+    @classmethod
+    def create_pool_manager(cls, **kwargs: Any) -> "ContainerPoolManager":
+        """Create a Docker container pool manager."""
+        from llm_sandbox.pool.docker_pool import DockerPoolManager
+
+        return DockerPoolManager(**kwargs)
+
+    @classmethod
+    def create_interactive_session(cls, **kwargs: Any) -> "BaseSession":
+        """Create the Docker session backing an interactive session."""
+        from llm_sandbox.docker import SandboxDockerSession
+
+        return SandboxDockerSession(**kwargs)
+
+
+class PodmanBackend(BuiltinBackend):
+    """The Podman backend, for rootless containers."""
+
+    name: ClassVar[str] = "podman"
+    capabilities: ClassVar[frozenset[BackendCapability]] = _CONTAINER_CAPABILITIES
+
+    @classmethod
+    def create_session(cls, *args: Any, **kwargs: Any) -> "BaseSession":
+        """Create a Podman sandbox session."""
+        from llm_sandbox.podman import SandboxPodmanSession
+
+        return SandboxPodmanSession(*args, **kwargs)
+
+    @classmethod
+    def create_pool_manager(cls, **kwargs: Any) -> "ContainerPoolManager":
+        """Create a Podman container pool manager."""
+        from llm_sandbox.pool.podman_pool import PodmanPoolManager
+
+        return PodmanPoolManager(**kwargs)
+
+    @classmethod
+    def create_interactive_session(cls, **kwargs: Any) -> "BaseSession":
+        """Create the Podman session backing an interactive session."""
+        from llm_sandbox.podman import SandboxPodmanSession
+
+        return SandboxPodmanSession(**kwargs)
+
+
+class KubernetesBackend(BuiltinBackend):
+    """The Kubernetes backend, for cluster-orchestrated execution."""
+
+    name: ClassVar[str] = "kubernetes"
+    capabilities: ClassVar[frozenset[BackendCapability]] = _CONTAINER_CAPABILITIES
+
+    @classmethod
+    def create_session(cls, *args: Any, **kwargs: Any) -> "BaseSession":
+        """Create a Kubernetes sandbox session."""
+        from llm_sandbox.kubernetes import SandboxKubernetesSession
+
+        return SandboxKubernetesSession(*args, **kwargs)
+
+    @classmethod
+    def create_pool_manager(cls, **kwargs: Any) -> "ContainerPoolManager":
+        """Create a Kubernetes pod pool manager."""
+        from llm_sandbox.pool.kubernetes_pool import KubernetesPoolManager
+
+        return KubernetesPoolManager(**kwargs)
+
+    @classmethod
+    def create_interactive_session(cls, **kwargs: Any) -> "BaseSession":
+        """Create the Kubernetes session backing an interactive session.
+
+        The Kubernetes session does not accept ``runtime_configs``; it is dropped here
+        rather than raising a ``TypeError``, matching long-standing behaviour.
+        """
+        from llm_sandbox.kubernetes import SandboxKubernetesSession
+
+        return SandboxKubernetesSession(**{k: v for k, v in kwargs.items() if k != "runtime_configs"})
+
+
+class MicromambaBackend(BuiltinBackend):
+    """The Micromamba backend: a Docker container with commands wrapped in ``micromamba run``.
+
+    Declares neither ``INTERACTIVE`` nor ``POOLING``. Neither has ever worked for this
+    backend, and both have always raised `llm_sandbox.exceptions.UnsupportedBackendError`.
+    """
+
+    name: ClassVar[str] = "micromamba"
+    capabilities: ClassVar[frozenset[BackendCapability]] = frozenset({
+        BackendCapability.ARTIFACTS,
+        BackendCapability.EXISTING_CONTAINER,
+    })
+
+    @classmethod
+    def create_session(cls, *args: Any, **kwargs: Any) -> "BaseSession":
+        """Create a Micromamba sandbox session."""
+        from llm_sandbox.micromamba import MicromambaSession
+
+        return MicromambaSession(*args, **kwargs)
+
+
+#: Built-in backends, keyed by their normalised name. A plugin can never take one of these
+#: names -- see ``registry._discover``.
+BUILTIN_BACKENDS: dict[str, type[BuiltinBackend]] = {
+    DockerBackend.name: DockerBackend,
+    KubernetesBackend.name: KubernetesBackend,
+    PodmanBackend.name: PodmanBackend,
+    MicromambaBackend.name: MicromambaBackend,
+}

--- a/llm_sandbox/backends/plugin.py
+++ b/llm_sandbox/backends/plugin.py
@@ -5,9 +5,11 @@ depend on these, so they may not be removed or changed incompatibly within a plu
 major version. See :data:`PLUGIN_API_VERSION` and ``docs/plugins/authoring.md``.
 """
 
+import re
+import unicodedata
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from llm_sandbox.const import StrEnum
 from llm_sandbox.exceptions import BackendCapabilityError
@@ -32,20 +34,33 @@ SUPPORTED_PLUGIN_API_VERSIONS = frozenset({1})
 ENTRY_POINT_GROUP = "llm_sandbox.backends"
 
 
+#: A normalised backend name must match this. Enforced on both sides -- an entry point whose
+#: name does not match is refused at discovery, and a lookup that does not match cannot
+#: resolve. Without it, an entry point named ``""`` (which ``entry_points.txt`` permits)
+#: would answer to ``backend=""``, so a caller reading the backend out of an unset config
+#: value or environment variable would silently route execution to whoever registered it.
+BACKEND_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_]*$")
+
+
 def normalize_backend_name(name: str) -> str:
     """Normalise a backend name for lookup and collision detection.
 
     Backend names are case-insensitive and treat hyphens and underscores as equivalent,
     so ``"My-Service"``, ``"my_service"`` and ``"MY_SERVICE"`` all address the same backend.
 
+    Compatibility characters are folded first (NFKC), so visually confusable forms -- a
+    fullwidth capital D, for instance -- cannot masquerade as a distinct backend in a
+    listing or a pasted config line.
+
     Args:
         name (str): The raw backend name, as typed by a user or declared by a plugin.
 
     Returns:
-        str: The normalised name.
+        str: The normalised name. May be empty or otherwise invalid; callers check it
+            against `BACKEND_NAME_PATTERN`.
 
     """
-    return name.strip().lower().replace("-", "_")
+    return unicodedata.normalize("NFKC", name).strip().lower().replace("-", "_")
 
 
 class BackendCapability(StrEnum):
@@ -72,6 +87,12 @@ class BackendCapability(StrEnum):
     """Attaching to an already-running container or pod via ``container_id=``."""
 
 
+#: Why a backend is or is not usable, as reported by :func:`llm_sandbox.list_backends`.
+#: Widening this later is source-compatible for callers; narrowing a bare ``str`` would not
+#: have been, which is why it is a ``Literal`` in a frozen dataclass.
+BackendStatus = Literal["ok", "shadowed", "conflict", "error"]
+
+
 @dataclass(frozen=True)
 class BackendInfo:
     """A backend that core can see, whether or not it has been loaded.
@@ -88,9 +109,10 @@ class BackendInfo:
         capabilities (frozenset[BackendCapability] | None): Declared capabilities, or None
             when the backend has not been loaded (the default -- see ``load=`` on
             :func:`llm_sandbox.list_backends`).
-        status (str): One of ``"ok"``, ``"shadowed"`` (a plugin tried to take a built-in
+        status (BackendStatus): ``"ok"``, ``"shadowed"`` (a plugin tried to take a built-in
             name and lost), ``"conflict"`` (several distributions claim the name), or
-            ``"error"`` (loading was attempted and failed).
+            ``"error"`` (loading was attempted and failed). A ``Literal`` rather than a bare
+            ``str`` so callers switching on it get checked, and so a typo in core is caught.
         detail (str | None): Explanation for any status other than ``"ok"``.
 
     """
@@ -101,7 +123,7 @@ class BackendInfo:
     version: str | None = None
     entry_point: str | None = None
     capabilities: frozenset[BackendCapability] | None = None
-    status: str = "ok"
+    status: "BackendStatus" = "ok"
     detail: str | None = None
 
 
@@ -206,7 +228,7 @@ class SandboxBackendPlugin(ABC):
             BackendCapabilityError: If this backend does not support pooling.
 
         """
-        raise BackendCapabilityError(cls.name, BackendCapability.POOLING.value)
+        raise BackendCapabilityError(cls.name, capability=BackendCapability.POOLING.value)
 
     @classmethod
     def create_interactive_session(cls, **kwargs: Any) -> "BaseSession":  # noqa: ARG003
@@ -227,7 +249,7 @@ class SandboxBackendPlugin(ABC):
             BackendCapabilityError: If this backend does not support interactive sessions.
 
         """
-        raise BackendCapabilityError(cls.name, BackendCapability.INTERACTIVE.value)
+        raise BackendCapabilityError(cls.name, capability=BackendCapability.INTERACTIVE.value)
 
     @classmethod
     def supports(cls, capability: BackendCapability | str) -> bool:
@@ -254,4 +276,4 @@ class SandboxBackendPlugin(ABC):
 
         """
         if not cls.supports(capability):
-            raise BackendCapabilityError(cls.name, str(capability))
+            raise BackendCapabilityError(cls.name, capability=str(capability))

--- a/llm_sandbox/backends/plugin.py
+++ b/llm_sandbox/backends/plugin.py
@@ -1,0 +1,257 @@
+"""The backend plugin contract.
+
+Every name in this module is part of the frozen plugin API. Third-party distributions
+depend on these, so they may not be removed or changed incompatibly within a plugin API
+major version. See :data:`PLUGIN_API_VERSION` and ``docs/plugins/authoring.md``.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from llm_sandbox.const import StrEnum
+from llm_sandbox.exceptions import BackendCapabilityError
+
+if TYPE_CHECKING:
+    from llm_sandbox.core.session_base import BaseSession
+    from llm_sandbox.pool.base import ContainerPoolManager
+
+#: The plugin API version this release of llm-sandbox implements.
+#:
+#: Deliberately independent of the package version. A plugin declares the version it was
+#: built against as ``PLUGIN_API_VERSION`` on its :class:`SandboxBackendPlugin` subclass.
+PLUGIN_API_VERSION = 1
+
+#: Plugin API versions this release accepts.
+#:
+#: A set rather than a single value so a future release can accept an old and a new version
+#: at once, giving plugin authors a transition window instead of a flag day.
+SUPPORTED_PLUGIN_API_VERSIONS = frozenset({1})
+
+#: The entry point group third-party backends register under.
+ENTRY_POINT_GROUP = "llm_sandbox.backends"
+
+
+def normalize_backend_name(name: str) -> str:
+    """Normalise a backend name for lookup and collision detection.
+
+    Backend names are case-insensitive and treat hyphens and underscores as equivalent,
+    so ``"My-Service"``, ``"my_service"`` and ``"MY_SERVICE"`` all address the same backend.
+
+    Args:
+        name (str): The raw backend name, as typed by a user or declared by a plugin.
+
+    Returns:
+        str: The normalised name.
+
+    """
+    return name.strip().lower().replace("-", "_")
+
+
+class BackendCapability(StrEnum):
+    """Optional behaviour a backend may support beyond the required interface.
+
+    A backend declares these on :attr:`SandboxBackendPlugin.capabilities`. Core checks the
+    declaration *before* constructing anything, so an unsupported capability fails cleanly
+    instead of leaving a half-built session or a leaked container behind.
+
+    New capabilities may be added within a plugin API major version. A plugin that does not
+    declare a capability it has never heard of is unaffected.
+    """
+
+    ARTIFACTS = "artifacts"
+    """Plot and artifact extraction, via ``get_archive()``. Required by ArtifactSandboxSession."""
+
+    INTERACTIVE = "interactive"
+    """Stateful interpreter sessions. Required by InteractiveSandboxSession."""
+
+    POOLING = "pooling"
+    """Pre-warmed container pooling, via ``create_pool_manager()``."""
+
+    EXISTING_CONTAINER = "existing_container"
+    """Attaching to an already-running container or pod via ``container_id=``."""
+
+
+@dataclass(frozen=True)
+class BackendInfo:
+    """A backend that core can see, whether or not it has been loaded.
+
+    Returned by :func:`llm_sandbox.list_backends`. Everything except ``capabilities`` is
+    read from distribution metadata, so building this never imports plugin code.
+
+    Attributes:
+        name (str): The normalised backend name, as passed to ``backend=``.
+        is_builtin (bool): True for backends shipped and CI-tested by llm-sandbox itself.
+        distribution (str | None): Distribution providing the backend; None for built-ins.
+        version (str | None): Version of that distribution; None for built-ins.
+        entry_point (str | None): The entry point's target, e.g. ``"pkg.module:Class"``.
+        capabilities (frozenset[BackendCapability] | None): Declared capabilities, or None
+            when the backend has not been loaded (the default -- see ``load=`` on
+            :func:`llm_sandbox.list_backends`).
+        status (str): One of ``"ok"``, ``"shadowed"`` (a plugin tried to take a built-in
+            name and lost), ``"conflict"`` (several distributions claim the name), or
+            ``"error"`` (loading was attempted and failed).
+        detail (str | None): Explanation for any status other than ``"ok"``.
+
+    """
+
+    name: str
+    is_builtin: bool = False
+    distribution: str | None = None
+    version: str | None = None
+    entry_point: str | None = None
+    capabilities: frozenset[BackendCapability] | None = None
+    status: str = "ok"
+    detail: str | None = None
+
+
+class SandboxBackendPlugin(ABC):
+    """Descriptor a distribution registers to provide a sandbox backend.
+
+    Subclass this, declare the class attributes, implement :meth:`create_session`, and point
+    an entry point at the subclass:
+
+    ```toml
+    [project.entry-points."llm_sandbox.backends"]
+    myservice = "llm_sandbox_myservice:MyServiceBackend"
+    ```
+
+    The entry point must resolve to the **class**, not an instance. Core never instantiates
+    it -- every method is a classmethod. This class is a factory and a declaration of intent,
+    not the session itself, which is what keeps the frozen surface small enough to promise
+    forever while leaving what happens behind ``create_session`` entirely up to you.
+
+    Example:
+        ```python
+        from llm_sandbox.backends import BackendCapability, SandboxBackendPlugin
+
+        class MyServiceBackend(SandboxBackendPlugin):
+            PLUGIN_API_VERSION = 1
+            name = "myservice"
+            capabilities = frozenset({BackendCapability.ARTIFACTS})
+
+            @classmethod
+            def create_session(cls, **kwargs):
+                from llm_sandbox_myservice.session import MyServiceSession
+
+                return MyServiceSession(**kwargs)
+        ```
+
+    """
+
+    PLUGIN_API_VERSION: ClassVar[int]
+    """The plugin API version this backend was built against. Required.
+
+    Without it, a plugin built for an interface core no longer has fails as an
+    ``AttributeError`` somewhere deep inside a session, which tells the user nothing.
+    """
+
+    name: ClassVar[str]
+    """The canonical backend name. Required.
+
+    The entry point name is what users actually type, but it is chosen by whoever wrote the
+    ``pyproject.toml`` -- which is not always the plugin author. Declaring the name here lets
+    core report a mismatch instead of silently honouring whichever it saw first.
+    """
+
+    capabilities: ClassVar[frozenset[BackendCapability]] = frozenset()
+    """Optional behaviour this backend supports. See :class:`BackendCapability`."""
+
+    @classmethod
+    @abstractmethod
+    def create_session(cls, *args: Any, **kwargs: Any) -> "BaseSession":
+        """Create a sandbox session for this backend.
+
+        Everything ``SandboxSession(backend=...)`` does routes through here. Implementations
+        receive the keyword arguments the caller passed, minus ``backend``, and should ignore
+        any they do not understand rather than raising -- callers share one call site across
+        backends.
+
+        Positional arguments are forwarded for backwards compatibility with the built-in
+        backends, which historically accepted them. Treat keyword arguments as the interface;
+        accept ``*args`` and ignore it.
+
+        The returned object must implement the required interface: ``open()``, ``close()``,
+        ``run()``, ``execute_command()``, ``copy_to_runtime()`` and ``copy_from_runtime()``.
+        Subclassing :class:`llm_sandbox.backends.SandboxBackendBase` gives you all of it
+        except the parts only you can supply; see ``docs/plugins/authoring.md``.
+
+        Args:
+            *args: Positional arguments, forwarded verbatim. Usually empty.
+            **kwargs: Session arguments -- commonly ``lang``, ``image``, ``verbose``,
+                ``workdir``, ``security_policy``, ``execution_timeout``, ``container_id``.
+
+        Returns:
+            BaseSession: A session satisfying the required backend interface.
+
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def create_pool_manager(cls, **kwargs: Any) -> "ContainerPoolManager":  # noqa: ARG003
+        """Create a container pool manager for this backend.
+
+        Optional. Override this and declare :attr:`BackendCapability.POOLING` to support
+        `llm_sandbox.pool.create_pool_manager`. Pooling has its own lifecycle and genuinely
+        backend-specific semantics -- a hosted service may pool server-side, or not at all --
+        so the default raises rather than pretending.
+
+        Args:
+            **kwargs: Pool arguments, commonly ``client``, ``config`` and ``lang``.
+
+        Returns:
+            ContainerPoolManager: A pool manager for this backend.
+
+        Raises:
+            BackendCapabilityError: If this backend does not support pooling.
+
+        """
+        raise BackendCapabilityError(cls.name, BackendCapability.POOLING.value)
+
+    @classmethod
+    def create_interactive_session(cls, **kwargs: Any) -> "BaseSession":  # noqa: ARG003
+        """Create the backing session for an interactive (stateful interpreter) session.
+
+        Optional. Override this and declare :attr:`BackendCapability.INTERACTIVE` to support
+        `llm_sandbox.InteractiveSandboxSession`. This is the least portable capability: core's
+        interactive layer writes a runner script into the sandbox filesystem and polls it, so
+        it only works for container-shaped backends. The default raises.
+
+        Args:
+            **kwargs: Session arguments, plus ``runtime_configs``.
+
+        Returns:
+            BaseSession: A session for the interactive layer to drive.
+
+        Raises:
+            BackendCapabilityError: If this backend does not support interactive sessions.
+
+        """
+        raise BackendCapabilityError(cls.name, BackendCapability.INTERACTIVE.value)
+
+    @classmethod
+    def supports(cls, capability: BackendCapability | str) -> bool:
+        """Report whether this backend declares a capability.
+
+        Args:
+            capability (BackendCapability | str): The capability to check.
+
+        Returns:
+            bool: True if declared.
+
+        """
+        return capability in cls.capabilities
+
+    @classmethod
+    def require(cls, capability: BackendCapability | str) -> None:
+        """Raise unless this backend declares a capability.
+
+        Args:
+            capability (BackendCapability | str): The capability to require.
+
+        Raises:
+            BackendCapabilityError: If the capability is not declared.
+
+        """
+        if not cls.supports(capability):
+            raise BackendCapabilityError(cls.name, str(capability))

--- a/llm_sandbox/exceptions.py
+++ b/llm_sandbox/exceptions.py
@@ -157,12 +157,14 @@ class BackendNameConflictError(UnsupportedBackendError):
 class BackendCapabilityError(UnsupportedBackendError):
     """Raised when a backend exists but does not support a requested capability."""
 
-    def __init__(self, backend: str, capability: str, message: str | None = None) -> None:
+    def __init__(self, backend: str, *, capability: str, message: str | None = None) -> None:
         """Initialize the BackendCapabilityError.
 
         Args:
             backend (str): The backend name.
-            capability (str): The capability that is not supported.
+            capability (str): The capability that is not supported. Keyword-only, so that a
+                generic ``type(exc)(exc.backend, msg)`` re-raise fails loudly rather than
+                silently binding the message to this argument.
             message (str | None): Optional override for the default wording.
 
         """

--- a/llm_sandbox/exceptions.py
+++ b/llm_sandbox/exceptions.py
@@ -100,9 +100,77 @@ class ImagePullError(SandboxError):
 class UnsupportedBackendError(SandboxError):
     """Raised when an unsupported backend is provided."""
 
-    def __init__(self, backend: str) -> None:
-        """Initialize the UnsupportedBackendError."""
-        super().__init__(f"Unsupported backend: {backend}")
+    def __init__(self, backend: str, message: str | None = None) -> None:
+        """Initialize the UnsupportedBackendError.
+
+        Args:
+            backend (str): The backend name that could not be used.
+            message (str | None): Optional pre-built message. When omitted, the default
+                ``"Unsupported backend: <backend>"`` wording is used. Subclasses raised by
+                the backend registry supply richer, multi-line guidance here.
+
+        """
+        super().__init__(message if message is not None else f"Unsupported backend: {backend}")
+        self.backend = backend
+
+
+class BackendNotFoundError(UnsupportedBackendError):
+    """Raised when no built-in backend or installed plugin provides the requested name."""
+
+
+class BackendLoadError(UnsupportedBackendError):
+    """Raised when a backend plugin entry point cannot be loaded or is malformed.
+
+    Loading failures are isolated to the backend that was requested: a broken plugin
+    never prevents other backends from resolving.
+    """
+
+    def __init__(self, backend: str, message: str, distribution: str | None = None) -> None:
+        """Initialize the BackendLoadError.
+
+        Args:
+            backend (str): The backend name that failed to load.
+            message (str): Description of what went wrong and what was expected.
+            distribution (str | None): The distribution providing the entry point, if known.
+
+        """
+        super().__init__(backend, message)
+        self.distribution = distribution
+
+
+class BackendNameConflictError(UnsupportedBackendError):
+    """Raised when two installed distributions register the same backend name."""
+
+    def __init__(self, backend: str, message: str, distributions: tuple[str, ...] = ()) -> None:
+        """Initialize the BackendNameConflictError.
+
+        Args:
+            backend (str): The contested backend name.
+            message (str): Description naming every distribution claiming the name.
+            distributions (tuple[str, ...]): The conflicting distribution names.
+
+        """
+        super().__init__(backend, message)
+        self.distributions = distributions
+
+
+class BackendCapabilityError(UnsupportedBackendError):
+    """Raised when a backend exists but does not support a requested capability."""
+
+    def __init__(self, backend: str, capability: str, message: str | None = None) -> None:
+        """Initialize the BackendCapabilityError.
+
+        Args:
+            backend (str): The backend name.
+            capability (str): The capability that is not supported.
+            message (str | None): Optional override for the default wording.
+
+        """
+        super().__init__(
+            backend,
+            message if message is not None else f"Backend {backend!r} does not support {capability!r}.",
+        )
+        self.capability = capability
 
 
 class MissingDependencyError(SandboxError):

--- a/llm_sandbox/interactive.py
+++ b/llm_sandbox/interactive.py
@@ -16,13 +16,14 @@ from typing import TYPE_CHECKING, Any, cast
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+from llm_sandbox.backends.plugin import BackendCapability
 from llm_sandbox.const import SandboxBackend, SupportedLanguage
 from llm_sandbox.core.session_base import BaseSession
 from llm_sandbox.data import ConsoleOutput
 from llm_sandbox.exceptions import ContainerError, LanguageNotSupportedError, NotOpenSessionError, SandboxTimeoutError
+from llm_sandbox.registry import get_backend
 
 from .const import StrEnum
-from .exceptions import UnsupportedBackendError
 
 RUNTIME_START_TIMEOUT = 30.0
 RESULT_POLL_INTERVAL = 0.2
@@ -64,7 +65,7 @@ class InteractiveSettings:
 
 
 def _create_backend_session(
-    backend: SandboxBackend,
+    backend: SandboxBackend | str,
     runtime_configs: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> BaseSession:
@@ -79,27 +80,13 @@ def _create_backend_session(
         BaseSession: An instance of the appropriate backend session
 
     Raises:
-        UnsupportedBackendError: If the backend is not supported
+        UnsupportedBackendError: If the backend is not supported, or does not declare the
+            ``interactive`` capability.
 
     """
-    match backend:
-        case SandboxBackend.DOCKER:
-            from llm_sandbox.docker import SandboxDockerSession
-
-            return SandboxDockerSession(runtime_configs=runtime_configs, **kwargs)
-        case SandboxBackend.PODMAN:
-            from llm_sandbox.podman import SandboxPodmanSession
-
-            return SandboxPodmanSession(runtime_configs=runtime_configs, **kwargs)
-        case SandboxBackend.KUBERNETES:
-            from llm_sandbox.kubernetes import SandboxKubernetesSession
-
-            # Kubernetes backend doesn't support runtime_configs parameter
-            # Filter it out from kwargs if it's present to avoid TypeError
-            kubernetes_kwargs = {k: v for k, v in kwargs.items() if k != "runtime_configs"}
-            return SandboxKubernetesSession(**kubernetes_kwargs)
-        case _:
-            raise UnsupportedBackendError(backend=backend)
+    provider = get_backend(str(backend))
+    provider.require(BackendCapability.INTERACTIVE)
+    return provider.create_interactive_session(runtime_configs=runtime_configs, **kwargs)
 
 
 class InteractiveSandboxSession(BaseSession):
@@ -117,7 +104,7 @@ class InteractiveSandboxSession(BaseSession):
     def __init__(
         self,
         *,
-        backend: SandboxBackend = SandboxBackend.DOCKER,
+        backend: SandboxBackend | str = SandboxBackend.DOCKER,
         lang: str | SupportedLanguage = SupportedLanguage.PYTHON,
         kernel_type: KernelType | str = KernelType.IPYTHON,
         max_memory: str | None = "1GB",

--- a/llm_sandbox/pool/base.py
+++ b/llm_sandbox/pool/base.py
@@ -193,6 +193,10 @@ class ContainerPoolManager(ABC):
         self.lang = lang
         self.image = image
         self.session_kwargs = session_kwargs
+        # `backend_name` is how a pooled session finds its way back to the backend that
+        # built this pool. Built-in subclasses declare it; `create_pool_manager` stamps the
+        # resolved name so plugin pool managers get one without having to know about it.
+        self.backend_name: str = getattr(type(self), "backend_name", "")
 
         # Pool state
         self._pool: list[PooledContainer] = []

--- a/llm_sandbox/pool/base.py
+++ b/llm_sandbox/pool/base.py
@@ -170,6 +170,14 @@ class ContainerPoolManager(ABC):
 
     """
 
+    backend_name: str = ""
+    """The backend this pool creates containers for.
+
+    How a pooled session routes back to the right backend. Built-in subclasses declare it;
+    `llm_sandbox.pool.create_pool_manager` stamps the resolved name onto any manager that
+    does not, so a plugin pool manager need not know about it.
+    """
+
     def __init__(
         self,
         client: Any,
@@ -193,10 +201,6 @@ class ContainerPoolManager(ABC):
         self.lang = lang
         self.image = image
         self.session_kwargs = session_kwargs
-        # `backend_name` is how a pooled session finds its way back to the backend that
-        # built this pool. Built-in subclasses declare it; `create_pool_manager` stamps the
-        # resolved name so plugin pool managers get one without having to know about it.
-        self.backend_name: str = getattr(type(self), "backend_name", "")
 
         # Pool state
         self._pool: list[PooledContainer] = []

--- a/llm_sandbox/pool/docker_pool.py
+++ b/llm_sandbox/pool/docker_pool.py
@@ -19,6 +19,8 @@ class DockerPoolManager(ContainerPoolManager):
     environment setup (venv, pip, library installation, etc.).
     """
 
+    backend_name = "docker"
+
     def __init__(
         self,
         config: PoolConfig,

--- a/llm_sandbox/pool/factory.py
+++ b/llm_sandbox/pool/factory.py
@@ -2,15 +2,16 @@
 
 from typing import Any
 
+from llm_sandbox.backends.plugin import BackendCapability
 from llm_sandbox.const import SandboxBackend, SupportedLanguage
-from llm_sandbox.exceptions import UnsupportedBackendError
 from llm_sandbox.pool.base import ContainerPoolManager
 from llm_sandbox.pool.config import PoolConfig
+from llm_sandbox.registry import get_backend
 
 
 def create_pool_manager(
     client: Any | None = None,
-    backend: SandboxBackend = SandboxBackend.DOCKER,
+    backend: SandboxBackend | str = SandboxBackend.DOCKER,
     config: PoolConfig | None = None,
     lang: SupportedLanguage | str = SupportedLanguage.PYTHON,
     **kwargs: Any,
@@ -19,7 +20,8 @@ def create_pool_manager(
 
     Args:
         client: Client to use for container creation (optional)
-        backend: Container backend to use (docker, kubernetes, podman)
+        backend: Container backend to use (docker, kubernetes, podman), or the name of a
+            plugin backend that declares the ``pooling`` capability
         config: Pool configuration (uses defaults if None)
         lang: Programming language for containers
         **kwargs: Additional backend-specific arguments
@@ -28,7 +30,8 @@ def create_pool_manager(
         ContainerPoolManager instance for the specified backend
 
     Raises:
-        UnsupportedBackendError: If the backend is not supported
+        UnsupportedBackendError: If the backend is not supported, or does not declare the
+            ``pooling`` capability
         MissingDependencyError: If required backend dependency is not installed
 
     Examples:
@@ -93,22 +96,6 @@ def create_pool_manager(
     if config is None:
         config = PoolConfig()
 
-    # Create appropriate pool manager based on backend
-    match backend:
-        case SandboxBackend.DOCKER:
-            from llm_sandbox.pool.docker_pool import DockerPoolManager
-
-            return DockerPoolManager(client=client, config=config, lang=lang, **kwargs)
-
-        case SandboxBackend.KUBERNETES:
-            from llm_sandbox.pool.kubernetes_pool import KubernetesPoolManager
-
-            return KubernetesPoolManager(client=client, config=config, lang=lang, **kwargs)
-
-        case SandboxBackend.PODMAN:
-            from llm_sandbox.pool.podman_pool import PodmanPoolManager
-
-            return PodmanPoolManager(client=client, config=config, lang=lang, **kwargs)
-
-        case _:
-            raise UnsupportedBackendError(backend)
+    provider = get_backend(str(backend))
+    provider.require(BackendCapability.POOLING)
+    return provider.create_pool_manager(client=client, config=config, lang=lang, **kwargs)

--- a/llm_sandbox/pool/factory.py
+++ b/llm_sandbox/pool/factory.py
@@ -98,4 +98,10 @@ def create_pool_manager(
 
     provider = get_backend(str(backend))
     provider.require(BackendCapability.POOLING)
-    return provider.create_pool_manager(client=client, config=config, lang=lang, **kwargs)
+    manager = provider.create_pool_manager(client=client, config=config, lang=lang, **kwargs)
+
+    # Stamp the resolved name so a PooledSandboxSession can route back to this backend
+    # without having to guess it from the manager's class name.
+    if not getattr(manager, "backend_name", ""):
+        manager.backend_name = provider.name
+    return manager

--- a/llm_sandbox/pool/factory.py
+++ b/llm_sandbox/pool/factory.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from llm_sandbox.backends.plugin import BackendCapability
+from llm_sandbox.backends.plugin import BackendCapability, normalize_backend_name
 from llm_sandbox.const import SandboxBackend, SupportedLanguage
 from llm_sandbox.pool.base import ContainerPoolManager
 from llm_sandbox.pool.config import PoolConfig
@@ -96,12 +96,14 @@ def create_pool_manager(
     if config is None:
         config = PoolConfig()
 
-    provider = get_backend(str(backend))
+    resolved = normalize_backend_name(str(backend))
+    provider = get_backend(resolved)
     provider.require(BackendCapability.POOLING)
     manager = provider.create_pool_manager(client=client, config=config, lang=lang, **kwargs)
 
-    # Stamp the resolved name so a PooledSandboxSession can route back to this backend
-    # without having to guess it from the manager's class name.
+    # Stamp the name the registry resolved, not provider.name: a plugin whose declared name
+    # differs from its entry point name is registered under the entry point name, so that is
+    # the one that will resolve again later.
     if not getattr(manager, "backend_name", ""):
-        manager.backend_name = provider.name
+        manager.backend_name = resolved
     return manager

--- a/llm_sandbox/pool/kubernetes_pool.py
+++ b/llm_sandbox/pool/kubernetes_pool.py
@@ -22,6 +22,8 @@ class KubernetesPoolManager(ContainerPoolManager):
     environment setup (venv, pip, library installation, etc.).
     """
 
+    backend_name = "kubernetes"
+
     def __init__(
         self,
         config: PoolConfig,

--- a/llm_sandbox/pool/podman_pool.py
+++ b/llm_sandbox/pool/podman_pool.py
@@ -17,6 +17,10 @@ class PodmanPoolManager(DockerPoolManager):
     The standard session logic handles all environment setup.
     """
 
+    # Must be declared explicitly: inheriting DockerPoolManager would otherwise route
+    # pooled Podman sessions to the Docker backend.
+    backend_name = "podman"
+
     def __init__(
         self,
         config: PoolConfig,

--- a/llm_sandbox/pool/session.py
+++ b/llm_sandbox/pool/session.py
@@ -2,8 +2,9 @@
 
 import logging
 from types import TracebackType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
+from llm_sandbox.backends.plugin import normalize_backend_name
 from llm_sandbox.const import EncodingErrorsType, SandboxBackend
 from llm_sandbox.data import ConsoleOutput, ExecutionResult, StreamCallback
 from llm_sandbox.pool.base import ContainerPoolManager, PooledContainer
@@ -13,6 +14,7 @@ if TYPE_CHECKING:
     from llm_sandbox.core.session_base import BaseSession
 
 from llm_sandbox.pool.exceptions import SessionNotOpenError
+from llm_sandbox.registry import get_backend
 
 
 class DuplicateClientError(ValueError):
@@ -99,8 +101,9 @@ class PooledSandboxSession:
         self._pool_manager = pool_manager
         self._pooled_container: PooledContainer | None = None
 
-        # Infer backend from pool manager
-        self.backend = self._infer_backend_from_pool()
+        # The backend this pool was built for. A plain string, which compares equal to the
+        # matching SandboxBackend member for built-ins.
+        self.backend = self._resolve_backend_name()
 
         # Session parameters (stored for creating backend session later)
         self._verbose = verbose
@@ -131,27 +134,31 @@ class PooledSandboxSession:
             self._logger.addHandler(handler)
             self._logger.setLevel(logging.DEBUG)
 
-    def _infer_backend_from_pool(self) -> SandboxBackend:
-        """Infer backend type from pool manager class.
+    def _resolve_backend_name(self) -> str:
+        """Read the backend name the pool manager was built for.
+
+        Previously this guessed from the manager's class name, which silently misrouted any
+        manager whose name happened to contain "Docker" and made pooling unreachable for
+        plugin backends. `ContainerPoolManager` now carries the name, and
+        `llm_sandbox.pool.create_pool_manager` stamps it for managers that do not set it.
 
         Returns:
-            SandboxBackend enum value
+            str: The normalised backend name.
 
         Raises:
-            RuntimeError: If backend cannot be determined
+            RuntimeError: If the pool manager does not declare a backend name.
 
         """
-        pool_class_name = self._pool_manager.__class__.__name__
-
-        if "Docker" in pool_class_name:
-            return SandboxBackend.DOCKER
-        if "Kubernetes" in pool_class_name:
-            return SandboxBackend.KUBERNETES
-        if "Podman" in pool_class_name:
-            return SandboxBackend.PODMAN
-
-        msg = f"Cannot infer backend from pool manager class: {pool_class_name}"
-        raise RuntimeError(msg)
+        backend_name = getattr(self._pool_manager, "backend_name", "")
+        if not backend_name:
+            msg = (
+                f"Cannot infer backend from pool manager "
+                f"{type(self._pool_manager).__name__!r}: it does not declare `backend_name`. "
+                f"Build pool managers with llm_sandbox.pool.create_pool_manager(), which sets it, "
+                f"or set the attribute on your manager."
+            )
+            raise RuntimeError(msg)
+        return normalize_backend_name(str(backend_name))
 
     def open(self) -> None:
         """Open session by acquiring a container from the pool.
@@ -212,89 +219,38 @@ class PooledSandboxSession:
             RuntimeError: If backend is not supported
 
         """
-        match self.backend:
-            case SandboxBackend.DOCKER:
-                from llm_sandbox.docker import SandboxDockerSession
+        # Resolve first: an unknown backend should fail before anything is assembled.
+        provider = get_backend(self.backend)
 
-                # Validate that pool-managed parameters are not passed
-                session_kwargs = self._session_kwargs.copy()
-                if "client" in session_kwargs:
-                    raise DuplicateClientError
+        session_kwargs = self._session_kwargs.copy()
+        if "client" in session_kwargs:
+            raise DuplicateClientError
 
-                return SandboxDockerSession(
-                    client=self._pool_manager.client,
-                    image=self._image,
-                    lang=self._lang,
-                    verbose=self._verbose,
-                    stream=self._stream,
-                    workdir=self._workdir,
-                    security_policy=self._security_policy,
-                    default_timeout=self._default_timeout,
-                    execution_timeout=self._execution_timeout,
-                    session_timeout=self._session_timeout,
-                    container_id=container_id,  # Connect to existing pooled container
-                    skip_environment_setup=True,  # Pool already set up the environment
-                    encoding_errors=self._encoding_errors,
-                    **session_kwargs,
-                )
+        session_kwargs.update(
+            client=self._pool_manager.client,
+            image=self._image,
+            lang=self._lang,
+            verbose=self._verbose,
+            workdir=self._workdir,
+            security_policy=self._security_policy,
+            default_timeout=self._default_timeout,
+            execution_timeout=self._execution_timeout,
+            session_timeout=self._session_timeout,
+            container_id=container_id,  # Connect to the existing pooled container
+            skip_environment_setup=True,  # Pool already set up the environment
+            encoding_errors=self._encoding_errors,
+        )
 
-            case SandboxBackend.KUBERNETES:
-                from llm_sandbox.kubernetes import SandboxKubernetesSession
+        if self.backend == SandboxBackend.KUBERNETES:
+            # The Kubernetes session names its namespace differently and takes no `stream`.
+            session_kwargs["kube_namespace"] = self._session_kwargs.get("namespace") or getattr(
+                self._pool_manager, "namespace", "default"
+            )
+            session_kwargs.pop("namespace", None)
+        else:
+            session_kwargs["stream"] = self._stream
 
-                # Validate that pool-managed parameters are not passed
-                session_kwargs = self._session_kwargs.copy()
-                if "client" in session_kwargs:
-                    raise DuplicateClientError
-
-                namespace = session_kwargs.pop("namespace", None) or (
-                    self._pool_manager.namespace if hasattr(self._pool_manager, "namespace") else "default"
-                )
-
-                return SandboxKubernetesSession(
-                    client=self._pool_manager.client,
-                    kube_namespace=namespace,
-                    image=self._image,
-                    lang=self._lang,
-                    verbose=self._verbose,
-                    workdir=self._workdir,
-                    security_policy=self._security_policy,
-                    default_timeout=self._default_timeout,
-                    execution_timeout=self._execution_timeout,
-                    session_timeout=self._session_timeout,
-                    container_id=container_id,  # Connect to existing pooled pod
-                    skip_environment_setup=True,
-                    encoding_errors=self._encoding_errors,
-                    **session_kwargs,
-                )
-
-            case SandboxBackend.PODMAN:
-                from llm_sandbox.podman import SandboxPodmanSession
-
-                # Validate that pool-managed parameters are not passed
-                session_kwargs = self._session_kwargs.copy()
-                if "client" in session_kwargs:
-                    raise DuplicateClientError
-
-                return SandboxPodmanSession(
-                    client=self._pool_manager.client,
-                    image=self._image,
-                    lang=self._lang,
-                    verbose=self._verbose,
-                    stream=self._stream,
-                    workdir=self._workdir,
-                    security_policy=self._security_policy,
-                    default_timeout=self._default_timeout,
-                    execution_timeout=self._execution_timeout,
-                    session_timeout=self._session_timeout,
-                    container_id=container_id,  # Connect to existing pooled container
-                    skip_environment_setup=True,
-                    encoding_errors=self._encoding_errors,
-                    **session_kwargs,
-                )
-
-            case _:
-                msg = f"Unsupported backend: {self.backend}"
-                raise RuntimeError(msg)
+        return cast("BaseSession", provider.create_session(**session_kwargs))
 
     def run(
         self,
@@ -414,6 +370,10 @@ class PooledSandboxSession:
         This allows pooled sessions to support all methods/attributes
         of the underlying backend session.
         """
+        if "_backend_session" not in self.__dict__:
+            # Guard against infinite recursion: __getattr__ is only called for attributes
+            # that are absent, and reading self._backend_session here would re-enter it.
+            raise AttributeError(name)
         if self._backend_session is None:
             raise SessionNotOpenError
 

--- a/llm_sandbox/pool/session.py
+++ b/llm_sandbox/pool/session.py
@@ -4,7 +4,7 @@ import logging
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, cast
 
-from llm_sandbox.backends.plugin import normalize_backend_name
+from llm_sandbox.backends.plugin import BackendCapability, normalize_backend_name
 from llm_sandbox.const import EncodingErrorsType, SandboxBackend
 from llm_sandbox.data import ConsoleOutput, ExecutionResult, StreamCallback
 from llm_sandbox.pool.base import ContainerPoolManager, PooledContainer
@@ -221,6 +221,8 @@ class PooledSandboxSession:
         """
         # Resolve first: an unknown backend should fail before anything is assembled.
         provider = get_backend(self.backend)
+        # Every pooled session attaches to a container the pool already created.
+        provider.require(BackendCapability.EXISTING_CONTAINER)
 
         session_kwargs = self._session_kwargs.copy()
         if "client" in session_kwargs:

--- a/llm_sandbox/registry.py
+++ b/llm_sandbox/registry.py
@@ -188,9 +188,7 @@ def _discover() -> tuple[dict[str, _PluginRecord], tuple[BackendInfo, ...], list
         # A conflict is recorded, not raised. Raising here would let one bad pair of plugins
         # break resolution for every other backend; instead it surfaces when that specific
         # name is requested.
-        conflicts = (
-            tuple(sorted({d or "<unknown distribution>" for _, d, _ in entries})) if len(entries) > 1 else ()
-        )
+        conflicts = tuple(sorted({d or "<unknown distribution>" for _, d, _ in entries})) if len(entries) > 1 else ()
         records[name] = _PluginRecord(
             name=name,
             entry_point=entry_point,
@@ -404,10 +402,7 @@ def _unknown_backend_error(key: str, requested: str) -> BackendNotFoundError:
             f"packages — try: pip install llm-sandbox-{key.replace('_', '-')}"
         )
     else:
-        lines.append(
-            f"{requested!r} is not a usable backend name. Names must match "
-            f"{BACKEND_NAME_PATTERN.pattern}."
-        )
+        lines.append(f"{requested!r} is not a usable backend name. Names must match {BACKEND_NAME_PATTERN.pattern}.")
 
     lines.append(f"See {INTEGRATIONS_URL}")
     return BackendNotFoundError(requested, "\n".join(lines))

--- a/llm_sandbox/registry.py
+++ b/llm_sandbox/registry.py
@@ -436,6 +436,15 @@ def get_backend(name: str) -> type[SandboxBackendPlugin]:
         ```
 
     """
+    if not isinstance(name, str):
+        # str(None) is "none", which is a syntactically valid backend name -- so coercing
+        # first would let an installed package answer to backend=None. Reject the type.
+        raise BackendNotFoundError(
+            str(name),
+            f"Backend must be a string or a SandboxBackend member, got {type(name).__name__}. "
+            f"Built-in backends: {', '.join(sorted(BUILTIN_BACKENDS))}.",
+        )
+
     requested = str(name)
     key = normalize_backend_name(requested)
 

--- a/llm_sandbox/registry.py
+++ b/llm_sandbox/registry.py
@@ -1,0 +1,461 @@
+"""Discovery and resolution of sandbox backends.
+
+Built-in backends resolve from a dict; third-party backends are discovered through the
+``llm_sandbox.backends`` entry point group.
+
+Discovery and loading are deliberately separate:
+
+- **Discovery** reads distribution metadata. It imports nothing and runs no third-party code.
+  `list_backends` works entirely at this level.
+- **Loading** imports the plugin's module, and happens only when that backend is requested
+  by name.
+
+That split is a security property, not an optimisation: importing ``llm_sandbox`` must never
+execute code belonging to every backend plugin that happens to be installed. It is not a
+sandbox, though -- by the time a plugin is installed, its build already ran. See
+``docs/plugins/authoring.md``.
+"""
+
+import difflib
+import inspect
+import logging
+import threading
+import warnings
+from collections import defaultdict
+from dataclasses import dataclass
+from importlib.metadata import EntryPoint, entry_points
+from typing import Any
+
+from llm_sandbox.backends.builtin import BUILTIN_BACKENDS
+from llm_sandbox.backends.plugin import (
+    ENTRY_POINT_GROUP,
+    SUPPORTED_PLUGIN_API_VERSIONS,
+    BackendCapability,
+    BackendInfo,
+    SandboxBackendPlugin,
+    normalize_backend_name,
+)
+from llm_sandbox.exceptions import (
+    BackendLoadError,
+    BackendNameConflictError,
+    BackendNotFoundError,
+)
+
+__all__ = [
+    "BackendNameMismatchWarning",
+    "BackendShadowWarning",
+    "clear_cache",
+    "get_backend",
+    "list_backends",
+]
+
+logger = logging.getLogger(__name__)
+
+INTEGRATIONS_URL = "https://github.com/vndee/llm-sandbox/blob/main/INTEGRATIONS.md"
+
+_DID_YOU_MEAN_CUTOFF = 0.6
+
+
+class BackendShadowWarning(UserWarning):
+    """Warned when an installed plugin registers a name a built-in backend already owns.
+
+    The built-in always wins. ``SandboxSession(backend="docker")`` must mean Docker on every
+    machine, and no installable package may change that.
+    """
+
+
+class BackendNameMismatchWarning(UserWarning):
+    """Warned when a plugin's declared ``name`` differs from its entry point name.
+
+    The entry point name wins, because that is what users type.
+    """
+
+
+@dataclass(frozen=True)
+class _PluginRecord:
+    """Bookkeeping for a discovered entry point, before it is loaded."""
+
+    name: str
+    entry_point: EntryPoint
+    distribution: str | None
+    version: str | None
+    conflicts: tuple[str, ...] = ()
+
+
+_lock = threading.Lock()
+_records: dict[str, _PluginRecord] | None = None
+_shadowed: list[BackendInfo] = []
+_loaded: dict[str, type[SandboxBackendPlugin]] = {}
+
+
+def clear_cache() -> None:
+    """Discard cached entry point discovery and loaded plugin classes.
+
+    Needed when plugins are installed into a running process, and by tests that register
+    backends dynamically. Ordinary applications never call this.
+    """
+    global _records  # noqa: PLW0603
+    with _lock:
+        _records = None
+        _shadowed.clear()
+        _loaded.clear()
+
+
+def _entry_points() -> list[EntryPoint]:
+    """Read this group's entry points, tolerating a broken metadata directory.
+
+    Returns:
+        list[EntryPoint]: Discovered entry points; empty if metadata could not be read.
+
+    """
+    try:
+        return list(entry_points(group=ENTRY_POINT_GROUP))
+    except Exception:  # noqa: BLE001 # pragma: no cover - defensive
+        # A corrupt or unreadable distribution on sys.path must not stop built-in backends
+        # from resolving.
+        logger.warning("Could not read %r entry points; no plugin backends available", ENTRY_POINT_GROUP)
+        return []
+
+
+def _discover() -> dict[str, _PluginRecord]:
+    """Scan entry points and build the plugin record table. Imports nothing.
+
+    Returns:
+        dict[str, _PluginRecord]: Records keyed by normalised backend name.
+
+    """
+    candidates: dict[str, list[tuple[EntryPoint, str | None, str | None]]] = defaultdict(list)
+    shadowed: list[BackendInfo] = []
+
+    for entry_point in _entry_points():
+        name = normalize_backend_name(entry_point.name)
+        dist = getattr(entry_point, "dist", None)
+        dist_name = getattr(dist, "name", None)
+        dist_version = getattr(dist, "version", None)
+
+        if name in BUILTIN_BACKENDS:
+            warnings.warn(
+                f"Plugin backend {entry_point.name!r} from {dist_name or 'an unknown distribution'}"
+                f"{' ' + dist_version if dist_version else ''} shadows the built-in backend {name!r}"
+                f" and will be ignored. Built-in backends always win.",
+                BackendShadowWarning,
+                stacklevel=2,
+            )
+            shadowed.append(
+                BackendInfo(
+                    name=name,
+                    distribution=dist_name,
+                    version=dist_version,
+                    entry_point=entry_point.value,
+                    status="shadowed",
+                    detail=f"Shadows the built-in {name!r} backend; the built-in is used instead.",
+                )
+            )
+            continue
+
+        # The same distribution can appear twice if it is installed twice on sys.path. That
+        # is not a conflict between two projects, so collapse it instead of reporting one.
+        duplicate_key = (dist_name, entry_point.value)
+        if any((seen_dist, seen_ep.value) == duplicate_key for seen_ep, seen_dist, _ in candidates[name]):
+            continue
+        candidates[name].append((entry_point, dist_name, dist_version))
+
+    records: dict[str, _PluginRecord] = {}
+    for name, entries in candidates.items():
+        entry_point, dist_name, dist_version = entries[0]
+        # A conflict is recorded, not raised. Raising here would let one bad pair of plugins
+        # break resolution for every other backend; instead it surfaces when that specific
+        # name is requested.
+        conflicts = tuple(d or "<unknown distribution>" for _, d, _ in entries) if len(entries) > 1 else ()
+        records[name] = _PluginRecord(
+            name=name,
+            entry_point=entry_point,
+            distribution=dist_name,
+            version=dist_version,
+            conflicts=conflicts,
+        )
+
+    _shadowed.clear()
+    _shadowed.extend(shadowed)
+    return records
+
+
+def _get_records() -> dict[str, _PluginRecord]:
+    """Return the plugin record table, discovering once and caching.
+
+    Returns:
+        dict[str, _PluginRecord]: Records keyed by normalised backend name.
+
+    """
+    global _records  # noqa: PLW0603
+    if _records is None:
+        with _lock:
+            if _records is None:
+                _records = _discover()
+    return _records
+
+
+def _validate(obj: Any, record: _PluginRecord) -> type[SandboxBackendPlugin]:
+    """Check a loaded entry point really is a usable backend plugin.
+
+    Args:
+        obj (Any): Whatever the entry point resolved to.
+        record (_PluginRecord): Bookkeeping for the entry point, used in error messages.
+
+    Returns:
+        type[SandboxBackendPlugin]: The validated plugin class.
+
+    Raises:
+        BackendLoadError: If the object is not a concrete `SandboxBackendPlugin` subclass,
+            or targets a plugin API version this release does not accept.
+
+    """
+    source = f"{record.distribution or '<unknown distribution>'} (entry point {record.entry_point.value!r})"
+
+    if not isinstance(obj, type) or not issubclass(obj, SandboxBackendPlugin):
+        raise BackendLoadError(
+            record.name,
+            f"Backend {record.name!r} from {source} is not usable: the entry point must resolve to a "
+            f"subclass of llm_sandbox.backends.SandboxBackendPlugin, but it resolved to "
+            f"{type(obj).__name__}. Point the entry point at the class itself, not an instance.",
+            record.distribution,
+        )
+
+    if inspect.isabstract(obj):
+        missing = ", ".join(sorted(obj.__abstractmethods__))
+        raise BackendLoadError(
+            record.name,
+            f"Backend {record.name!r} from {source} is incomplete: it does not implement {missing}.",
+            record.distribution,
+        )
+
+    declared = getattr(obj, "PLUGIN_API_VERSION", None)
+    if declared is None:
+        raise BackendLoadError(
+            record.name,
+            f"Backend {record.name!r} from {source} does not declare PLUGIN_API_VERSION. "
+            f"Add `PLUGIN_API_VERSION = {sorted(SUPPORTED_PLUGIN_API_VERSIONS)[-1]}` to the plugin class. "
+            f"This release accepts plugin API version(s): "
+            f"{', '.join(str(v) for v in sorted(SUPPORTED_PLUGIN_API_VERSIONS))}.",
+            record.distribution,
+        )
+
+    if declared not in SUPPORTED_PLUGIN_API_VERSIONS:
+        supported = ", ".join(str(v) for v in sorted(SUPPORTED_PLUGIN_API_VERSIONS))
+        raise BackendLoadError(
+            record.name,
+            f"Backend {record.name!r} from {source} targets plugin API version {declared}, "
+            f"which this release of llm-sandbox does not support (it accepts: {supported}). "
+            f"Upgrade or downgrade {record.distribution or 'the plugin'}, or change the version of "
+            f"llm-sandbox. See {INTEGRATIONS_URL}",
+            record.distribution,
+        )
+
+    declared_name = getattr(obj, "name", None)
+    if declared_name and normalize_backend_name(str(declared_name)) != record.name:
+        warnings.warn(
+            f"Backend plugin from {source} declares name {declared_name!r} but is registered under "
+            f"entry point name {record.name!r}. The entry point name is used.",
+            BackendNameMismatchWarning,
+            stacklevel=2,
+        )
+
+    return obj
+
+
+def _load(record: _PluginRecord) -> type[SandboxBackendPlugin]:
+    """Import and validate one plugin, caching the result.
+
+    Args:
+        record (_PluginRecord): The discovered entry point to load.
+
+    Returns:
+        type[SandboxBackendPlugin]: The plugin class.
+
+    Raises:
+        BackendLoadError: If importing the entry point fails for any reason.
+
+    """
+    cached = _loaded.get(record.name)
+    if cached is not None:
+        return cached
+
+    try:
+        obj = record.entry_point.load()
+    except BackendLoadError:
+        raise
+    except Exception as exc:
+        source = record.distribution or "<unknown distribution>"
+        raise BackendLoadError(
+            record.name,
+            f"Backend {record.name!r} from {source} failed to load: {type(exc).__name__}: {exc}\n"
+            f"This is a problem with the plugin, not with llm-sandbox. Other backends are unaffected.",
+            record.distribution,
+        ) from exc
+
+    plugin = _validate(obj, record)
+    _loaded[record.name] = plugin
+    return plugin
+
+
+def _unknown_backend_error(key: str, requested: str) -> BackendNotFoundError:
+    """Build the message shown when a backend name resolves to nothing.
+
+    For most plugin users this message is the whole onboarding experience, so it names what
+    is available, what is installed, and what to install.
+
+    Args:
+        key (str): The normalised backend name.
+        requested (str): The name exactly as the caller typed it.
+
+    Returns:
+        BackendNotFoundError: The error, ready to raise.
+
+    """
+    records = _get_records()
+    lines = [
+        f"Unknown backend {requested!r}.",
+        f"Built-in backends: {', '.join(sorted(BUILTIN_BACKENDS))}.",
+    ]
+
+    if records:
+        installed = ", ".join(
+            f"{name} ({record.distribution or 'unknown'} {record.version or '?'})"
+            for name, record in sorted(records.items())
+        )
+        lines.append(f"Installed plugin backends: {installed}.")
+
+    close = difflib.get_close_matches(key, [*BUILTIN_BACKENDS, *records], n=1, cutoff=_DID_YOU_MEAN_CUTOFF)
+    if close:
+        lines.append(f"Did you mean {close[0]!r}?")
+    else:
+        lines.append(
+            f"No installed package provides {requested!r}. Third-party backends ship as separate\n"
+            f"packages — try: pip install llm-sandbox-{key.replace('_', '-')}"
+        )
+
+    lines.append(f"See {INTEGRATIONS_URL}")
+    return BackendNotFoundError(requested, "\n".join(lines))
+
+
+def get_backend(name: str) -> type[SandboxBackendPlugin]:
+    """Resolve a backend name to its provider, loading a plugin only if necessary.
+
+    Entry point metadata is scanned once per process and cached. Plugin code is imported
+    only when that plugin's backend is the one being requested.
+
+    Args:
+        name (str): A backend name. Case-insensitive; hyphens and underscores are
+            equivalent. Accepts `llm_sandbox.const.SandboxBackend` members, which are
+            strings.
+
+    Returns:
+        type[SandboxBackendPlugin]: The provider for that backend.
+
+    Raises:
+        BackendNotFoundError: If nothing provides the name.
+        BackendNameConflictError: If several installed distributions claim the name.
+        BackendLoadError: If the plugin's entry point cannot be loaded or is malformed.
+
+    Examples:
+        ```python
+        from llm_sandbox.registry import get_backend
+
+        provider = get_backend("docker")
+        session = provider.create_session(lang="python")
+        ```
+
+    """
+    requested = str(name)
+    key = normalize_backend_name(requested)
+
+    # Discovery runs even when a built-in will win, so that a package attempting to shadow
+    # a built-in name is reported. That shape is a supply-chain attack, and a user who only
+    # ever asks for "docker" is exactly the user who needs to hear about it. Metadata is
+    # scanned once per process and cached; no plugin code is imported.
+    records = _get_records()
+
+    builtin = BUILTIN_BACKENDS.get(key)
+    if builtin is not None:
+        return builtin
+
+    record = records.get(key)
+    if record is None:
+        raise _unknown_backend_error(key, requested)
+
+    if record.conflicts:
+        claimants = ", ".join(sorted(record.conflicts))
+        raise BackendNameConflictError(
+            requested,
+            f"Backend name {key!r} is claimed by more than one installed distribution: {claimants}. "
+            f"Uninstall all but one of them. Other backends are unaffected.",
+            record.conflicts,
+        )
+
+    return _load(record)
+
+
+def list_backends(load: bool = False) -> list[BackendInfo]:
+    """List every backend core can see, built-in and installed plugins alike.
+
+    By default this reads distribution metadata only and imports no plugin code, so it is
+    safe to call in any context.
+
+    Args:
+        load (bool): Import each plugin to populate `BackendInfo.capabilities`. Plugins that
+            fail to load are reported with ``status="error"`` rather than raising, so one
+            broken plugin never hides the rest.
+
+    Returns:
+        list[BackendInfo]: One entry per visible backend, built-ins first, then plugins,
+            each alphabetically. Shadowed plugin registrations are listed after those.
+
+    Examples:
+        ```python
+        import llm_sandbox
+
+        for backend in llm_sandbox.list_backends():
+            origin = "built-in" if backend.is_builtin else f"{backend.distribution} {backend.version}"
+            print(f"{backend.name:<16} {origin}")
+        ```
+
+    """
+    infos: list[BackendInfo] = [
+        BackendInfo(
+            name=name,
+            is_builtin=True,
+            capabilities=frozenset(provider.capabilities),
+        )
+        for name, provider in sorted(BUILTIN_BACKENDS.items())
+    ]
+
+    for name, record in sorted(_get_records().items()):
+        capabilities: frozenset[BackendCapability] | None = None
+        status = "ok"
+        detail: str | None = None
+
+        if record.conflicts:
+            status = "conflict"
+            detail = f"Claimed by: {', '.join(sorted(record.conflicts))}"
+        elif load:
+            try:
+                capabilities = frozenset(_load(record).capabilities)
+            except Exception as exc:  # noqa: BLE001
+                status = "error"
+                detail = str(exc)
+
+        infos.append(
+            BackendInfo(
+                name=name,
+                is_builtin=False,
+                distribution=record.distribution,
+                version=record.version,
+                entry_point=record.entry_point.value,
+                capabilities=capabilities,
+                status=status,
+                detail=detail,
+            )
+        )
+
+    infos.extend(_shadowed)
+    return infos

--- a/llm_sandbox/registry.py
+++ b/llm_sandbox/registry.py
@@ -16,7 +16,7 @@ sandbox, though -- by the time a plugin is installed, its build already ran. See
 ``docs/plugins/authoring.md``.
 """
 
-import difflib
+import contextlib
 import inspect
 import logging
 import threading
@@ -28,10 +28,12 @@ from typing import Any
 
 from llm_sandbox.backends.builtin import BUILTIN_BACKENDS
 from llm_sandbox.backends.plugin import (
+    BACKEND_NAME_PATTERN,
     ENTRY_POINT_GROUP,
     SUPPORTED_PLUGIN_API_VERSIONS,
     BackendCapability,
     BackendInfo,
+    BackendStatus,
     SandboxBackendPlugin,
     normalize_backend_name,
 )
@@ -84,7 +86,7 @@ class _PluginRecord:
 
 _lock = threading.Lock()
 _records: dict[str, _PluginRecord] | None = None
-_shadowed: list[BackendInfo] = []
+_shadowed: tuple[BackendInfo, ...] = ()
 _loaded: dict[str, type[SandboxBackendPlugin]] = {}
 
 
@@ -94,10 +96,10 @@ def clear_cache() -> None:
     Needed when plugins are installed into a running process, and by tests that register
     backends dynamically. Ordinary applications never call this.
     """
-    global _records  # noqa: PLW0603
+    global _records, _shadowed  # noqa: PLW0603
     with _lock:
         _records = None
-        _shadowed.clear()
+        _shadowed = ()
         _loaded.clear()
 
 
@@ -110,36 +112,56 @@ def _entry_points() -> list[EntryPoint]:
     """
     try:
         return list(entry_points(group=ENTRY_POINT_GROUP))
-    except Exception:  # noqa: BLE001 # pragma: no cover - defensive
+    except Exception as exc:  # noqa: BLE001
         # A corrupt or unreadable distribution on sys.path must not stop built-in backends
-        # from resolving.
-        logger.warning("Could not read %r entry points; no plugin backends available", ENTRY_POINT_GROUP)
+        # from resolving. Report the cause, or the user has nothing to act on.
+        logger.warning(
+            "Could not read %r entry points; no plugin backends available: %s: %s",
+            ENTRY_POINT_GROUP,
+            type(exc).__name__,
+            exc,
+        )
         return []
 
 
-def _discover() -> dict[str, _PluginRecord]:
+def _discover() -> tuple[dict[str, _PluginRecord], tuple[BackendInfo, ...], list[str]]:
     """Scan entry points and build the plugin record table. Imports nothing.
 
+    Pure with respect to module state, and emits no warnings: it returns the messages for
+    the caller to deliver *after* the record table is committed. Warning delivery runs
+    arbitrary user code (filters, ``showwarning``) and raises under ``-W error``, and neither
+    may be able to abort discovery or leave the cache unpopulated.
+
     Returns:
-        dict[str, _PluginRecord]: Records keyed by normalised backend name.
+        tuple[dict[str, _PluginRecord], tuple[BackendInfo, ...], list[str]]: Records keyed
+            by normalised backend name, shadowed registrations, and pending warnings.
 
     """
     candidates: dict[str, list[tuple[EntryPoint, str | None, str | None]]] = defaultdict(list)
     shadowed: list[BackendInfo] = []
+    pending: list[str] = []
 
     for entry_point in _entry_points():
         name = normalize_backend_name(entry_point.name)
         dist = getattr(entry_point, "dist", None)
         dist_name = getattr(dist, "name", None)
         dist_version = getattr(dist, "version", None)
+        source = f"{dist_name or 'an unknown distribution'}{' ' + dist_version if dist_version else ''}"
+
+        if not BACKEND_NAME_PATTERN.match(name):
+            # Refused rather than registered. An empty or exotic entry point name would
+            # otherwise answer to backend="" or a homoglyph, turning an unset config value
+            # into a silent hand-off of code execution.
+            pending.append(
+                f"Plugin backend {entry_point.name!r} from {source} has an unusable name and will be "
+                f"ignored. Backend names must match {BACKEND_NAME_PATTERN.pattern}."
+            )
+            continue
 
         if name in BUILTIN_BACKENDS:
-            warnings.warn(
-                f"Plugin backend {entry_point.name!r} from {dist_name or 'an unknown distribution'}"
-                f"{' ' + dist_version if dist_version else ''} shadows the built-in backend {name!r}"
-                f" and will be ignored. Built-in backends always win.",
-                BackendShadowWarning,
-                stacklevel=2,
+            pending.append(
+                f"Plugin backend {entry_point.name!r} from {source} shadows the built-in backend "
+                f"{name!r} and will be ignored. Built-in backends always win."
             )
             shadowed.append(
                 BackendInfo(
@@ -166,7 +188,9 @@ def _discover() -> dict[str, _PluginRecord]:
         # A conflict is recorded, not raised. Raising here would let one bad pair of plugins
         # break resolution for every other backend; instead it surfaces when that specific
         # name is requested.
-        conflicts = tuple(d or "<unknown distribution>" for _, d, _ in entries) if len(entries) > 1 else ()
+        conflicts = (
+            tuple(sorted({d or "<unknown distribution>" for _, d, _ in entries})) if len(entries) > 1 else ()
+        )
         records[name] = _PluginRecord(
             name=name,
             entry_point=entry_point,
@@ -175,9 +199,7 @@ def _discover() -> dict[str, _PluginRecord]:
             conflicts=conflicts,
         )
 
-    _shadowed.clear()
-    _shadowed.extend(shadowed)
-    return records
+    return records, tuple(shadowed), pending
 
 
 def _get_records() -> dict[str, _PluginRecord]:
@@ -187,12 +209,43 @@ def _get_records() -> dict[str, _PluginRecord]:
         dict[str, _PluginRecord]: Records keyed by normalised backend name.
 
     """
-    global _records  # noqa: PLW0603
-    if _records is None:
-        with _lock:
-            if _records is None:
-                _records = _discover()
-    return _records
+    global _records, _shadowed
+
+    records = _records
+    if records is not None:
+        return records
+
+    pending: list[str] = []
+    with _lock:
+        # Re-read under the lock, and bind to a local: a concurrent clear_cache() may set
+        # the global back to None between the assignment and the return.
+        records = _records
+        if records is None:
+            records, shadowed, pending = _discover()
+            _records, _shadowed = records, shadowed
+
+    _emit_discovery_warnings(pending)
+    return records
+
+
+def _emit_discovery_warnings(messages: list[str]) -> None:
+    """Deliver discovery warnings outside the lock, best effort.
+
+    Every message is logged unconditionally, because a shadowing attempt is a supply-chain
+    signal and ``warnings`` may be filtered to silence, deduplicated to once per location,
+    or configured to raise. The ``warnings`` call is then best effort: warning *policy* must
+    never decide whether a backend resolves.
+
+    Args:
+        messages (list[str]): Warning texts collected during discovery.
+
+    """
+    for message in messages:
+        logger.warning("%s", message)
+        # Best effort: a filter set to "error", or a custom showwarning that raises, must not
+        # decide whether a backend resolves. The logger call above is the guaranteed channel.
+        with contextlib.suppress(Exception):
+            warnings.warn(message, BackendShadowWarning, stacklevel=3)
 
 
 def _validate(obj: Any, record: _PluginRecord) -> type[SandboxBackendPlugin]:
@@ -226,6 +279,17 @@ def _validate(obj: Any, record: _PluginRecord) -> type[SandboxBackendPlugin]:
         raise BackendLoadError(
             record.name,
             f"Backend {record.name!r} from {source} is incomplete: it does not implement {missing}.",
+            record.distribution,
+        )
+
+    if not getattr(obj, "name", None):
+        # `require()` and the default optional factories all read `cls.name`. Without this
+        # check the failure is a bare AttributeError from deep inside a call, which is the
+        # exact outcome declaring PLUGIN_API_VERSION exists to prevent.
+        raise BackendLoadError(
+            record.name,
+            f"Backend {record.name!r} from {source} does not declare a `name` class attribute. "
+            f"Add `name = {record.name!r}` to the plugin class.",
             record.distribution,
         )
 
@@ -282,9 +346,11 @@ def _load(record: _PluginRecord) -> type[SandboxBackendPlugin]:
 
     try:
         obj = record.entry_point.load()
-    except BackendLoadError:
+    except (BackendLoadError, KeyboardInterrupt):
         raise
-    except Exception as exc:
+    except BaseException as exc:
+        # BaseException, not Exception: a plugin doing sys.exit() on missing config raises
+        # SystemExit, and failure isolation has to hold for that too.
         source = record.distribution or "<unknown distribution>"
         raise BackendLoadError(
             record.name,
@@ -325,13 +391,22 @@ def _unknown_backend_error(key: str, requested: str) -> BackendNotFoundError:
         )
         lines.append(f"Installed plugin backends: {installed}.")
 
+    import difflib
+
     close = difflib.get_close_matches(key, [*BUILTIN_BACKENDS, *records], n=1, cutoff=_DID_YOU_MEAN_CUTOFF)
     if close:
         lines.append(f"Did you mean {close[0]!r}?")
-    else:
+    elif BACKEND_NAME_PATTERN.match(key):
+        # Only suggest a command for a name that survived validation. This line is written to
+        # be pasted into a shell, so it must never carry through whatever the caller passed.
         lines.append(
             f"No installed package provides {requested!r}. Third-party backends ship as separate\n"
             f"packages — try: pip install llm-sandbox-{key.replace('_', '-')}"
+        )
+    else:
+        lines.append(
+            f"{requested!r} is not a usable backend name. Names must match "
+            f"{BACKEND_NAME_PATTERN.pattern}."
         )
 
     lines.append(f"See {INTEGRATIONS_URL}")
@@ -374,6 +449,12 @@ def get_backend(name: str) -> type[SandboxBackendPlugin]:
     # ever asks for "docker" is exactly the user who needs to hear about it. Metadata is
     # scanned once per process and cached; no plugin code is imported.
     records = _get_records()
+
+    if not BACKEND_NAME_PATTERN.match(key):
+        # Fail closed. `backend=None` and `backend=""` are what a caller passes when a config
+        # value or environment variable is unset, and they must never be able to select
+        # anything -- least of all a name an installed package chose to answer to.
+        raise _unknown_backend_error(key, requested)
 
     builtin = BUILTIN_BACKENDS.get(key)
     if builtin is not None:
@@ -431,7 +512,7 @@ def list_backends(load: bool = False) -> list[BackendInfo]:
 
     for name, record in sorted(_get_records().items()):
         capabilities: frozenset[BackendCapability] | None = None
-        status = "ok"
+        status: BackendStatus = "ok"
         detail: str | None = None
 
         if record.conflicts:
@@ -440,7 +521,9 @@ def list_backends(load: bool = False) -> list[BackendInfo]:
         elif load:
             try:
                 capabilities = frozenset(_load(record).capabilities)
-            except Exception as exc:  # noqa: BLE001
+            except KeyboardInterrupt:
+                raise
+            except BaseException as exc:  # noqa: BLE001
                 status = "error"
                 detail = str(exc)
 
@@ -457,5 +540,5 @@ def list_backends(load: bool = False) -> list[BackendInfo]:
             )
         )
 
-    infos.extend(_shadowed)
+    infos.extend(_shadowed)  # atomically swapped tuple; safe to read unlocked
     return infos

--- a/llm_sandbox/session.py
+++ b/llm_sandbox/session.py
@@ -4,7 +4,7 @@ from importlib.util import find_spec
 from types import TracebackType
 from typing import Any
 
-from llm_sandbox.backends.plugin import normalize_backend_name
+from llm_sandbox.backends.plugin import BackendCapability, normalize_backend_name
 from llm_sandbox.registry import get_backend
 from llm_sandbox.security import SecurityPolicy
 
@@ -258,7 +258,14 @@ def create_session(
 
     # Resolve the backend. Built-ins resolve from a dict; plugin backends are imported here
     # and only here, so installing a plugin never costs anything until it is asked for.
-    return get_backend(str(backend)).create_session(*args, **kwargs)
+    provider = get_backend(str(backend))
+
+    # Check the capability before constructing, so an unsupported request fails cleanly
+    # rather than after a container has been created and billed.
+    if kwargs.get("container_id") is not None:
+        provider.require(BackendCapability.EXISTING_CONTAINER)
+
+    return provider.create_session(*args, **kwargs)
 
 
 class ArtifactSandboxSession:
@@ -473,6 +480,11 @@ class ArtifactSandboxSession:
             # Don't create _session when using pooled implementation
             self._session = None
         else:
+            # Artifact extraction needs get_archive(). Check before creating anything, so a
+            # backend that cannot do it fails here rather than mid-run with a live container.
+            if enable_plotting:
+                get_backend(str(backend)).require(BackendCapability.ARTIFACTS)
+
             # Create the base session (non-pooled)
             self._pooled_impl = None
             self._session = create_session(

--- a/llm_sandbox/session.py
+++ b/llm_sandbox/session.py
@@ -4,12 +4,14 @@ from importlib.util import find_spec
 from types import TracebackType
 from typing import Any
 
+from llm_sandbox.backends.plugin import normalize_backend_name
+from llm_sandbox.registry import get_backend
 from llm_sandbox.security import SecurityPolicy
 
 from .const import SandboxBackend, SupportedLanguage
 from .core.session_base import BaseSession
 from .data import ExecutionResult, StreamCallback
-from .exceptions import LanguageNotSupportPlotError, MissingDependencyError, UnsupportedBackendError
+from .exceptions import LanguageNotSupportPlotError, MissingDependencyError
 from .interactive import InteractiveSandboxSession
 from .pool.base import ContainerPoolManager
 from .pool.session import ArtifactPooledSandboxSession, PooledSandboxSession
@@ -24,21 +26,26 @@ __all__ = [
 ]
 
 
-def _check_dependency(backend: SandboxBackend) -> None:
-    """Check if required dependency is installed for the given backend."""
-    if backend in {SandboxBackend.DOCKER, SandboxBackend.MICROMAMBA} and not find_spec("docker"):
+def _check_dependency(backend: SandboxBackend | str) -> None:
+    """Check if required dependency is installed for the given backend.
+
+    Only built-in backends are checked. Plugin backends declare their own dependencies and
+    are responsible for reporting them.
+    """
+    name = normalize_backend_name(str(backend))
+    if name in {SandboxBackend.DOCKER, SandboxBackend.MICROMAMBA} and not find_spec("docker"):
         msg = "Docker backend requires 'docker' package. Install it with: pip install llm-sandbox[docker]"
         raise MissingDependencyError(msg)
-    if backend == SandboxBackend.KUBERNETES and not find_spec("kubernetes"):
+    if name == SandboxBackend.KUBERNETES and not find_spec("kubernetes"):
         msg = "Kubernetes backend requires 'kubernetes' package. Install it with: pip install llm-sandbox[k8s]"
         raise MissingDependencyError(msg)
-    if backend == SandboxBackend.PODMAN and not find_spec("podman"):
+    if name == SandboxBackend.PODMAN and not find_spec("podman"):
         msg = "Podman backend requires 'podman' package. Install it with: pip install llm-sandbox[podman]"
         raise MissingDependencyError(msg)
 
 
 def create_session(
-    backend: SandboxBackend = SandboxBackend.DOCKER,
+    backend: SandboxBackend | str = SandboxBackend.DOCKER,
     pool: ContainerPoolManager | None = None,
     *args: Any,
     **kwargs: Any,
@@ -50,11 +57,16 @@ def create_session(
     For backward compatibility, we also keep a `SandboxSession` alias for this function.
 
     Args:
-        backend (SandboxBackend): Container backend to use. Options:
+        backend (SandboxBackend | str): Container backend to use. Built-in options:
             - SandboxBackend.DOCKER (default)
             - SandboxBackend.KUBERNETES
             - SandboxBackend.PODMAN
             - SandboxBackend.MICROMAMBA
+
+            Backends provided by an installed plugin are selected by name, e.g.
+            `backend="my-service"`. Names are case-insensitive and treat hyphens and
+            underscores as equivalent. Call `llm_sandbox.list_backends()` to see what is
+            available, and see INTEGRATIONS.md for the plugin policy.
         pool (ContainerPoolManager | None): Pool manager to use for container pooling.
             If provided, containers are acquired from the pool instead of being created new.
             Create a pool manager using `create_pool_manager()` from llm_sandbox.pool.
@@ -244,26 +256,9 @@ def create_session(
     # Check if required dependency is installed for non-pooled sessions
     _check_dependency(backend)
 
-    # Create the appropriate session based on backend
-    match backend:
-        case SandboxBackend.DOCKER:
-            from .docker import SandboxDockerSession
-
-            return SandboxDockerSession(*args, **kwargs)
-        case SandboxBackend.KUBERNETES:
-            from .kubernetes import SandboxKubernetesSession
-
-            return SandboxKubernetesSession(*args, **kwargs)
-        case SandboxBackend.PODMAN:
-            from .podman import SandboxPodmanSession
-
-            return SandboxPodmanSession(*args, **kwargs)
-        case SandboxBackend.MICROMAMBA:
-            from .micromamba import MicromambaSession
-
-            return MicromambaSession(*args, **kwargs)
-        case _:
-            raise UnsupportedBackendError(backend=backend)
+    # Resolve the backend. Built-ins resolve from a dict; plugin backends are imported here
+    # and only here, so installing a plugin never costs anything until it is asked for.
+    return get_backend(str(backend)).create_session(*args, **kwargs)
 
 
 class ArtifactSandboxSession:
@@ -271,7 +266,7 @@ class ArtifactSandboxSession:
 
     def __init__(
         self,
-        backend: SandboxBackend = SandboxBackend.DOCKER,
+        backend: SandboxBackend | str = SandboxBackend.DOCKER,
         image: str | None = None,
         dockerfile: str | None = None,
         lang: str = SupportedLanguage.PYTHON,

--- a/llm_sandbox/testing/__init__.py
+++ b/llm_sandbox/testing/__init__.py
@@ -1,0 +1,32 @@
+"""Conformance test suites for backend plugins.
+
+A plugin subclasses one of these and points it at its own backend; pytest collects the
+inherited tests and runs them against the real implementation:
+
+```python
+from llm_sandbox.testing import BackendComplianceTests
+
+
+class TestMyServiceCompliance(BackendComplianceTests):
+    backend = "myservice"
+    session_kwargs = {"lang": "python"}
+```
+
+Two entry points, because the interface half needs no infrastructure:
+
+- `BackendInterfaceComplianceTests` -- static checks only. Registration, plugin API version,
+  capability declarations, and whether the methods a declared capability implies actually
+  exist. Runs anywhere, including CI without credentials.
+- `BackendComplianceTests` -- the above plus lifecycle, result types, file transfer, and
+  timeout behaviour, which create real sessions.
+
+Requires pytest, which core does not depend on. Install it with the ``testing`` extra:
+``pip install llm-sandbox[testing]``.
+"""
+
+from llm_sandbox.testing.compliance import BackendComplianceTests, BackendInterfaceComplianceTests
+
+__all__ = [
+    "BackendComplianceTests",
+    "BackendInterfaceComplianceTests",
+]

--- a/llm_sandbox/testing/compliance.py
+++ b/llm_sandbox/testing/compliance.py
@@ -324,10 +324,14 @@ class BackendComplianceTests(BackendInterfaceComplianceTests):
         source = tmp_path / "payload.txt"
         source.write_text(payload)
         destination = tmp_path / "returned.txt"
+        # Unique per run: for a host-executing backend this is a real host path, where a
+        # fixed name is both a collision between concurrent runs and a symlink-overwrite
+        # target on a shared machine.
+        remote = f"/tmp/llm_sandbox_compliance_{uuid.uuid4().hex}.txt"
 
         with self.make_session() as session:
-            session.copy_to_runtime(str(source), "/tmp/llm_sandbox_compliance.txt")
-            session.copy_from_runtime("/tmp/llm_sandbox_compliance.txt", str(destination))
+            session.copy_to_runtime(str(source), remote)
+            session.copy_from_runtime(remote, str(destination))
 
         assert destination.read_text() == payload, "File contents changed in transit."
 
@@ -353,10 +357,11 @@ class BackendComplianceTests(BackendInterfaceComplianceTests):
 
         source = tmp_path / "artifact.txt"
         source.write_text("artifact-payload")
+        remote = f"/tmp/llm_sandbox_artifact_{uuid.uuid4().hex}.txt"
 
         with self.make_session() as session:
-            session.copy_to_runtime(str(source), "/tmp/llm_sandbox_artifact.txt")
-            data, stat = session.get_archive("/tmp/llm_sandbox_artifact.txt")
+            session.copy_to_runtime(str(source), remote)
+            data, stat = session.get_archive(remote)
 
         assert isinstance(data, bytes), "get_archive() must return tar bytes."
         assert data, "get_archive() returned no data for a file that exists."

--- a/llm_sandbox/testing/compliance.py
+++ b/llm_sandbox/testing/compliance.py
@@ -1,0 +1,412 @@
+"""Reusable conformance suites a backend plugin can run against itself.
+
+This is the main lever core has for keeping third-party backend quality up without
+reviewing anyone's code, so the checks are the ones that actually catch broken backends:
+resources released when a block raises, timeouts that really cancel work, exit codes that
+survive, and file transfer that round-trips.
+"""
+
+import contextlib
+import uuid
+from pathlib import Path
+from typing import Any, ClassVar
+
+try:
+    import pytest
+except ImportError as exc:  # pragma: no cover - depends on the installing environment
+    msg = (
+        "llm_sandbox.testing requires pytest, which llm-sandbox does not depend on at runtime. "
+        "Install it with: pip install llm-sandbox[testing]"
+    )
+    raise ImportError(msg) from exc
+
+from llm_sandbox.backends.plugin import (
+    SUPPORTED_PLUGIN_API_VERSIONS,
+    BackendCapability,
+    SandboxBackendPlugin,
+    normalize_backend_name,
+)
+from llm_sandbox.data import ConsoleOutput
+from llm_sandbox.exceptions import NotOpenSessionError, SandboxTimeoutError, UnsupportedBackendError
+from llm_sandbox.registry import get_backend
+from llm_sandbox.session import create_session
+
+_REQUIRED_SESSION_METHODS = (
+    "open",
+    "close",
+    "run",
+    "execute_command",
+    "copy_to_runtime",
+    "copy_from_runtime",
+)
+
+_EXPECTED_EXIT_CODE = 3
+
+
+class BackendInterfaceComplianceTests:
+    """Static conformance checks. Creates no sessions and needs no infrastructure.
+
+    Subclass it and set `backend`. Everything else has a working default.
+
+    Example:
+        ```python
+        from llm_sandbox.testing import BackendInterfaceComplianceTests
+
+
+        class TestMyServiceInterface(BackendInterfaceComplianceTests):
+            backend = "myservice"
+        ```
+
+    """
+
+    backend: ClassVar[str]
+    """The backend name, as passed to ``backend=``. Required."""
+
+    expect_registered_entry_point: ClassVar[bool] = True
+    """Whether the backend must be discoverable through an installed entry point.
+
+    Set False when testing a backend registered in-process (for example one injected by a
+    fixture) rather than installed as a distribution.
+    """
+
+    @pytest.fixture
+    def provider(self) -> type[SandboxBackendPlugin]:
+        """Resolve the backend under test.
+
+        Returns:
+            type[SandboxBackendPlugin]: The provider registered for `backend`.
+
+        """
+        return get_backend(self.backend)
+
+    def test_backend_resolves(self, provider: type[SandboxBackendPlugin]) -> None:
+        """The backend name resolves to a SandboxBackendPlugin subclass."""
+        assert isinstance(provider, type), (
+            f"Backend {self.backend!r} resolved to an instance, not a class. The entry point must "
+            f"point at the SandboxBackendPlugin subclass itself."
+        )
+        assert issubclass(provider, SandboxBackendPlugin), (
+            f"Backend {self.backend!r} must subclass llm_sandbox.backends.SandboxBackendPlugin."
+        )
+
+    def test_declares_supported_plugin_api_version(self, provider: type[SandboxBackendPlugin]) -> None:
+        """The backend declares a plugin API version this release accepts."""
+        declared = getattr(provider, "PLUGIN_API_VERSION", None)
+        assert declared is not None, "Backend must declare PLUGIN_API_VERSION."
+        assert declared in SUPPORTED_PLUGIN_API_VERSIONS, (
+            f"Backend targets plugin API version {declared}; this release accepts "
+            f"{sorted(SUPPORTED_PLUGIN_API_VERSIONS)}."
+        )
+
+    def test_declares_matching_name(self, provider: type[SandboxBackendPlugin]) -> None:
+        """The declared name matches the name the backend is addressed by."""
+        declared = getattr(provider, "name", None)
+        assert declared, "Backend must declare a `name` class attribute."
+        assert normalize_backend_name(str(declared)) == normalize_backend_name(self.backend), (
+            f"Backend declares name {declared!r} but is registered as {self.backend!r}."
+        )
+
+    def test_capabilities_are_recognised(self, provider: type[SandboxBackendPlugin]) -> None:
+        """Every declared capability is a real BackendCapability."""
+        valid = {capability.value for capability in BackendCapability}
+        for capability in provider.capabilities:
+            assert str(capability) in valid, (
+                f"Unknown capability {capability!r}. Valid capabilities: {sorted(valid)}."
+            )
+
+    def test_name_normalisation_is_stable(self, provider: type[SandboxBackendPlugin]) -> None:
+        """The backend resolves identically through hyphen, underscore, and case variants."""
+        base = normalize_backend_name(self.backend)
+        for variant in (base, base.replace("_", "-"), base.upper()):
+            assert get_backend(variant) is provider, (
+                f"Backend did not resolve identically for the name variant {variant!r}."
+            )
+
+    def test_registered_as_entry_point(self, provider: type[SandboxBackendPlugin]) -> None:
+        """The backend is discoverable through the ``llm_sandbox.backends`` entry point group."""
+        if not self.expect_registered_entry_point:
+            pytest.skip("expect_registered_entry_point is False")
+
+        import llm_sandbox
+
+        names = {info.name for info in llm_sandbox.list_backends()}
+        assert normalize_backend_name(self.backend) in names, (
+            f"Backend {self.backend!r} is not listed by llm_sandbox.list_backends(). Check the "
+            f'[project.entry-points."llm_sandbox.backends"] table in pyproject.toml, and that the '
+            f"distribution is installed."
+        )
+        assert provider is not None
+
+    def test_unsupported_capabilities_raise(self, provider: type[SandboxBackendPlugin]) -> None:
+        """Undeclared optional factories raise rather than half-working."""
+        if not provider.supports(BackendCapability.POOLING):
+            with pytest.raises(UnsupportedBackendError) as excinfo:
+                provider.create_pool_manager()
+            assert "pool" in str(excinfo.value).lower()
+
+        if not provider.supports(BackendCapability.INTERACTIVE):
+            with pytest.raises(UnsupportedBackendError) as excinfo:
+                provider.create_interactive_session()
+            assert "interactive" in str(excinfo.value).lower()
+
+
+class BackendComplianceTests(BackendInterfaceComplianceTests):
+    """Full conformance suite: interface checks plus live session behaviour.
+
+    Subclass it, set `backend`, and adjust `session_kwargs` if your backend needs
+    configuration. The code snippets default to Python; override them for a backend whose
+    default language is something else.
+
+    Every test creates its own session and closes it, so a failure never leaks a container
+    into the next test.
+
+    Example:
+        ```python
+        from llm_sandbox.testing import BackendComplianceTests
+
+
+        class TestMyServiceCompliance(BackendComplianceTests):
+            backend = "myservice"
+            session_kwargs = {"lang": "python", "api_key": "test-key"}
+        ```
+
+    """
+
+    session_kwargs: ClassVar[dict[str, Any]] = {}
+    """Extra keyword arguments passed to every session created by the suite."""
+
+    hello_code: ClassVar[str] = "print('llm-sandbox-compliance')"
+    """Code that writes `hello_expected` to stdout and exits 0."""
+
+    hello_expected: ClassVar[str] = "llm-sandbox-compliance"
+    """Text `hello_code` is expected to produce on stdout."""
+
+    failing_code: ClassVar[str] = "import sys; sys.exit(3)"
+    """Code that must terminate with exit code 3."""
+
+    slow_code: ClassVar[str] = "import time; time.sleep(30)"
+    """Code that runs long enough to be cancelled by a 1-second timeout."""
+
+    timeout_seconds: ClassVar[float] = 1.0
+    """Timeout used by the timeout test."""
+
+    def make_session(self, **overrides: Any) -> Any:
+        """Create an unopened session for the backend under test.
+
+        Args:
+            **overrides: Keyword arguments merged over `session_kwargs`.
+
+        Returns:
+            Any: The session, not yet opened.
+
+        """
+        return create_session(backend=self.backend, **{**self.session_kwargs, **overrides})
+
+    # ------------------------------------------------------------------ #
+    # Interface completeness
+    # ------------------------------------------------------------------ #
+
+    def test_session_exposes_required_methods(self) -> None:
+        """The session implements every method in the required interface."""
+        session = self.make_session()
+        try:
+            missing = [name for name in _REQUIRED_SESSION_METHODS if not callable(getattr(session, name, None))]
+            assert not missing, (
+                f"Session is missing required method(s): {', '.join(missing)}. See the required "
+                f"interface in docs/plugins/authoring.md."
+            )
+        finally:
+            with contextlib.suppress(Exception):
+                session.close()
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+
+    def test_context_manager_runs_code(self) -> None:
+        """A session used as a context manager executes code and reports success."""
+        with self.make_session() as session:
+            result = session.run(self.hello_code)
+
+        assert result.exit_code == 0, f"Expected exit code 0, got {result.exit_code}. stderr: {result.stderr}"
+        assert self.hello_expected in result.stdout, (
+            f"Expected {self.hello_expected!r} in stdout, got {result.stdout!r}"
+        )
+
+    def test_run_before_open_raises(self) -> None:
+        """Running before the session is opened raises NotOpenSessionError."""
+        session = self.make_session()
+        try:
+            with pytest.raises(NotOpenSessionError):
+                session.run(self.hello_code)
+        finally:
+            with contextlib.suppress(Exception):
+                session.close()
+
+    def test_cleanup_on_exception(self) -> None:
+        """An exception inside the context manager still closes the session.
+
+        This is the check most worth having. A backend that leaks a container when the body
+        raises will pass every happy-path test and quietly cost its users money.
+        """
+        session = self.make_session()
+
+        def use_session_then_fail() -> None:
+            with session:
+                session.run(self.hello_code)
+                msg = "compliance sentinel"
+                raise RuntimeError(msg)
+
+        with pytest.raises(RuntimeError, match="compliance sentinel"):
+            use_session_then_fail()
+
+        assert session.is_open is False, (
+            "Session remained open after an exception propagated out of the context manager. "
+            "close() must release resources on the error path too."
+        )
+
+    def test_close_is_idempotent(self) -> None:
+        """Closing an already-closed session does not raise."""
+        session = self.make_session()
+        with session:
+            pass
+        session.close()
+
+    def test_close_without_open_does_not_raise(self) -> None:
+        """Closing a session that was never opened does not raise."""
+        self.make_session().close()
+
+    # ------------------------------------------------------------------ #
+    # Result types
+    # ------------------------------------------------------------------ #
+
+    def test_run_returns_console_output(self) -> None:
+        """run() returns a ConsoleOutput with correctly typed fields."""
+        with self.make_session() as session:
+            result = session.run(self.hello_code)
+
+        assert isinstance(result, ConsoleOutput), (
+            f"run() must return llm_sandbox.ConsoleOutput (or a subclass such as ExecutionResult), "
+            f"got {type(result).__name__}."
+        )
+        assert isinstance(result.exit_code, int)
+        assert isinstance(result.stdout, str)
+        assert isinstance(result.stderr, str)
+        assert result.success() is True
+
+    def test_nonzero_exit_code_is_reported(self) -> None:
+        """A failing program's exit code reaches the caller instead of being swallowed."""
+        with self.make_session() as session:
+            result = session.run(self.failing_code)
+
+        assert result.exit_code == _EXPECTED_EXIT_CODE, (
+            f"Expected exit code {_EXPECTED_EXIT_CODE}, got {result.exit_code}. Exit codes must be "
+            f"propagated, not normalised to 0 or 1."
+        )
+        assert result.success() is False
+
+    def test_execute_command_returns_console_output(self) -> None:
+        """execute_command() returns a ConsoleOutput and reports the command's output."""
+        with self.make_session() as session:
+            result = session.execute_command("echo llm-sandbox-compliance")
+
+        assert isinstance(result, ConsoleOutput)
+        assert result.exit_code == 0
+        assert "llm-sandbox-compliance" in result.stdout
+
+    # ------------------------------------------------------------------ #
+    # File transfer
+    # ------------------------------------------------------------------ #
+
+    def test_file_round_trip(self, tmp_path: Path) -> None:
+        """A file copied into the sandbox can be copied back out unchanged."""
+        payload = f"compliance-{uuid.uuid4().hex}"
+        source = tmp_path / "payload.txt"
+        source.write_text(payload)
+        destination = tmp_path / "returned.txt"
+
+        with self.make_session() as session:
+            session.copy_to_runtime(str(source), "/tmp/llm_sandbox_compliance.txt")
+            session.copy_from_runtime("/tmp/llm_sandbox_compliance.txt", str(destination))
+
+        assert destination.read_text() == payload, "File contents changed in transit."
+
+    def test_copy_to_runtime_rejects_missing_source(self, tmp_path: Path) -> None:
+        """Copying a nonexistent file raises FileNotFoundError."""
+        with self.make_session() as session, pytest.raises(FileNotFoundError):
+            session.copy_to_runtime(str(tmp_path / "does-not-exist.txt"), "/tmp/nope.txt")
+
+    # ------------------------------------------------------------------ #
+    # Declared capabilities
+    # ------------------------------------------------------------------ #
+
+    def test_artifacts_capability_works(self, tmp_path: Path) -> None:
+        """A backend declaring ARTIFACTS can actually read a file back out as a tar archive.
+
+        Checked behaviourally rather than structurally: `create_session` is a factory, so
+        there is no session class to introspect, and a method that exists but raises is not
+        the same as artifact support.
+        """
+        provider = get_backend(self.backend)
+        if not provider.supports(BackendCapability.ARTIFACTS):
+            pytest.skip("Backend does not declare the artifacts capability")
+
+        source = tmp_path / "artifact.txt"
+        source.write_text("artifact-payload")
+
+        with self.make_session() as session:
+            session.copy_to_runtime(str(source), "/tmp/llm_sandbox_artifact.txt")
+            data, stat = session.get_archive("/tmp/llm_sandbox_artifact.txt")
+
+        assert isinstance(data, bytes), "get_archive() must return tar bytes."
+        assert data, "get_archive() returned no data for a file that exists."
+        assert stat.get("size", 0) > 0, (
+            "get_archive() must report a non-zero size; callers treat size 0 as 'not found'."
+        )
+
+    def test_existing_container_capability_implies_connect(self) -> None:
+        """A backend declaring EXISTING_CONTAINER really implements the attach hook."""
+        provider = get_backend(self.backend)
+        if not provider.supports(BackendCapability.EXISTING_CONTAINER):
+            pytest.skip("Backend does not declare the existing_container capability")
+
+        from llm_sandbox.backends.base import SandboxBackendBase
+
+        session = self.make_session()
+        try:
+            session_cls = type(session)
+            override = getattr(session_cls, "connect_to_existing_container", None) or getattr(
+                session_cls, "_connect_to_existing_container", None
+            )
+            assert override is not None, (
+                "Declaring EXISTING_CONTAINER requires a connect_to_existing_container() method."
+            )
+            assert override is not SandboxBackendBase.connect_to_existing_container, (
+                "Backend declares EXISTING_CONTAINER but inherits the default, which always raises."
+            )
+        finally:
+            with contextlib.suppress(Exception):
+                session.close()
+
+    # ------------------------------------------------------------------ #
+    # Timeout
+    # ------------------------------------------------------------------ #
+
+    def test_timeout_raises_sandbox_timeout_error(self) -> None:
+        """Code exceeding its timeout raises SandboxTimeoutError."""
+        with self.make_session() as session, pytest.raises(SandboxTimeoutError):
+            session.run(self.slow_code, timeout=self.timeout_seconds)
+
+    def test_session_usable_after_timeout_cleanup(self) -> None:
+        """A timeout leaves the session closable without raising.
+
+        Backends kill the runtime to cancel work, so the session need not still be usable --
+        but tearing it down must not raise on top of the timeout.
+        """
+        session = self.make_session()
+        session.open()
+        try:
+            with contextlib.suppress(SandboxTimeoutError):
+                session.run(self.slow_code, timeout=self.timeout_seconds)
+        finally:
+            session.close()

--- a/llm_sandbox/testing/compliance.py
+++ b/llm_sandbox/testing/compliance.py
@@ -188,6 +188,30 @@ class BackendComplianceTests(BackendInterfaceComplianceTests):
     timeout_seconds: ClassVar[float] = 1.0
     """Timeout used by the timeout test."""
 
+    scratch_dir: ClassVar[str | None] = None
+    """Directory inside the sandbox to write scratch files to.
+
+    Defaults to the session's own ``workdir``. The kit deliberately does not assume ``/tmp``
+    exists or is writable in your sandbox -- a minimal image or a non-POSIX runtime may have
+    neither -- and for a backend that executes on the host, a predictable shared path is a
+    collision between concurrent runs and a symlink target on a shared machine. Override this
+    only if your sandbox needs scratch files somewhere specific.
+    """
+
+    def scratch_path(self, session: Any, name: str) -> str:
+        """Build a unique scratch path inside the sandbox.
+
+        Args:
+            session (Any): The open session the path will be used with.
+            name (str): A short label distinguishing this file from others.
+
+        Returns:
+            str: An absolute path inside the sandbox, unique to this call.
+
+        """
+        base = self.scratch_dir or getattr(getattr(session, "config", None), "workdir", "") or "."
+        return f"{base.rstrip('/')}/llm_sandbox_{name}_{uuid.uuid4().hex}.txt"
+
     def make_session(self, **overrides: Any) -> Any:
         """Create an unopened session for the backend under test.
 
@@ -322,12 +346,9 @@ class BackendComplianceTests(BackendInterfaceComplianceTests):
         source = tmp_path / "payload.txt"
         source.write_text(payload)
         destination = tmp_path / "returned.txt"
-        # Unique per run: for a host-executing backend this is a real host path, where a
-        # fixed name is both a collision between concurrent runs and a symlink-overwrite
-        # target on a shared machine.
-        remote = f"/tmp/llm_sandbox_compliance_{uuid.uuid4().hex}.txt"
 
         with self.make_session() as session:
+            remote = self.scratch_path(session, "roundtrip")
             session.copy_to_runtime(str(source), remote)
             session.copy_from_runtime(remote, str(destination))
 
@@ -336,7 +357,7 @@ class BackendComplianceTests(BackendInterfaceComplianceTests):
     def test_copy_to_runtime_rejects_missing_source(self, tmp_path: Path) -> None:
         """Copying a nonexistent file raises FileNotFoundError."""
         with self.make_session() as session, pytest.raises(FileNotFoundError):
-            session.copy_to_runtime(str(tmp_path / "does-not-exist.txt"), "/tmp/nope.txt")
+            session.copy_to_runtime(str(tmp_path / "does-not-exist.txt"), self.scratch_path(session, "missing"))
 
     # ------------------------------------------------------------------ #
     # Declared capabilities
@@ -355,9 +376,9 @@ class BackendComplianceTests(BackendInterfaceComplianceTests):
 
         source = tmp_path / "artifact.txt"
         source.write_text("artifact-payload")
-        remote = f"/tmp/llm_sandbox_artifact_{uuid.uuid4().hex}.txt"
 
         with self.make_session() as session:
+            remote = self.scratch_path(session, "artifact")
             session.copy_to_runtime(str(source), remote)
             data, stat = session.get_archive(remote)
 

--- a/llm_sandbox/testing/compliance.py
+++ b/llm_sandbox/testing/compliance.py
@@ -110,9 +110,7 @@ class BackendInterfaceComplianceTests:
         """Every declared capability is a real BackendCapability."""
         valid = {capability.value for capability in BackendCapability}
         for capability in provider.capabilities:
-            assert str(capability) in valid, (
-                f"Unknown capability {capability!r}. Valid capabilities: {sorted(valid)}."
-            )
+            assert str(capability) in valid, f"Unknown capability {capability!r}. Valid capabilities: {sorted(valid)}."
 
     def test_name_normalisation_is_stable(self, provider: type[SandboxBackendPlugin]) -> None:
         """The backend resolves identically through hyphen, underscore, and case variants."""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,9 @@ nav:
       - LLM Integrations: integrations.md
       - MCP Integration: mcp-integration.md
       - Existing Container Support: existing-container-support.md
+  - Backend Plugins:
+      - Community Plugins: plugins/index.md
+      - Writing a Plugin: plugins/authoring.md
   - Examples: examples.md
   - API Reference: api-reference.md
   - Contributing: contributing.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ podman = ["docker>=7.1.0", "podman>=5.4.0.1"]
 mcp-docker = ["docker>=7.1.0", "mcp>=1.28.1,<3"]
 mcp-podman = ["docker>=7.1.0", "mcp>=1.28.1,<3", "podman>=5.4.0.1"]
 mcp-k8s = ["kubernetes>=32.0.1", "mcp>=1.28.1,<3"]
+# Backend plugin authors install this to run llm_sandbox.testing.BackendComplianceTests
+# against their own backend. Core never imports it.
+testing = ["pytest>=7.2.0"]
 
 [dependency-groups]
 dev = [
@@ -119,6 +122,14 @@ unfixable = []
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101", "SLF001", "PLR2004", "PT019", "ARG002", "ANN201"]
+# The compliance kit is a pytest suite that happens to ship inside the package, so it needs
+# the same allowances as tests/ -- assertions above all.
+"llm_sandbox/testing/*" = ["S101", "SLF001", "PLR2004", "PT019"]
+# The reference plugin is a standalone distribution vendored for plugin authors to copy. It
+# is linted as a package in its own right, and its tests get the tests/ allowances. INP001 is
+# waived because a copied plugin lives in its own repository, where a tests/__init__.py that
+# only exists to satisfy this repo's lint config would be noise.
+"examples/plugins/*/tests/*" = ["S101", "SLF001", "PLR2004", "PT019", "ARG002", "ANN201", "INP001"]
 
 [tool.ruff.format]
 preview = true
@@ -140,6 +151,10 @@ ignore = ["DEP004"]
 # crewai, ag2, ...) that is intentionally not a project dependency: they are
 # illustrations, installed ad hoc by whoever runs one. Declaring all of them
 # would also be unresolvable, since several pin conflicting langchain versions.
+# The reference backend plugin is a separate distribution with its own pyproject.toml. Its
+# imports resolve against that project's dependencies, not this one's, so checking it here
+# reports its own package as an undeclared dependency of llm-sandbox.
+#
 # extend_exclude, not exclude: the latter replaces deptry's defaults, which
 # already skip tests/ and .venv.
-extend_exclude = ["examples/agent_sdks"]
+extend_exclude = ["examples/agent_sdks", "examples/plugins"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-sandbox"
-version = "0.3.13"
+version = "0.4.0"
 description = "LLM Sandbox is a lightweight and portable sandbox environment designed to run large language model (LLM) generated code in a safe and isolated mode."
 authors = [{ name = "Duy Huynh", email = "vndee.huynh@gmail.com" }]
 readme = "README.md"

--- a/tests/plugin_helpers.py
+++ b/tests/plugin_helpers.py
@@ -107,7 +107,8 @@ import sys
 sys.exit("plugin decided to exit during import")
 """
 
-#: A plugin that declares POOLING and returns a working pool manager.
+#: A plugin that declares POOLING (and EXISTING_CONTAINER, which pooling requires) and
+#: returns a working pool manager.
 POOLING_PLUGIN = """
 from typing import Any, ClassVar
 
@@ -125,7 +126,10 @@ class FakePoolManager:
 class Backend(SandboxBackendPlugin):
     PLUGIN_API_VERSION: ClassVar[int] = 1
     name: ClassVar[str] = "{name}"
-    capabilities: ClassVar[frozenset] = frozenset({{BackendCapability.POOLING}})
+    capabilities: ClassVar[frozenset] = frozenset({{
+        BackendCapability.POOLING,
+        BackendCapability.EXISTING_CONTAINER,
+    }})
 
     @classmethod
     def create_session(cls, *args: Any, **kwargs: Any) -> Any:

--- a/tests/plugin_helpers.py
+++ b/tests/plugin_helpers.py
@@ -185,9 +185,7 @@ def write_distribution(
 
     dist_info = root / f"{distribution.replace('-', '_')}-{version}.dist-info"
     dist_info.mkdir(parents=True, exist_ok=True)
-    (dist_info / "METADATA").write_text(
-        f"Metadata-Version: 2.1\nName: {distribution}\nVersion: {version}\n"
-    )
+    (dist_info / "METADATA").write_text(f"Metadata-Version: 2.1\nName: {distribution}\nVersion: {version}\n")
     (dist_info / "entry_points.txt").write_text(f"[{group}]\n{entry_point_name} = {module}:{attribute}\n")
     return root
 

--- a/tests/plugin_helpers.py
+++ b/tests/plugin_helpers.py
@@ -1,0 +1,173 @@
+"""Helpers for exercising the backend plugin system against real distribution metadata.
+
+Rather than mocking `importlib.metadata`, these helpers write an actual ``.dist-info``
+directory onto ``sys.path``. Entry point discovery, ``ep.dist.name``, ``ep.dist.version``,
+and ``ep.load()`` then all run for real, which is the only way to be confident the registry
+behaves the same on a user's machine as it does in CI.
+"""
+
+import importlib
+import sys
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+
+from llm_sandbox import registry
+
+#: A plugin that satisfies the contract completely.
+VALID_PLUGIN = """
+from typing import Any, ClassVar
+
+from llm_sandbox.backends import BackendCapability, SandboxBackendPlugin
+
+
+class Backend(SandboxBackendPlugin):
+    PLUGIN_API_VERSION: ClassVar[int] = 1
+    name: ClassVar[str] = "{name}"
+    capabilities: ClassVar[frozenset] = frozenset({{BackendCapability.ARTIFACTS}})
+
+    @classmethod
+    def create_session(cls, *args: Any, **kwargs: Any) -> Any:
+        return {{"backend": cls.name, "kwargs": kwargs}}
+"""
+
+#: A module that raises while being imported.
+EXPLODING_PLUGIN = """
+raise RuntimeError("plugin import blew up")
+"""
+
+#: A plugin that forgets to declare PLUGIN_API_VERSION.
+NO_VERSION_PLUGIN = """
+from typing import Any, ClassVar
+
+from llm_sandbox.backends import SandboxBackendPlugin
+
+
+class Backend(SandboxBackendPlugin):
+    name: ClassVar[str] = "{name}"
+
+    @classmethod
+    def create_session(cls, *args: Any, **kwargs: Any) -> Any:
+        return object()
+"""
+
+#: A plugin built against a plugin API version core does not accept.
+FUTURE_VERSION_PLUGIN = """
+from typing import Any, ClassVar
+
+from llm_sandbox.backends import SandboxBackendPlugin
+
+
+class Backend(SandboxBackendPlugin):
+    PLUGIN_API_VERSION: ClassVar[int] = 99
+    name: ClassVar[str] = "{name}"
+
+    @classmethod
+    def create_session(cls, *args: Any, **kwargs: Any) -> Any:
+        return object()
+"""
+
+#: An entry point resolving to something that is not a plugin class at all.
+NOT_A_PLUGIN = """
+Backend = "this is a string, not a SandboxBackendPlugin subclass"
+"""
+
+#: A plugin that never implements create_session, so it stays abstract.
+ABSTRACT_PLUGIN = """
+from typing import ClassVar
+
+from llm_sandbox.backends import SandboxBackendPlugin
+
+
+class Backend(SandboxBackendPlugin):
+    PLUGIN_API_VERSION: ClassVar[int] = 1
+    name: ClassVar[str] = "{name}"
+"""
+
+#: A plugin whose declared name disagrees with its entry point name.
+MISMATCHED_NAME_PLUGIN = """
+from typing import Any, ClassVar
+
+from llm_sandbox.backends import SandboxBackendPlugin
+
+
+class Backend(SandboxBackendPlugin):
+    PLUGIN_API_VERSION: ClassVar[int] = 1
+    name: ClassVar[str] = "something-else"
+
+    @classmethod
+    def create_session(cls, *args: Any, **kwargs: Any) -> Any:
+        return object()
+"""
+
+
+def write_distribution(
+    root: Path,
+    *,
+    distribution: str,
+    version: str,
+    module: str,
+    source: str,
+    entry_point_name: str,
+    attribute: str = "Backend",
+    group: str = "llm_sandbox.backends",
+) -> Path:
+    """Write an importable module plus the ``.dist-info`` that registers its entry point.
+
+    Args:
+        root (Path): Directory to write into. Must be added to ``sys.path`` to take effect.
+        distribution (str): Distribution name, as it appears in ``pip list``.
+        version (str): Distribution version.
+        module (str): Importable module name to create.
+        source (str): Module source. ``{name}`` is formatted with ``entry_point_name``.
+        entry_point_name (str): The name users would pass to ``backend=``.
+        attribute (str): Attribute within the module the entry point points at.
+        group (str): Entry point group.
+
+    Returns:
+        Path: The root directory, for convenience.
+
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    (root / f"{module}.py").write_text(source.format(name=entry_point_name))
+
+    dist_info = root / f"{distribution.replace('-', '_')}-{version}.dist-info"
+    dist_info.mkdir(parents=True, exist_ok=True)
+    (dist_info / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {distribution}\nVersion: {version}\n"
+    )
+    (dist_info / "entry_points.txt").write_text(f"[{group}]\n{entry_point_name} = {module}:{attribute}\n")
+    return root
+
+
+@contextmanager
+def installed(*roots: Path) -> Generator[None, None, None]:
+    """Put directories on ``sys.path`` so their distributions become discoverable.
+
+    Clears the registry cache on the way in and on the way out, and drops any modules the
+    plugins imported, so tests do not leak state into each other.
+
+    Args:
+        *roots: Directories containing modules and ``.dist-info`` directories.
+
+    Yields:
+        None: While the distributions are importable.
+
+    """
+    added = [str(root) for root in roots]
+    modules_before = set(sys.modules)
+
+    for path in added:
+        sys.path.insert(0, path)
+    importlib.invalidate_caches()
+    registry.clear_cache()
+    try:
+        yield
+    finally:
+        for path in added:
+            if path in sys.path:
+                sys.path.remove(path)
+        for name in set(sys.modules) - modules_before:
+            sys.modules.pop(name, None)
+        importlib.invalidate_caches()
+        registry.clear_cache()

--- a/tests/plugin_helpers.py
+++ b/tests/plugin_helpers.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from llm_sandbox import registry
+from llm_sandbox.backends.plugin import ENTRY_POINT_GROUP
 
 #: A plugin that satisfies the contract completely.
 VALID_PLUGIN = """
@@ -84,6 +85,57 @@ class Backend(SandboxBackendPlugin):
     name: ClassVar[str] = "{name}"
 """
 
+#: A plugin that never declares `name`, which `require()` and the optional factories read.
+NO_NAME_PLUGIN = """
+from typing import Any, ClassVar
+
+from llm_sandbox.backends import SandboxBackendPlugin
+
+
+class Backend(SandboxBackendPlugin):
+    PLUGIN_API_VERSION: ClassVar[int] = 1
+
+    @classmethod
+    def create_session(cls, *args: Any, **kwargs: Any) -> Any:
+        return object()
+"""
+
+#: A plugin that calls sys.exit() while being imported, as one might on missing config.
+SYSTEM_EXIT_PLUGIN = """
+import sys
+
+sys.exit("plugin decided to exit during import")
+"""
+
+#: A plugin that declares POOLING and returns a working pool manager.
+POOLING_PLUGIN = """
+from typing import Any, ClassVar
+
+from llm_sandbox.backends import BackendCapability, SandboxBackendPlugin
+
+
+class FakePoolManager:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.lang = kwargs.get("lang", "python")
+        self.image = None
+        self.client = object()
+
+
+class Backend(SandboxBackendPlugin):
+    PLUGIN_API_VERSION: ClassVar[int] = 1
+    name: ClassVar[str] = "{name}"
+    capabilities: ClassVar[frozenset] = frozenset({{BackendCapability.POOLING}})
+
+    @classmethod
+    def create_session(cls, *args: Any, **kwargs: Any) -> Any:
+        return {{"backend": cls.name}}
+
+    @classmethod
+    def create_pool_manager(cls, **kwargs: Any) -> Any:
+        return FakePoolManager(**kwargs)
+"""
+
 #: A plugin whose declared name disagrees with its entry point name.
 MISMATCHED_NAME_PLUGIN = """
 from typing import Any, ClassVar
@@ -110,7 +162,7 @@ def write_distribution(
     source: str,
     entry_point_name: str,
     attribute: str = "Backend",
-    group: str = "llm_sandbox.backends",
+    group: str = ENTRY_POINT_GROUP,
 ) -> Path:
     """Write an importable module plus the ``.dist-info`` that registers its entry point.
 

--- a/tests/test_backends_plugin.py
+++ b/tests/test_backends_plugin.py
@@ -95,6 +95,7 @@ class TestSandboxBackendPlugin:
 
     def test_create_session_is_abstract(self) -> None:
         """Create session is abstract."""
+
         class Incomplete(SandboxBackendPlugin):
             PLUGIN_API_VERSION: ClassVar[int] = 1
             name: ClassVar[str] = "incomplete"
@@ -113,6 +114,7 @@ class TestSandboxBackendPlugin:
 
     def test_supports_and_require(self) -> None:
         """Supports and require."""
+
         class Capable(_MinimalPlugin):
             capabilities: ClassVar[frozenset[BackendCapability]] = frozenset({BackendCapability.ARTIFACTS})
 

--- a/tests/test_backends_plugin.py
+++ b/tests/test_backends_plugin.py
@@ -1,0 +1,329 @@
+"""Tests for the frozen plugin contract and the public backend base class."""
+
+import dataclasses
+import importlib
+from typing import Any, ClassVar
+
+import pytest
+
+import llm_sandbox
+from llm_sandbox.backends import (
+    ENTRY_POINT_GROUP,
+    PLUGIN_API_VERSION,
+    SUPPORTED_PLUGIN_API_VERSIONS,
+    BackendCapability,
+    BackendInfo,
+    SandboxBackendBase,
+    SandboxBackendPlugin,
+)
+from llm_sandbox.core.config import SessionConfig
+from llm_sandbox.exceptions import (
+    BackendCapabilityError,
+    BackendLoadError,
+    BackendNameConflictError,
+    BackendNotFoundError,
+    SandboxError,
+    UnsupportedBackendError,
+)
+
+
+class _MinimalPlugin(SandboxBackendPlugin):
+    """The smallest thing that satisfies the contract."""
+
+    PLUGIN_API_VERSION: ClassVar[int] = 1
+    name: ClassVar[str] = "minimal"
+
+    @classmethod
+    def create_session(cls, *args: Any, **kwargs: Any) -> Any:
+        return {"args": args, "kwargs": kwargs}
+
+
+class _StubSession(SandboxBackendBase):
+    """A concrete SandboxBackendBase used to exercise the bridges."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.calls: list[tuple[str, Any]] = []
+
+    def open(self) -> None:
+        super().open()
+
+    def close(self) -> None:
+        super().close()
+
+    def handle_timeout(self) -> None:
+        self.calls.append(("handle_timeout", None))
+
+    def ensure_directory_exists(self, path: str) -> None:
+        self.calls.append(("ensure_directory_exists", path))
+
+    def ensure_ownership(self, paths: list[str]) -> None:
+        self.calls.append(("ensure_ownership", paths))
+
+    def process_non_stream_output(self, output: Any) -> tuple[str, str]:
+        self.calls.append(("process_non_stream_output", output))
+        return "out", "err"
+
+    def process_stream_output(
+        self,
+        output: Any,
+        on_stdout: Any = None,
+        on_stderr: Any = None,
+    ) -> tuple[str, str]:
+        self.calls.append(("process_stream_output", (output, on_stdout, on_stderr)))
+        return "sout", "serr"
+
+
+class TestPluginApiVersion:
+    """The version constant is the compatibility contract."""
+
+    def test_current_version_is_supported(self) -> None:
+        """Current version is supported."""
+        assert PLUGIN_API_VERSION in SUPPORTED_PLUGIN_API_VERSIONS
+
+    def test_supported_versions_is_immutable(self) -> None:
+        """Supported versions is immutable."""
+        assert isinstance(SUPPORTED_PLUGIN_API_VERSIONS, frozenset)
+
+    def test_entry_point_group_is_stable(self) -> None:
+        """Changing this breaks every published plugin, so pin it in a test."""
+        assert ENTRY_POINT_GROUP == "llm_sandbox.backends"
+
+
+class TestSandboxBackendPlugin:
+    """The registered descriptor."""
+
+    def test_create_session_is_abstract(self) -> None:
+        """Create session is abstract."""
+        class Incomplete(SandboxBackendPlugin):
+            PLUGIN_API_VERSION: ClassVar[int] = 1
+            name: ClassVar[str] = "incomplete"
+
+        assert "create_session" in Incomplete.__abstractmethods__
+
+    def test_forwards_positional_and_keyword_arguments(self) -> None:
+        """Forwards positional and keyword arguments."""
+        result = _MinimalPlugin.create_session("positional", lang="python")
+
+        assert result == {"args": ("positional",), "kwargs": {"lang": "python"}}
+
+    def test_capabilities_default_to_empty(self) -> None:
+        """Capabilities default to empty."""
+        assert _MinimalPlugin.capabilities == frozenset()
+
+    def test_supports_and_require(self) -> None:
+        """Supports and require."""
+        class Capable(_MinimalPlugin):
+            capabilities: ClassVar[frozenset[BackendCapability]] = frozenset({BackendCapability.ARTIFACTS})
+
+        assert Capable.supports(BackendCapability.ARTIFACTS)
+        assert not Capable.supports(BackendCapability.POOLING)
+        Capable.require(BackendCapability.ARTIFACTS)
+
+        with pytest.raises(BackendCapabilityError):
+            Capable.require(BackendCapability.POOLING)
+
+    def test_optional_factories_raise_by_default(self) -> None:
+        """Optional factories raise by default."""
+        with pytest.raises(BackendCapabilityError, match="pooling"):
+            _MinimalPlugin.create_pool_manager()
+
+        with pytest.raises(BackendCapabilityError, match="interactive"):
+            _MinimalPlugin.create_interactive_session()
+
+    def test_capability_values_are_stable(self) -> None:
+        """Capability strings appear in plugin source; they are contract."""
+        assert {capability.value for capability in BackendCapability} == {
+            "artifacts",
+            "interactive",
+            "pooling",
+            "existing_container",
+        }
+
+
+class TestSandboxBackendBase:
+    """The public base class bridges BaseSession's private contract."""
+
+    def test_builds_config_from_kwargs(self) -> None:
+        """Builds config from kwargs."""
+        session = _StubSession(lang="python", workdir="/tmp/example", verbose=True)
+
+        assert isinstance(session.config, SessionConfig)
+        assert session.config.workdir == "/tmp/example"
+        assert session.config.verbose is True
+
+    def test_accepts_a_prebuilt_config(self) -> None:
+        """Accepts a prebuilt config."""
+        config = SessionConfig(workdir="/tmp/prebuilt")
+        session = _StubSession(config=config)
+
+        assert session.config is config
+
+    def test_unrecognised_kwargs_reach_base_session(self) -> None:
+        """Unrecognised kwargs reach base session."""
+        session = _StubSession(lang="python", libraries=["numpy"])
+
+        assert session._initial_libraries == ["numpy"]
+
+    def test_stream_defaults_to_false(self) -> None:
+        """Stream defaults to false."""
+        assert _StubSession().stream is False
+        assert _StubSession(stream=True).stream is True
+
+    @pytest.mark.parametrize(
+        ("private", "public", "args"),
+        [
+            ("_handle_timeout", "handle_timeout", ()),
+            ("_ensure_directory_exists", "ensure_directory_exists", ("/tmp/dir",)),
+            ("_ensure_ownership", "ensure_ownership", (["/tmp/a"],)),
+            ("_process_non_stream_output", "process_non_stream_output", ("payload",)),
+        ],
+    )
+    def test_private_hooks_bridge_to_public_ones(self, private: str, public: str, args: tuple) -> None:
+        """Private hooks bridge to public ones."""
+        session = _StubSession()
+
+        getattr(session, private)(*args)
+
+        assert session.calls[-1][0] == public
+
+    def test_stream_bridge_forwards_callbacks(self) -> None:
+        """Stream bridge forwards callbacks."""
+        session = _StubSession()
+
+        def on_stdout(_chunk: str) -> None: ...
+
+        result = session._process_stream_output("payload", on_stdout=on_stdout)
+
+        assert result == ("sout", "serr")
+        name, (output, stdout_cb, stderr_cb) = session.calls[-1]
+        assert name == "process_stream_output"
+        assert output == "payload"
+        assert stdout_cb is on_stdout
+        assert stderr_cb is None
+
+    def test_optional_hooks_raise_when_not_overridden(self) -> None:
+        """Optional hooks raise when not overridden."""
+        session = _StubSession()
+
+        with pytest.raises(BackendCapabilityError, match="artifacts"):
+            session.get_archive("/tmp/whatever")
+
+        with pytest.raises(BackendCapabilityError, match="existing_container"):
+            session.connect_to_existing_container("abc123")
+
+    def test_required_hooks_are_abstract(self) -> None:
+        """Required hooks are abstract."""
+        expected = {
+            "handle_timeout",
+            "ensure_directory_exists",
+            "ensure_ownership",
+            "process_non_stream_output",
+            "process_stream_output",
+            "open",
+            "close",
+        }
+        assert expected <= set(SandboxBackendBase.__abstractmethods__)
+
+
+class TestExceptionHierarchy:
+    """New errors must not break `except UnsupportedBackendError` downstream."""
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            BackendNotFoundError("x", "message"),
+            BackendLoadError("x", "message"),
+            BackendNameConflictError("x", "message"),
+            BackendCapabilityError("x", "pooling"),
+        ],
+    )
+    def test_all_subclass_unsupported_backend_error(self, error: Exception) -> None:
+        """All subclass unsupported backend error."""
+        assert isinstance(error, UnsupportedBackendError)
+        assert isinstance(error, SandboxError)
+
+    def test_unsupported_backend_error_message_unchanged(self) -> None:
+        """Pinned by tests/test_exceptions.py; restated here because plugins depend on it."""
+        assert str(UnsupportedBackendError("invalid_backend")) == "Unsupported backend: invalid_backend"
+
+    def test_backend_attribute_is_exposed(self) -> None:
+        """Backend attribute is exposed."""
+        assert UnsupportedBackendError("tenki").backend == "tenki"
+        assert BackendNotFoundError("tenki", "msg").backend == "tenki"
+
+    def test_load_error_records_distribution(self) -> None:
+        """Load error records distribution."""
+        error = BackendLoadError("tenki", "msg", "llm-sandbox-tenki")
+        assert error.distribution == "llm-sandbox-tenki"
+
+    def test_conflict_error_records_distributions(self) -> None:
+        """Conflict error records distributions."""
+        error = BackendNameConflictError("tenki", "msg", ("a", "b"))
+        assert error.distributions == ("a", "b")
+
+
+class TestPublicSurface:
+    """Names plugin authors depend on must be importable from documented paths."""
+
+    def test_backends_module_exports(self) -> None:
+        """Backends module exports."""
+        module = importlib.import_module("llm_sandbox.backends")
+
+        for name in module.__all__:
+            assert hasattr(module, name), f"llm_sandbox.backends.__all__ lists missing name {name!r}"
+
+    def test_top_level_exports(self) -> None:
+        """Top level exports."""
+        for name in llm_sandbox.__all__:
+            assert hasattr(llm_sandbox, name), f"llm_sandbox.__all__ lists missing name {name!r}"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "list_backends",
+            "BackendNotFoundError",
+            "BackendLoadError",
+            "BackendNameConflictError",
+            "BackendCapabilityError",
+            "BackendShadowWarning",
+            "BackendNameMismatchWarning",
+            "UnsupportedBackendError",
+            "SandboxTimeoutError",
+            "NotOpenSessionError",
+            "CommandFailedError",
+            "MissingDependencyError",
+            "LibraryInstallationNotSupportedError",
+        ],
+    )
+    def test_plugin_facing_names_are_top_level(self, name: str) -> None:
+        """Plugin facing names are top level."""
+        assert name in llm_sandbox.__all__
+        assert hasattr(llm_sandbox, name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "SandboxBackendPlugin",
+            "SandboxBackendBase",
+            "BackendCapability",
+            "BackendInfo",
+            "BaseSession",
+            "ContainerAPI",
+            "PLUGIN_API_VERSION",
+            "SUPPORTED_PLUGIN_API_VERSIONS",
+            "ENTRY_POINT_GROUP",
+            "normalize_backend_name",
+        ],
+    )
+    def test_plugin_authoring_names_are_in_backends(self, name: str) -> None:
+        """Plugin authoring names are in backends."""
+        module = importlib.import_module("llm_sandbox.backends")
+        assert name in module.__all__
+        assert hasattr(module, name)
+
+    def test_backend_info_is_frozen(self) -> None:
+        """Backend info is frozen."""
+        info = BackendInfo(name="x")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            info.name = "y"  # type: ignore[misc]

--- a/tests/test_backends_plugin.py
+++ b/tests/test_backends_plugin.py
@@ -235,7 +235,7 @@ class TestExceptionHierarchy:
             BackendNotFoundError("x", "message"),
             BackendLoadError("x", "message"),
             BackendNameConflictError("x", "message"),
-            BackendCapabilityError("x", "pooling"),
+            BackendCapabilityError("x", capability="pooling"),
         ],
     )
     def test_all_subclass_unsupported_backend_error(self, error: Exception) -> None:

--- a/tests/test_example_plugin.py
+++ b/tests/test_example_plugin.py
@@ -15,12 +15,28 @@ from pathlib import Path
 
 import pytest
 
-from llm_sandbox import create_session, list_backends
+from llm_sandbox import ArtifactSandboxSession, create_session, list_backends
 from llm_sandbox.backends import BackendCapability
 from llm_sandbox.exceptions import BackendCapabilityError
 from llm_sandbox.registry import get_backend
 from llm_sandbox.testing import BackendComplianceTests
-from tests.plugin_helpers import installed
+from tests.plugin_helpers import installed, write_distribution
+
+#: A plugin that declares no capabilities at all.
+NO_CAPABILITY_PLUGIN = '''
+from typing import Any, ClassVar
+
+from llm_sandbox.backends import SandboxBackendPlugin
+
+
+class Backend(SandboxBackendPlugin):
+    PLUGIN_API_VERSION: ClassVar[int] = 1
+    name: ClassVar[str] = "{name}"
+
+    @classmethod
+    def create_session(cls, *args: Any, **kwargs: Any) -> Any:
+        return object()
+'''
 
 EXAMPLE_PLUGIN_ROOT = Path(__file__).parent.parent / "examples" / "plugins" / "llm-sandbox-example"
 EXAMPLE_PLUGIN_SRC = EXAMPLE_PLUGIN_ROOT / "src"
@@ -111,3 +127,82 @@ class TestExamplePluginCompliance(BackendComplianceTests):
 
     backend = "example"
     session_kwargs = {"lang": "python"}  # noqa: RUF012
+
+
+class TestArtifactSessionWithAPlugin:
+    """Regression: ArtifactSandboxSession is the only consumer of BackendCapability.ARTIFACTS.
+
+    It forwards ``runtime_configs=None`` and ``workdir="/sandbox"`` unconditionally, which
+    used to reach SessionConfig as a pydantic ValidationError -- not even a SandboxError, so
+    `except SandboxError` downstream would not catch it.
+    """
+
+    def test_artifact_session_runs_against_a_plugin(self, example_plugin: None) -> None:
+        """The plugin's declared capability actually works end to end."""
+        with ArtifactSandboxSession(backend="example", lang="python") as session:
+            result = session.run("print('artifacts ok')")
+
+        assert result.exit_code == 0
+        assert "artifacts ok" in result.stdout
+
+    def test_artifact_session_maps_the_container_workdir(self, example_plugin: None) -> None:
+        """A host-executing backend must not be handed core's in-container default verbatim."""
+        session = ArtifactSandboxSession(backend="example", lang="python")
+        with session:
+            assert session._session.config.workdir != "/sandbox"
+
+    def test_backend_without_artifacts_is_refused_before_construction(
+        self, tmp_path: Path
+    ) -> None:
+        """A backend that cannot do artifacts fails up front, not mid-run with a live container."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-plain",
+            version="0.1.0",
+            module="plain_backend",
+            source=NO_CAPABILITY_PLUGIN,
+            entry_point_name="plain",
+        )
+        with installed(root), pytest.raises(BackendCapabilityError, match="artifacts"):
+            ArtifactSandboxSession(backend="plain", lang="python")
+
+    def test_existing_container_is_refused_when_undeclared(self, tmp_path: Path) -> None:
+        """container_id= requires the EXISTING_CONTAINER capability."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-plain",
+            version="0.1.0",
+            module="plain_backend",
+            source=NO_CAPABILITY_PLUGIN,
+            entry_point_name="plain",
+        )
+        with installed(root), pytest.raises(BackendCapabilityError, match="existing_container"):
+            create_session(backend="plain", container_id="abc123")
+
+
+class TestExamplePluginWorkdirOwnership:
+    """Mirrors the reference plugin's own tests, which this repo's CI does not collect.
+
+    Whether a backend deletes a directory the caller supplied is exactly the irreversible
+    class of bug worth guarding in CI.
+    """
+
+    def test_temporary_workdir_is_removed_on_close(self, example_plugin: None) -> None:
+        """A directory the backend created is cleaned up."""
+        session = create_session(backend="example", lang="python")
+        workdir = Path(session.config.workdir)
+
+        with session:
+            assert workdir.exists()
+
+        assert not workdir.exists(), "Session leaked its temporary working directory"
+
+    def test_caller_supplied_workdir_is_left_alone(self, example_plugin: None, tmp_path: Path) -> None:
+        """A directory the caller named is never deleted."""
+        workdir = tmp_path / "mine"
+        workdir.mkdir()
+
+        with create_session(backend="example", lang="python", workdir=str(workdir)) as session:
+            session.run("print('hello')")
+
+        assert workdir.exists(), "Backend deleted a directory it did not create"

--- a/tests/test_example_plugin.py
+++ b/tests/test_example_plugin.py
@@ -23,7 +23,7 @@ from llm_sandbox.testing import BackendComplianceTests
 from tests.plugin_helpers import installed, write_distribution
 
 #: A plugin that declares no capabilities at all.
-NO_CAPABILITY_PLUGIN = '''
+NO_CAPABILITY_PLUGIN = """
 from typing import Any, ClassVar
 
 from llm_sandbox.backends import SandboxBackendPlugin
@@ -36,7 +36,7 @@ class Backend(SandboxBackendPlugin):
     @classmethod
     def create_session(cls, *args: Any, **kwargs: Any) -> Any:
         return object()
-'''
+"""
 
 EXAMPLE_PLUGIN_ROOT = Path(__file__).parent.parent / "examples" / "plugins" / "llm-sandbox-example"
 EXAMPLE_PLUGIN_SRC = EXAMPLE_PLUGIN_ROOT / "src"
@@ -54,9 +54,7 @@ def _write_dist_info(target: Path) -> Path:
     """
     dist_info = target / "llm_sandbox_example-0.1.0.dist-info"
     dist_info.mkdir(parents=True, exist_ok=True)
-    (dist_info / "METADATA").write_text(
-        "Metadata-Version: 2.1\nName: llm-sandbox-example\nVersion: 0.1.0\n"
-    )
+    (dist_info / "METADATA").write_text("Metadata-Version: 2.1\nName: llm-sandbox-example\nVersion: 0.1.0\n")
     (dist_info / "entry_points.txt").write_text(
         "[llm_sandbox.backends]\nexample = llm_sandbox_example:ExampleBackend\n"
     )
@@ -151,9 +149,7 @@ class TestArtifactSessionWithAPlugin:
         with session:
             assert session._session.config.workdir != "/sandbox"
 
-    def test_backend_without_artifacts_is_refused_before_construction(
-        self, tmp_path: Path
-    ) -> None:
+    def test_backend_without_artifacts_is_refused_before_construction(self, tmp_path: Path) -> None:
         """A backend that cannot do artifacts fails up front, not mid-run with a live container."""
         root = write_distribution(
             tmp_path / "site",

--- a/tests/test_example_plugin.py
+++ b/tests/test_example_plugin.py
@@ -1,0 +1,113 @@
+"""End-to-end test of the reference plugin, through the real entry point machinery.
+
+This is the one test that proves the whole chain works together: a distribution on
+``sys.path`` registers an entry point, the registry discovers and loads it, `create_session`
+routes to it, and the compliance kit passes against the result.
+
+The reference plugin lives in ``examples/plugins/llm-sandbox-example/`` and is not installed
+into the development environment, so the ``.dist-info`` that registers it is fabricated here.
+Everything downstream of that -- discovery, loading, session lifecycle -- is real.
+"""
+
+import sys
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from llm_sandbox import create_session, list_backends
+from llm_sandbox.backends import BackendCapability
+from llm_sandbox.exceptions import BackendCapabilityError
+from llm_sandbox.registry import get_backend
+from llm_sandbox.testing import BackendComplianceTests
+from tests.plugin_helpers import installed
+
+EXAMPLE_PLUGIN_ROOT = Path(__file__).parent.parent / "examples" / "plugins" / "llm-sandbox-example"
+EXAMPLE_PLUGIN_SRC = EXAMPLE_PLUGIN_ROOT / "src"
+
+
+def _write_dist_info(target: Path) -> Path:
+    """Fabricate the ``.dist-info`` pip would install for the reference plugin.
+
+    Args:
+        target (Path): Directory to write the metadata into.
+
+    Returns:
+        Path: The directory containing the metadata.
+
+    """
+    dist_info = target / "llm_sandbox_example-0.1.0.dist-info"
+    dist_info.mkdir(parents=True, exist_ok=True)
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: llm-sandbox-example\nVersion: 0.1.0\n"
+    )
+    (dist_info / "entry_points.txt").write_text(
+        "[llm_sandbox.backends]\nexample = llm_sandbox_example:ExampleBackend\n"
+    )
+    return target
+
+
+@pytest.fixture
+def example_plugin(tmp_path: Path) -> Generator[None, None, None]:
+    """Make the reference plugin discoverable as an installed distribution."""
+    metadata_root = _write_dist_info(tmp_path / "site")
+    with installed(metadata_root, EXAMPLE_PLUGIN_SRC):
+        yield
+
+
+class TestExamplePluginRegistration:
+    """The reference plugin registers and resolves like any third-party backend."""
+
+    def test_appears_in_list_backends(self, example_plugin: None) -> None:
+        """Appears in list backends."""
+        info = next(item for item in list_backends() if item.name == "example")
+
+        assert info.is_builtin is False
+        assert info.distribution == "llm-sandbox-example"
+        assert info.version == "0.1.0"
+        assert info.entry_point == "llm_sandbox_example:ExampleBackend"
+
+    def test_not_imported_until_requested(self, example_plugin: None) -> None:
+        """Not imported until requested."""
+        list_backends()
+        assert "llm_sandbox_example" not in sys.modules
+
+        get_backend("example")
+        assert "llm_sandbox_example" in sys.modules
+
+    def test_declares_artifacts_only(self, example_plugin: None) -> None:
+        """Declares artifacts only."""
+        provider = get_backend("example")
+
+        assert provider.supports(BackendCapability.ARTIFACTS)
+        assert not provider.supports(BackendCapability.POOLING)
+        assert not provider.supports(BackendCapability.INTERACTIVE)
+
+    def test_undeclared_capabilities_raise(self, example_plugin: None) -> None:
+        """Undeclared capabilities raise."""
+        provider = get_backend("example")
+
+        with pytest.raises(BackendCapabilityError):
+            provider.create_pool_manager()
+        with pytest.raises(BackendCapabilityError):
+            provider.create_interactive_session()
+
+    def test_create_session_routes_to_the_plugin(self, example_plugin: None) -> None:
+        """Create session routes to the plugin."""
+        session = create_session(backend="example", lang="python")
+        try:
+            assert type(session).__name__ == "LocalSandboxSession"
+        finally:
+            session.close()
+
+
+@pytest.mark.usefixtures("example_plugin")
+class TestExamplePluginCompliance(BackendComplianceTests):
+    """Run the published compliance kit against the reference plugin.
+
+    A plugin author writes exactly this much in their own repository. If the kit is wrong,
+    or the reference plugin is wrong, this fails.
+    """
+
+    backend = "example"
+    session_kwargs = {"lang": "python"}  # noqa: RUF012

--- a/tests/test_pool_session.py
+++ b/tests/test_pool_session.py
@@ -556,17 +556,41 @@ class TestPooledSessionBackendCreation:
         finally:
             pool.close()
 
-    def test_infer_backend_failure(self) -> None:
-        """Test failure to infer backend from pool manager."""
+    def test_resolve_backend_name_failure(self) -> None:
+        """A pool manager that declares no backend_name is rejected with actionable guidance."""
         pool = MagicMock()
-        pool.__class__.__name__ = "UnknownPoolManager"
+        pool.backend_name = ""
 
-        # We need to bypass __init__ because it calls _infer_backend_from_pool
         session = PooledSandboxSession.__new__(PooledSandboxSession)
         session._pool_manager = pool
 
-        with pytest.raises(RuntimeError, match="Cannot infer backend"):
-            session._infer_backend_from_pool()
+        with pytest.raises(RuntimeError, match="does not declare `backend_name`"):
+            session._resolve_backend_name()
+
+    def test_resolve_backend_name_normalises(self) -> None:
+        """The declared name is normalised, so a plugin's hyphenated name resolves."""
+        pool = MagicMock()
+        pool.backend_name = "My-Service"
+
+        session = PooledSandboxSession.__new__(PooledSandboxSession)
+        session._pool_manager = pool
+
+        assert session._resolve_backend_name() == "my_service"
+
+    def test_backend_name_is_not_guessed_from_class_name(self) -> None:
+        """A manager whose class name merely contains 'Docker' is not routed to Docker.
+
+        The previous implementation matched on the class name as a substring, so any
+        third-party manager named e.g. MyDockerlikePoolManager was silently misrouted.
+        """
+        pool = MagicMock()
+        pool.__class__.__name__ = "MyDockerlikePoolManager"
+        pool.backend_name = "mydockerlike"
+
+        session = PooledSandboxSession.__new__(PooledSandboxSession)
+        session._pool_manager = pool
+
+        assert session._resolve_backend_name() == "mydockerlike"
 
     def test_open_no_pool_manager(self) -> None:
         """Test open raises RuntimeError if pool manager is missing."""
@@ -587,12 +611,19 @@ class TestPooledSessionBackendCreation:
         session.close()
 
     def test_create_backend_session_unsupported(self) -> None:
-        """Test _create_backend_session with unsupported backend."""
-        session = PooledSandboxSession.__new__(PooledSandboxSession)
-        session.backend = "unsupported"  # type: ignore[assignment]
-        session._session_kwargs = {}
+        """An unknown backend name surfaces the registry's typed error, not a bare RuntimeError."""
+        from llm_sandbox.exceptions import UnsupportedBackendError
 
-        with pytest.raises(RuntimeError, match="Unsupported backend"):
+        pool = MagicMock()
+        pool.backend_name = "unsupported"
+
+        session = PooledSandboxSession.__new__(PooledSandboxSession)
+        session._pool_manager = pool
+        session.backend = "unsupported"
+        session._session_kwargs = {}
+        session._stream = False
+
+        with pytest.raises(UnsupportedBackendError, match="Unknown backend"):
             session._create_backend_session("id")
 
     def test_methods_raise_if_not_open(self) -> None:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,498 @@
+"""Tests for backend discovery, resolution, and error reporting."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from llm_sandbox import list_backends, registry
+from llm_sandbox.backends.builtin import BUILTIN_BACKENDS, DockerBackend, MicromambaBackend
+from llm_sandbox.backends.plugin import BackendCapability, SandboxBackendPlugin, normalize_backend_name
+from llm_sandbox.exceptions import (
+    BackendCapabilityError,
+    BackendLoadError,
+    BackendNameConflictError,
+    BackendNotFoundError,
+    UnsupportedBackendError,
+)
+from llm_sandbox.registry import BackendNameMismatchWarning, BackendShadowWarning, get_backend
+from tests.plugin_helpers import (
+    ABSTRACT_PLUGIN,
+    EXPLODING_PLUGIN,
+    FUTURE_VERSION_PLUGIN,
+    MISMATCHED_NAME_PLUGIN,
+    NO_VERSION_PLUGIN,
+    NOT_A_PLUGIN,
+    VALID_PLUGIN,
+    installed,
+    write_distribution,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> None:
+    """Keep discovery state from leaking between tests."""
+    registry.clear_cache()
+
+
+class TestNameNormalisation:
+    """Backend names are case-insensitive and hyphen/underscore agnostic."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("docker", "docker"),
+            ("Docker", "docker"),
+            ("DOCKER", "docker"),
+            ("my-service", "my_service"),
+            ("my_service", "my_service"),
+            ("MY-SERVICE", "my_service"),
+            ("  spaced  ", "spaced"),
+        ],
+    )
+    def test_normalisation(self, raw: str, expected: str) -> None:
+        """Normalisation."""
+        assert normalize_backend_name(raw) == expected
+
+    def test_builtin_resolves_through_variants(self) -> None:
+        """Builtin resolves through variants."""
+        for variant in ("docker", "Docker", "DOCKER", " docker "):
+            assert get_backend(variant) is DockerBackend
+
+
+class TestBuiltins:
+    """Built-in backends resolve without touching entry points at all."""
+
+    def test_all_four_builtins_resolve(self) -> None:
+        """All four builtins resolve."""
+        for name in ("docker", "kubernetes", "podman", "micromamba"):
+            assert issubclass(get_backend(name), SandboxBackendPlugin)
+
+    def test_discovery_runs_once_and_is_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Metadata is scanned once per process, however many backends are resolved."""
+        calls: list[int] = []
+
+        def counting() -> list[object]:
+            calls.append(1)
+            return []
+
+        monkeypatch.setattr(registry, "_entry_points", counting)
+
+        get_backend("docker")
+        get_backend("podman")
+        get_backend("docker")
+
+        assert len(calls) == 1, f"Entry points scanned {len(calls)} times; expected exactly one cached scan"
+
+    def test_micromamba_declares_no_interactive_or_pooling(self) -> None:
+        """Preserves long-standing behaviour: neither has ever worked for micromamba."""
+        assert not MicromambaBackend.supports(BackendCapability.INTERACTIVE)
+        assert not MicromambaBackend.supports(BackendCapability.POOLING)
+        assert MicromambaBackend.supports(BackendCapability.ARTIFACTS)
+
+    def test_require_raises_backend_capability_error(self) -> None:
+        """Require raises backend capability error."""
+        with pytest.raises(BackendCapabilityError) as excinfo:
+            MicromambaBackend.require(BackendCapability.POOLING)
+
+        assert isinstance(excinfo.value, UnsupportedBackendError)
+        assert "pooling" in str(excinfo.value)
+
+
+class TestUnknownBackendMessage:
+    """The unknown-backend message is most plugin users' entire onboarding experience."""
+
+    def test_names_builtins_and_suggests_install(self) -> None:
+        """Names builtins and suggests install."""
+        with pytest.raises(BackendNotFoundError) as excinfo:
+            get_backend("tenki")
+
+        message = str(excinfo.value)
+        assert "Unknown backend 'tenki'." in message
+        assert "Built-in backends: docker, kubernetes, micromamba, podman." in message
+        assert "No installed package provides 'tenki'." in message
+        assert "pip install llm-sandbox-tenki" in message
+        assert "INTEGRATIONS.md" in message
+
+    def test_subclasses_unsupported_backend_error_for_compatibility(self) -> None:
+        """Downstream `except UnsupportedBackendError` must keep working."""
+        with pytest.raises(UnsupportedBackendError):
+            get_backend("nope")
+
+    def test_underscored_name_suggests_hyphenated_package(self) -> None:
+        """Underscored name suggests hyphenated package."""
+        with pytest.raises(BackendNotFoundError) as excinfo:
+            get_backend("my_service")
+
+        assert "pip install llm-sandbox-my-service" in str(excinfo.value)
+
+    def test_typo_of_builtin_gets_did_you_mean(self) -> None:
+        """Typo of builtin gets did you mean."""
+        with pytest.raises(BackendNotFoundError) as excinfo:
+            get_backend("dokcer")
+
+        assert "Did you mean 'docker'?" in str(excinfo.value)
+
+    def test_typo_of_installed_plugin_lists_it(self, tmp_path: Path) -> None:
+        """Typo of installed plugin lists it."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-tenki",
+            version="0.1.0",
+            module="tenki_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="tenki",
+        )
+        with installed(root), pytest.raises(BackendNotFoundError) as excinfo:
+            get_backend("tenkki")
+
+        message = str(excinfo.value)
+        assert "Installed plugin backends: tenki (llm-sandbox-tenki 0.1.0)." in message
+        assert "Did you mean 'tenki'?" in message
+
+
+class TestDiscoveryAndLoading:
+    """Discovery reads metadata; loading imports. They must stay separate."""
+
+    def test_plugin_resolves_and_creates_session(self, tmp_path: Path) -> None:
+        """Plugin resolves and creates session."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-tenki",
+            version="1.2.3",
+            module="tenki_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="tenki",
+        )
+        with installed(root):
+            provider = get_backend("tenki")
+
+            assert provider.name == "tenki"
+            assert provider.create_session(lang="python") == {"backend": "tenki", "kwargs": {"lang": "python"}}
+
+    def test_plugin_resolves_through_name_variants(self, tmp_path: Path) -> None:
+        """Plugin resolves through name variants."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-my-service",
+            version="0.1.0",
+            module="my_service_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="my-service",
+        )
+        with installed(root):
+            provider = get_backend("my-service")
+            assert get_backend("my_service") is provider
+            assert get_backend("MY_SERVICE") is provider
+
+    def test_discovery_does_not_import_the_plugin(self, tmp_path: Path) -> None:
+        """Listing backends must never execute third-party code."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-tenki",
+            version="0.1.0",
+            module="tenki_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="tenki",
+        )
+        with installed(root):
+            backends = list_backends()
+            assert "tenki" in {info.name for info in backends}
+            assert "tenki_backend" not in sys.modules, "list_backends() imported the plugin module"
+
+            get_backend("tenki")
+            assert "tenki_backend" in sys.modules, "get_backend() did not import the plugin"
+
+    def test_load_is_cached(self, tmp_path: Path) -> None:
+        """Load is cached."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-tenki",
+            version="0.1.0",
+            module="tenki_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="tenki",
+        )
+        with installed(root):
+            assert get_backend("tenki") is get_backend("tenki")
+
+    def test_importing_llm_sandbox_does_not_load_plugins(self, tmp_path: Path) -> None:
+        """The security property: installing a plugin must not get it imported on start-up."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-tenki",
+            version="0.1.0",
+            module="tenki_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="tenki",
+        )
+        with installed(root):
+            import llm_sandbox
+
+            llm_sandbox.create_session  # noqa: B018
+            assert "tenki_backend" not in sys.modules
+
+
+class TestFailureIsolation:
+    """A broken plugin fails only the request that names it."""
+
+    @pytest.mark.parametrize(
+        ("source", "expected_fragment"),
+        [
+            (EXPLODING_PLUGIN, "failed to load"),
+            (NOT_A_PLUGIN, "must resolve to a subclass"),
+            (NO_VERSION_PLUGIN, "does not declare PLUGIN_API_VERSION"),
+            (FUTURE_VERSION_PLUGIN, "targets plugin API version 99"),
+            (ABSTRACT_PLUGIN, "does not implement create_session"),
+        ],
+    )
+    def test_broken_plugin_raises_backend_load_error(
+        self, tmp_path: Path, source: str, expected_fragment: str
+    ) -> None:
+        """Broken plugin raises backend load error."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-broken",
+            version="0.1.0",
+            module="broken_backend",
+            source=source,
+            entry_point_name="broken",
+        )
+        with installed(root), pytest.raises(BackendLoadError) as excinfo:
+            get_backend("broken")
+
+        message = str(excinfo.value)
+        assert expected_fragment in message
+        assert "llm-sandbox-broken" in message, "Error must name the offending distribution"
+
+    def test_broken_plugin_does_not_break_other_backends(self, tmp_path: Path) -> None:
+        """Broken plugin does not break other backends."""
+        broken = write_distribution(
+            tmp_path / "broken",
+            distribution="llm-sandbox-broken",
+            version="0.1.0",
+            module="broken_backend",
+            source=EXPLODING_PLUGIN,
+            entry_point_name="broken",
+        )
+        good = write_distribution(
+            tmp_path / "good",
+            distribution="llm-sandbox-tenki",
+            version="0.1.0",
+            module="tenki_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="tenki",
+        )
+        with installed(broken, good):
+            assert get_backend("docker") is DockerBackend
+            assert get_backend("tenki").name == "tenki"
+            with pytest.raises(BackendLoadError):
+                get_backend("broken")
+
+    def test_broken_plugin_is_reported_not_raised_by_list_backends(self, tmp_path: Path) -> None:
+        """Broken plugin is reported not raised by list backends."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-broken",
+            version="0.1.0",
+            module="broken_backend",
+            source=EXPLODING_PLUGIN,
+            entry_point_name="broken",
+        )
+        with installed(root):
+            infos = {info.name: info for info in list_backends(load=True)}
+
+        assert infos["broken"].status == "error"
+        assert "failed to load" in (infos["broken"].detail or "")
+        assert infos["docker"].status == "ok"
+
+    def test_unreadable_metadata_does_not_break_builtins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unreadable metadata does not break builtins."""
+        def explode(**_kwargs: object) -> None:
+            msg = "corrupt metadata on sys.path"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(registry, "entry_points", explode)
+        registry.clear_cache()
+
+        assert get_backend("docker") is DockerBackend
+        assert [info.name for info in list_backends() if info.is_builtin] == sorted(BUILTIN_BACKENDS)
+
+
+class TestCollisions:
+    """Built-ins always win; two plugins claiming one name is an error naming both."""
+
+    def test_plugin_shadowing_a_builtin_loses_and_warns(self, tmp_path: Path) -> None:
+        """Plugin shadowing a builtin loses and warns."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-impostor",
+            version="6.6.6",
+            module="impostor_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="docker",
+        )
+        with installed(root), pytest.warns(BackendShadowWarning, match="llm-sandbox-impostor"):
+            assert get_backend("docker") is DockerBackend
+
+    def test_shadowed_registration_is_listed(self, tmp_path: Path) -> None:
+        """Shadowed registration is listed."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-impostor",
+            version="6.6.6",
+            module="impostor_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="docker",
+        )
+        with installed(root), pytest.warns(BackendShadowWarning):
+            shadowed = [info for info in list_backends() if info.status == "shadowed"]
+
+        assert len(shadowed) == 1
+        assert shadowed[0].distribution == "llm-sandbox-impostor"
+        assert shadowed[0].name == "docker"
+
+    def test_two_distributions_claiming_one_name_is_an_error_naming_both(self, tmp_path: Path) -> None:
+        """Two distributions claiming one name is an error naming both."""
+        first = write_distribution(
+            tmp_path / "first",
+            distribution="llm-sandbox-tenki",
+            version="1.0.0",
+            module="tenki_one",
+            source=VALID_PLUGIN,
+            entry_point_name="tenki",
+        )
+        second = write_distribution(
+            tmp_path / "second",
+            distribution="tenki-sandbox",
+            version="2.0.0",
+            module="tenki_two",
+            source=VALID_PLUGIN,
+            entry_point_name="tenki",
+        )
+        with installed(first, second), pytest.raises(BackendNameConflictError) as excinfo:
+            get_backend("tenki")
+
+        message = str(excinfo.value)
+        assert "llm-sandbox-tenki" in message
+        assert "tenki-sandbox" in message
+
+    def test_conflict_does_not_break_other_backends(self, tmp_path: Path) -> None:
+        """Conflict does not break other backends."""
+        first = write_distribution(
+            tmp_path / "first",
+            distribution="llm-sandbox-tenki",
+            version="1.0.0",
+            module="tenki_one",
+            source=VALID_PLUGIN,
+            entry_point_name="tenki",
+        )
+        second = write_distribution(
+            tmp_path / "second",
+            distribution="tenki-sandbox",
+            version="2.0.0",
+            module="tenki_two",
+            source=VALID_PLUGIN,
+            entry_point_name="tenki",
+        )
+        other = write_distribution(
+            tmp_path / "other",
+            distribution="llm-sandbox-other",
+            version="1.0.0",
+            module="other_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="other",
+        )
+        with installed(first, second, other):
+            assert get_backend("other").name == "other"
+            assert get_backend("docker") is DockerBackend
+
+            infos = {info.name: info for info in list_backends()}
+            assert infos["tenki"].status == "conflict"
+            assert infos["other"].status == "ok"
+
+    def test_declared_name_mismatch_warns_but_resolves(self, tmp_path: Path) -> None:
+        """Declared name mismatch warns but resolves."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-confused",
+            version="0.1.0",
+            module="confused_backend",
+            source=MISMATCHED_NAME_PLUGIN,
+            entry_point_name="confused",
+        )
+        with installed(root), pytest.warns(BackendNameMismatchWarning, match="something-else"):
+            assert get_backend("confused") is not None
+
+
+class TestListBackends:
+    """The public discovery helper."""
+
+    def test_lists_all_builtins_with_capabilities(self) -> None:
+        """Lists all builtins with capabilities."""
+        infos = {info.name: info for info in list_backends()}
+
+        assert set(BUILTIN_BACKENDS) <= set(infos)
+        assert infos["docker"].is_builtin is True
+        assert infos["docker"].distribution is None
+        assert BackendCapability.POOLING in (infos["docker"].capabilities or frozenset())
+
+    def test_reports_plugin_distribution_and_version(self, tmp_path: Path) -> None:
+        """Reports plugin distribution and version."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-tenki",
+            version="1.2.3",
+            module="tenki_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="tenki",
+        )
+        with installed(root):
+            info = next(item for item in list_backends() if item.name == "tenki")
+
+        assert info.is_builtin is False
+        assert info.distribution == "llm-sandbox-tenki"
+        assert info.version == "1.2.3"
+        assert info.entry_point == "tenki_backend:Backend"
+        assert info.capabilities is None, "capabilities require load=True"
+
+    def test_load_populates_capabilities(self, tmp_path: Path) -> None:
+        """Load populates capabilities."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-tenki",
+            version="1.2.3",
+            module="tenki_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="tenki",
+        )
+        with installed(root):
+            info = next(item for item in list_backends(load=True) if item.name == "tenki")
+
+        assert info.capabilities == frozenset({BackendCapability.ARTIFACTS})
+
+    def test_builtins_are_listed_first_and_sorted(self) -> None:
+        """Builtins are listed first and sorted."""
+        names = [info.name for info in list_backends() if info.is_builtin]
+        assert names == sorted(BUILTIN_BACKENDS)
+
+
+class TestCacheControl:
+    """clear_cache() exists for tests and for processes that install plugins at runtime."""
+
+    def test_clear_cache_picks_up_newly_installed_plugin(self, tmp_path: Path) -> None:
+        """Clear cache picks up newly installed plugin."""
+        assert "late" not in {info.name for info in list_backends()}
+
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-late",
+            version="0.1.0",
+            module="late_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="late",
+        )
+        with installed(root):
+            assert "late" in {info.name for info in list_backends()}
+
+        assert "late" not in {info.name for info in list_backends()}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,6 +1,11 @@
 """Tests for backend discovery, resolution, and error reporting."""
 
+import contextlib
+import logging
 import sys
+import threading
+import time
+import warnings
 from pathlib import Path
 
 import pytest
@@ -21,8 +26,11 @@ from tests.plugin_helpers import (
     EXPLODING_PLUGIN,
     FUTURE_VERSION_PLUGIN,
     MISMATCHED_NAME_PLUGIN,
+    NO_NAME_PLUGIN,
     NO_VERSION_PLUGIN,
     NOT_A_PLUGIN,
+    POOLING_PLUGIN,
+    SYSTEM_EXIT_PLUGIN,
     VALID_PLUGIN,
     installed,
     write_distribution,
@@ -496,3 +504,288 @@ class TestCacheControl:
             assert "late" in {info.name for info in list_backends()}
 
         assert "late" not in {info.name for info in list_backends()}
+
+
+class TestHardenedNames:
+    """Degenerate and confusable names must fail closed, not select a plugin."""
+
+    @pytest.mark.parametrize("requested", [None, "", "   ", "  \t ", "foo; rm -rf /", "-", "_x"])
+    def test_unusable_names_never_resolve(self, requested: object) -> None:
+        """A name that is empty or malformed cannot select any backend.
+
+        `backend=""` and `backend=None` are what a caller passes when a config value or
+        environment variable is unset. Those must not be selectable by an installed package.
+        """
+        with pytest.raises(BackendNotFoundError):
+            get_backend(requested)  # type: ignore[arg-type]
+
+    def test_entry_point_with_empty_name_is_refused(self, tmp_path: Path) -> None:
+        """An entry point named '' is ignored rather than answering to backend=''."""
+        root = tmp_path / "site"
+        root.mkdir(parents=True)
+        (root / "empty_backend.py").write_text(VALID_PLUGIN.format(name="empty"))
+        dist_info = root / "llm_sandbox_empty-0.1.0.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text("Metadata-Version: 2.1\nName: llm-sandbox-empty\nVersion: 0.1.0\n")
+        (dist_info / "entry_points.txt").write_text("[llm_sandbox.backends]\n = empty_backend:Backend\n")
+
+        with installed(root), pytest.warns(BackendShadowWarning, match="unusable name"):
+            names = {info.name for info in list_backends()}
+
+        assert "" not in names
+
+        with installed(root), pytest.raises(BackendNotFoundError):
+            get_backend("")
+
+    def test_fullwidth_homoglyph_folds_onto_the_builtin(self) -> None:
+        """NFKC folding means a fullwidth homoglyph cannot pose as a separate backend."""
+        assert normalize_backend_name("ＤOCKER") == "docker"  # noqa: RUF001
+        assert get_backend("ＤOCKER") is DockerBackend  # noqa: RUF001
+
+    def test_shell_metacharacters_get_no_install_suggestion(self) -> None:
+        """The pip line is written to be pasted into a shell, so it never echoes junk."""
+        with pytest.raises(BackendNotFoundError) as excinfo:
+            get_backend("foo; rm -rf /")
+
+        message = str(excinfo.value)
+        assert "pip install" not in message
+        assert "not a usable backend name" in message
+
+
+class TestWarningDeliveryCannotBreakDiscovery:
+    """Warning policy must never decide whether a backend resolves."""
+
+    def test_warnings_as_errors_does_not_break_resolution(self, tmp_path: Path) -> None:
+        """With -W error and a shadowing plugin installed, every backend still resolves."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-impostor",
+            version="6.6.6",
+            module="impostor_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="docker",
+        )
+        with installed(root), warnings.catch_warnings():
+            warnings.simplefilter("error")
+
+            assert get_backend("docker") is DockerBackend
+            assert get_backend("podman").name == "podman"
+            assert [info.name for info in list_backends() if info.is_builtin] == sorted(BUILTIN_BACKENDS)
+
+    def test_discovery_is_cached_even_when_a_warning_fires(self, tmp_path: Path) -> None:
+        """A shadowing plugin must not force a metadata re-scan on every call."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-impostor",
+            version="6.6.6",
+            module="impostor_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="docker",
+        )
+        with installed(root), warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with contextlib.suppress(Exception):
+                get_backend("docker")
+
+            scans = []
+            original = registry._entry_points
+
+            def counting() -> list[object]:
+                scans.append(1)
+                return original()
+
+            registry._entry_points = counting  # type: ignore[assignment]
+            try:
+                get_backend("docker")
+                get_backend("podman")
+            finally:
+                registry._entry_points = original  # type: ignore[assignment]
+
+        assert scans == [], "Discovery re-scanned metadata after a warning fired"
+
+    def test_shadow_attempt_is_logged_even_when_warnings_are_silenced(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A hijack attempt is a supply-chain signal, so it survives a warnings filter."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-impostor",
+            version="6.6.6",
+            module="impostor_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="docker",
+        )
+        with (
+            installed(root),
+            warnings.catch_warnings(),
+            caplog.at_level(logging.WARNING, logger="llm_sandbox.registry"),
+        ):
+            warnings.simplefilter("ignore")
+            get_backend("docker")
+
+        assert "llm-sandbox-impostor" in caplog.text
+        assert "shadows the built-in" in caplog.text
+
+
+class TestFailureIsolationIsTotal:
+    """Isolation has to hold for BaseException too, not just Exception."""
+
+    def test_plugin_calling_sys_exit_does_not_kill_the_process(self, tmp_path: Path) -> None:
+        """SystemExit inherits BaseException; a plugin must not be able to exit the host."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-suicidal",
+            version="0.1.0",
+            module="suicidal_backend",
+            source=SYSTEM_EXIT_PLUGIN,
+            entry_point_name="suicidal",
+        )
+        with installed(root):
+            with pytest.raises(BackendLoadError, match="failed to load"):
+                get_backend("suicidal")
+
+            infos = {info.name: info for info in list_backends(load=True)}
+            assert infos["suicidal"].status == "error"
+            assert infos["docker"].status == "ok"
+
+    def test_plugin_without_a_name_is_rejected_at_load(self, tmp_path: Path) -> None:
+        """`name` is read by require() and the optional factories, so absence is fatal early."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-nameless",
+            version="0.1.0",
+            module="nameless_backend",
+            source=NO_NAME_PLUGIN,
+            entry_point_name="nameless",
+        )
+        with installed(root), pytest.raises(BackendLoadError, match="does not declare a `name`"):
+            get_backend("nameless")
+
+
+class TestConcurrency:
+    """Pool code creates sessions from worker threads, so the cache is used concurrently."""
+
+    def test_concurrent_resolution_is_consistent(self, tmp_path: Path) -> None:
+        """Many threads resolving at once agree, and discovery still runs once."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-tenki",
+            version="1.0.0",
+            module="tenki_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="tenki",
+        )
+        with installed(root):
+            results: list[object] = []
+            errors: list[BaseException] = []
+
+            def resolve() -> None:
+                try:
+                    results.extend(get_backend(name) for name in ("docker", "tenki", "podman"))
+                except BaseException as exc:  # noqa: BLE001
+                    errors.append(exc)
+
+            threads = [threading.Thread(target=resolve) for _ in range(16)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        assert not errors, f"Concurrent resolution raised: {errors}"
+        assert len(results) == 16 * 3
+
+    def test_clear_cache_racing_resolution_never_returns_none(self, tmp_path: Path) -> None:
+        """_get_records() must not hand back None when clear_cache() lands mid-call."""
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-tenki",
+            version="1.0.0",
+            module="tenki_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="tenki",
+        )
+        errors: list[BaseException] = []
+        stop = threading.Event()
+
+        def clear() -> None:
+            while not stop.is_set():
+                registry.clear_cache()
+
+        def resolve() -> None:
+            try:
+                while not stop.is_set():
+                    get_backend("docker")
+                    list_backends()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        with installed(root):
+            workers = [threading.Thread(target=clear) for _ in range(3)]
+            workers += [threading.Thread(target=resolve) for _ in range(3)]
+            for thread in workers:
+                thread.start()
+            time.sleep(0.75)
+            stop.set()
+            for thread in workers:
+                thread.join()
+
+        assert not errors, f"Racing clear_cache() with resolution raised: {errors}"
+
+
+class TestPluginPooling:
+    """POOLING must be reachable end to end, not just declarable."""
+
+    def test_plugin_pool_manager_is_created_and_stamped(self, tmp_path: Path) -> None:
+        """create_pool_manager routes to the plugin and stamps the resolved backend name."""
+        from llm_sandbox.pool import create_pool_manager
+
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-pooler",
+            version="0.1.0",
+            module="pooler_backend",
+            source=POOLING_PLUGIN,
+            entry_point_name="pooler",
+        )
+        with installed(root):
+            manager = create_pool_manager(backend="pooler", lang="python")
+
+            assert type(manager).__name__ == "FakePoolManager"
+            assert manager.backend_name == "pooler"
+
+    def test_pooled_session_routes_back_to_the_plugin(self, tmp_path: Path) -> None:
+        """A PooledSandboxSession built on a plugin pool resolves through the registry.
+
+        Previously this raised a bare RuntimeError from _infer_backend_from_pool, which made
+        the POOLING capability undeliverable for any third-party backend.
+        """
+        from llm_sandbox.pool import create_pool_manager
+        from llm_sandbox.pool.session import PooledSandboxSession
+
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-pooler",
+            version="0.1.0",
+            module="pooler_backend",
+            source=POOLING_PLUGIN,
+            entry_point_name="pooler",
+        )
+        with installed(root):
+            manager = create_pool_manager(backend="pooler", lang="python")
+            session = PooledSandboxSession(pool_manager=manager)
+
+            assert session.backend == "pooler"
+            assert session._create_backend_session("container-1") == {"backend": "pooler"}
+
+    def test_builtin_pool_managers_declare_their_own_name(self) -> None:
+        """PodmanPoolManager subclasses DockerPoolManager, so it must declare its own name."""
+        from llm_sandbox.pool.docker_pool import DockerPoolManager
+        from llm_sandbox.pool.kubernetes_pool import KubernetesPoolManager
+        from llm_sandbox.pool.podman_pool import PodmanPoolManager
+
+        assert DockerPoolManager.backend_name == "docker"
+        assert KubernetesPoolManager.backend_name == "kubernetes"
+        assert PodmanPoolManager.backend_name == "podman", (
+            "PodmanPoolManager inherits DockerPoolManager; without its own backend_name a "
+            "pooled Podman session would be routed to the Docker backend."
+        )

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -254,9 +254,7 @@ class TestFailureIsolation:
             (ABSTRACT_PLUGIN, "does not implement create_session"),
         ],
     )
-    def test_broken_plugin_raises_backend_load_error(
-        self, tmp_path: Path, source: str, expected_fragment: str
-    ) -> None:
+    def test_broken_plugin_raises_backend_load_error(self, tmp_path: Path, source: str, expected_fragment: str) -> None:
         """Broken plugin raises backend load error."""
         root = write_distribution(
             tmp_path / "site",
@@ -316,6 +314,7 @@ class TestFailureIsolation:
 
     def test_unreadable_metadata_does_not_break_builtins(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Unreadable metadata does not break builtins."""
+
         def explode(**_kwargs: object) -> None:
             msg = "corrupt metadata on sys.path"
             raise RuntimeError(msg)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -508,7 +508,7 @@ class TestCacheControl:
 class TestHardenedNames:
     """Degenerate and confusable names must fail closed, not select a plugin."""
 
-    @pytest.mark.parametrize("requested", [None, "", "   ", "  \t ", "foo; rm -rf /", "-", "_x"])
+    @pytest.mark.parametrize("requested", [None, "", "   ", "  \t ", "foo; rm -rf /", "-", "_x", 0, 1.5])
     def test_unusable_names_never_resolve(self, requested: object) -> None:
         """A name that is empty or malformed cannot select any backend.
 
@@ -535,6 +535,26 @@ class TestHardenedNames:
 
         with installed(root), pytest.raises(BackendNotFoundError):
             get_backend("")
+
+    def test_non_string_backend_cannot_select_a_plugin(self, tmp_path: Path) -> None:
+        """`backend=None` must not resolve, even when a plugin is registered as "none".
+
+        str(None) is "none", which is a syntactically valid backend name -- so coercing
+        before validating let an installed package answer to an unset config value.
+        """
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-none",
+            version="1.0.0",
+            module="none_backend",
+            source=VALID_PLUGIN,
+            entry_point_name="none",
+        )
+        with installed(root):
+            assert get_backend("none").name == "none"
+
+            with pytest.raises(BackendNotFoundError, match="must be a string"):
+                get_backend(None)  # type: ignore[arg-type]
 
     def test_fullwidth_homoglyph_folds_onto_the_builtin(self) -> None:
         """NFKC folding means a fullwidth homoglyph cannot pose as a separate backend."""
@@ -788,3 +808,49 @@ class TestPluginPooling:
             "PodmanPoolManager inherits DockerPoolManager; without its own backend_name a "
             "pooled Podman session would be routed to the Docker backend."
         )
+
+    def test_pooling_without_existing_container_is_rejected(self, tmp_path: Path) -> None:
+        """POOLING implies EXISTING_CONTAINER, because a pooled session attaches to one."""
+        from llm_sandbox.pool import create_pool_manager
+        from llm_sandbox.pool.session import PooledSandboxSession
+
+        source = POOLING_PLUGIN.replace(
+            "        BackendCapability.POOLING,\n        BackendCapability.EXISTING_CONTAINER,\n",
+            "        BackendCapability.POOLING,\n",
+        )
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-halfpool",
+            version="0.1.0",
+            module="halfpool_backend",
+            source=source,
+            entry_point_name="halfpool",
+        )
+        with installed(root):
+            manager = create_pool_manager(backend="halfpool", lang="python")
+            session = PooledSandboxSession(pool_manager=manager)
+
+            with pytest.raises(BackendCapabilityError, match="existing_container"):
+                session._create_backend_session("container-1")
+
+    def test_pool_manager_is_stamped_with_the_entry_point_name(self, tmp_path: Path) -> None:
+        """A plugin whose declared name differs is registered under its entry point name.
+
+        Stamping `provider.name` instead would record a name that does not resolve.
+        """
+        from llm_sandbox.pool import create_pool_manager
+
+        source = POOLING_PLUGIN.replace('name: ClassVar[str] = "{name}"', 'name: ClassVar[str] = "declared-elsewhere"')
+        root = write_distribution(
+            tmp_path / "site",
+            distribution="llm-sandbox-renamed",
+            version="0.1.0",
+            module="renamed_backend",
+            source=source,
+            entry_point_name="renamed",
+        )
+        with installed(root), pytest.warns(BackendNameMismatchWarning):
+            manager = create_pool_manager(backend="renamed", lang="python")
+
+            assert manager.backend_name == "renamed"
+            assert get_backend(manager.backend_name) is not None

--- a/uv.lock
+++ b/uv.lock
@@ -2,10 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
-    "python_full_version >= '3.12.4' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.12.4' and python_full_version < '3.14' and sys_platform != 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version >= '3.12.4' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12.4' and python_full_version < '3.14' and sys_platform != 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.12.4'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
@@ -1533,6 +1533,9 @@ podman = [
     { name = "docker" },
     { name = "podman" },
 ]
+testing = [
+    { name = "pytest" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1573,8 +1576,9 @@ requires-dist = [
     { name = "podman", marker = "extra == 'mcp-podman'", specifier = ">=5.4.0.1" },
     { name = "podman", marker = "extra == 'podman'", specifier = ">=5.4.0.1" },
     { name = "pydantic", specifier = ">=2.11.5" },
+    { name = "pytest", marker = "extra == 'testing'", specifier = ">=7.2.0" },
 ]
-provides-extras = ["docker", "k8s", "podman", "mcp-docker", "mcp-podman", "mcp-k8s"]
+provides-extras = ["docker", "k8s", "podman", "mcp-docker", "mcp-podman", "mcp-k8s", "testing"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1502,7 +1502,7 @@ wheels = [
 
 [[package]]
 name = "llm-sandbox"
-version = "0.3.13"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic", version = "2.11.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },


### PR DESCRIPTION
`INTEGRATIONS.md` is on `main` and commits publicly to a plugin path for third-party
backends — a standalone package that depends on `llm-sandbox`, registers through "the backend
entry-point interface", and is selectable with `SandboxSession(backend="<service>")`.

That mechanism did not exist. This builds it, documents it, and makes it safe to depend on.

Once a third party publishes against the entry-point contract it is effectively frozen, so
every public API decision here is made on that basis.

## How it works

A plugin registers a descriptor under the `llm_sandbox.backends` entry point group:

```toml
[project.entry-points."llm_sandbox.backends"]
myservice = "llm_sandbox_myservice:MyServiceBackend"
```

```python
class MyServiceBackend(SandboxBackendPlugin):
    PLUGIN_API_VERSION = 1
    name = "myservice"
    capabilities = frozenset({BackendCapability.ARTIFACTS})

    @classmethod
    def create_session(cls, *args, **kwargs):
        from llm_sandbox_myservice.session import MyServiceSession
        return MyServiceSession(**kwargs)
```

```python
llm_sandbox.list_backends()   # built-ins plus every installed plugin, without importing any
```

**The registered object is a descriptor, not a session class.** Registering the session class
would have been simpler to write, but it freezes all of `BaseSession` — including six
underscore-prefixed abstract methods — as permanent public contract. The descriptor freezes
six names, and what happens behind `create_session` stays the plugin's business.

**Plugins subclass the new public `SandboxBackendBase`**, which re-declares `BaseSession`'s six
private abstract methods under public names and bridges them with `@final`. No plugin has to
implement private API, which is what keeps core's internals refactorable.

**Discovery and loading are separate, and that split is a security property.** Discovery reads
packaging metadata and imports nothing; a plugin's module is imported only when its backend is
requested by name. `import llm_sandbox` never executes plugin code.

## What's in it

| Area | |
|---|---|
| Registry | `llm_sandbox/registry.py` — discovery, resolution, collision handling, failure isolation |
| Contract | `llm_sandbox/backends/` — `SandboxBackendPlugin`, `SandboxBackendBase`, `BackendCapability`, `PLUGIN_API_VERSION` |
| Compliance kit | `llm_sandbox/testing/` — `BackendComplianceTests`, importable by any plugin |
| Reference plugin | `examples/plugins/llm-sandbox-example/` — complete, installable, passes the kit |
| Docs | `docs/plugins/authoring.md`, `docs/plugins/index.md`, `docs/design/plugin-system.md` |

Built-in backends now route through the same registry, replacing four separate dispatch sites.
Behaviour is preserved exactly, including the pre-existing gaps — micromamba still has no
interactive or pooling support, and asking for either still raises.

Collisions: a built-in always wins, with a warning naming the offending distribution. Two
plugins claiming one name is an error naming both, raised at lookup rather than discovery so
one bad pair cannot break every other backend. All new errors subclass `UnsupportedBackendError`,
so existing `except` clauses keep working.

## Backwards compatibility

**No breaking changes.** The 1094 tests that existed before this branch pass unmodified.

Several risks were found and designed around rather than accepted:

- `UnsupportedBackendError`'s message is pinned exactly by `tests/test_exceptions.py:193`. Left
  untouched; the four new errors subclass it.
- `tests/test_const.py:84` asserts `len(SandboxBackend) == 4`. The enum stays closed — plugins
  are strings, built-ins are enum members that are *also* strings, so they coexist with no
  machinery. `SandboxSession(backend="docker")` already worked before this change and still does.
- Six tests patch `llm_sandbox.session.find_spec`, so `_check_dependency` cannot move out of
  `session.py`. Four patch source-module attributes, so built-in providers must import session
  classes inside the method.

`backend=` parameters widen from `SandboxBackend` to `SandboxBackend | str`, which is pure
widening for callers.

## Code review

A four-agent review (performance, architecture, quality, security) ran against the first commit.
It found three defects that made the feature partly non-functional plus a security hole, all
fixed in `c919c2c` with regression tests:

- **`ArtifactSandboxSession` was broken for every plugin.** Core forwards `runtime_configs=None`
  and `workdir="/sandbox"` unconditionally; the built-ins each normalise by hand and the new base
  class did not, so the one consumer of the `ARTIFACTS` capability raised a pydantic
  `ValidationError` — not even a `SandboxError`.
- **A fourth dispatch site was missed.** `PooledSandboxSession` inferred the backend by
  substring-matching the pool manager's *class name*. `POOLING` was undeliverable for any plugin,
  and a manager whose class name contained `Docker` was silently misrouted.
- **Backend names failed open.** `entry_points.txt` legally permits a name of `""`, and
  `str(None)` is `"none"` — so a package could answer to `backend=""` or `backend=None`, which is
  what a caller passes when a config value is unset. Names are now NFKC-folded and validated.
- Capabilities were documented as enforced but only two of four were; `warnings.warn` inside the
  cache lock let one shadowing plugin break every backend under `-W error`; `SystemExit` from a
  plugin escaped failure isolation.

## Version

Bumped to **0.4.0**. The reference plugin and the authoring guide pin `llm-sandbox>=0.4.0` as the
release that introduced the plugin API; without the bump, `pip install -e ".[test]"` from the
plugin's own README cannot resolve.

## Security

Installing a backend plugin means running third-party code that executes code on your behalf.
Users choosing a community backend are trusting that package's authors, not this project. That is
stated plainly and unsoftened in the authoring guide, the plugin index, and the README, along with
the fact that lazy loading is not a sandbox — by the time a plugin is installed, its build already
ran.

The reference plugin runs code on the host with **no isolation** and is marked
`Private :: Do Not Upload`. It exists to be read and copied, never installed from an index.

## Verification

| Check | Result |
|---|---|
| Tests | 1242 pass, 3 skipped (1094 pre-existing, unmodified) |
| Python 3.10 / 3.11 / 3.13 | full suite green on each |
| ruff, mypy, deptry, `uv lock --locked` | clean |
| `mkdocs build -s` | exit 0 |
| Reference plugin via real `pip install -e ".[test]"` | 29 pass |

Tests use real `.dist-info` directories on `sys.path` rather than mocking `importlib.metadata`,
so entry point discovery, `ep.dist.name`/`.version`, and `ep.load()` all execute for real.

## Notes for review

- **`INTEGRATIONS.md` was not edited**, as intended. One thing worth knowing: it names Docker,
  Podman and Kubernetes as what ships in core and omits **micromamba**, which is a real selectable
  backend. `list_backends()` and every error message now answer that question publicly, and they
  say four. Whether that warrants a wording change is a call for you.
- Two decisions in the design note were reversed while building — `ContainerAPI` is published
  after all, and discovery is no longer skipped for built-ins so a package trying to hijack the
  name `docker` is always reported. Both are recorded in §11 of the design note rather than
  quietly amended.
- Pre-existing and untouched: `core/mixins.py:224` calls `tar.extract()` without `filter=`.
  Python 3.14 changes that default and `requires-python` already allows 3.14. It affects all
  backends and deserves its own look.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for discovering and using third-party backend plugins.
  - Added backend listing, capability reporting, name normalization, and clearer backend errors.
  - Updated sessions, interactive sessions, and connection pools to support plugin-provided backends.
  - Added an example local backend plugin for evaluation and customization.

- **Documentation**
  - Added plugin installation, authoring, security, compatibility, and community guidance.

- **Testing**
  - Added reusable backend compliance tests and comprehensive plugin integration coverage.

- **Chores**
  - Updated the project version to 0.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->