### PR TITLE
docs: switch remaining dev-install snippets to uv workflow

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,7 @@ pip install 'llm-sandbox[docker,k8s,podman]'
 
 ### Development Installation
 
-For contributing or development, dev dependencies are managed as a [uv dependency group](https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups). Use `uv` (or the `make install` shortcut) instead of `pip install -e '.[dev]'`:
+For contributing or development, dev dependencies live in a [uv dependency group](https://docs.astral.sh/uv/concepts/projects/dependencies/#dependency-groups). Install everything (dev deps + pre-commit hooks) with:
 
 ```bash
 git clone https://github.com/vndee/llm-sandbox.git

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -365,11 +365,11 @@ The assistant will execute the code in a secure sandbox and automatically captur
 For development and testing of the MCP server:
 
 ```bash
-# Install in development mode
-pip install -e '.[mcp-docker]'
+# Install in development mode (dev deps live in a uv dependency group)
+uv sync --extra mcp-docker
 
 # Run the MCP server directly
-python -m llm_sandbox.mcp_server.server
+uv run python -m llm_sandbox.mcp_server.server
 
 # Test with MCP client tools
 # Follow MCP client documentation for testing


### PR DESCRIPTION
## Summary

Closes #163.

This PR handles the last remaining item in that issue: two `pip install -e '.[...]'` snippets in the published docs that had not yet been migrated to the project's uv-based workflow declared in `pyproject.toml`.

- `docs/mcp-integration.md` → `uv sync --extra mcp-docker` + `uv run python -m llm_sandbox.mcp_server.server`
- `docs/getting-started.md` → drop the `pip install -e '.[dev]'` counter-example phrasing so no stale command lingers in the published docs

## Status of the original acceptance criteria on current main

Most of #163's checklist has already been resolved in prior PRs. Recording the current state for maintainer review:

| Criterion | Status | Evidence |
|---|---|---|
| README / docs use uv workflow | ✅ already done | `README.md` L83–88, `docs/getting-started.md` L45 |
| `custom-images.md` in mkdocs nav | ✅ already done | `mkdocs.yml` L72 |
| `container-pooling.md` anchor fixed | ✅ already done | `#container-pooling-configuration` in `docs/configuration.md` L883 |
| CI fails on docs warnings | ✅ already done | `Makefile` `mkdocs build -s`, `.github/workflows/main.yml` `check-docs` job |
| `mkdocs build -s` clean | ✅ verified locally | zero warnings |
| Remaining `pip install -e` snippets | ⛔ **this PR** | `docs/mcp-integration.md` L369, `docs/getting-started.md` L45 |

## Test plan

- [x] `make docs-test` → clean build, no warnings
- [x] `grep -rn "pip install -e" docs/ README.md CONTRIBUTING.md` → no matches
- [x] `git diff --stat` → 2 files, +4/-4 (size:XS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated development installation guidance to use the current `uv` workflow.
  - Updated MCP integration setup instructions to install optional dependencies with `uv sync`.
  - Updated the MCP server run command to use `uv run`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->