### PR TITLE
fix: restore broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1006,4 +1006,4 @@ If you find LLM Sandbox useful, please consider giving it a star on GitHub!
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=vndee/llm-sandbox&type=Date)](https://www.star-history.com/#vndee/llm-sandbox&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=vndee/llm-sandbox&type=Date)](https://star-history.dera.page/#vndee/llm-sandbox&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because the upstream chart no longer works under GitHub stargazer API restrictions. This is a small fix worth shipping: it updates the chart endpoint to a mirror that renders the same data correctly, and aligns the surrounding link with the new host.

No other fields or links in the README are affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s Star History chart image and link to use the new Star History site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->